### PR TITLE
Group dev dependencies in dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,18 @@ updates:
       time: "08:00"
       timezone: "Europe/Amsterdam"
     versioning-strategy: increase
+    groups:
+      dev-dependencies: # name of group
+        patterns:
+          - "mypy"
+          - "ruff"
+          - "isort"
+          - "pre-commit"
+          - "pytest"
+          - "pytest-cov" 
+          - "pytest-describe"
+          - "pytest-pspec"
+          - "pytest-raises"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description
Currently, we need to approve multiple PR's created by dependabot every week. After approving and merging each PR, other PR's need to be recreated, because the branch containing the changes goes out of sync with the main branch. This is very time consuming. By grouping the dependencies, only one PR needs to be reviewed, approved and merged every week. I propose we start with dev dependencies.

P.S. We have implemented this for our repo's and it works really fine. Credits to Wichard for finding this helpful feature!

Fixes #249 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
