### PR TITLE
Fix wrong TypeError at instantiating MockAbstractEnum

### DIFF
--- a/tests/utils/test_abc_enum_meta.py
+++ b/tests/utils/test_abc_enum_meta.py
@@ -38,8 +38,24 @@ class TestABCEnumMeta:
     def test_mock_abstract_enum_is_abstract(self) -> None:
         """Test case for MockAbstractEnum class to check if it's an abstract class."""
         assert MockAbstractEnum.__abstractmethods__ == frozenset({"test_method"})
-        with pytest.raises(TypeError):
-            _ = MockAbstractEnum("a")  # type: ignore[abstract]
+
+    def test_abstract_enum_with_memebers_raises_type_error(self) -> None:
+        """Test case for MockAbstractEnumWithMembers class to check if it raises a TypeError."""
+        with pytest.raises(TypeError) as error_info:
+
+            class MockAbstractEnumWithMembers(Enum, metaclass=ABCEnumMeta):
+                """Mock class with members for testing the ABCEnumMeta class."""
+
+                A = "a"
+
+                @abstractmethod
+                def test_method(self) -> int:
+                    """Test method for the MockAbstractEnum class."""
+
+        assert (
+            str(error_info.value)
+            == "Can't instantiate abstract class 'MockAbstractEnumWithMembers' without an implementation for abstract method 'test_method'"
+        )
 
     def test_mock_concrete_enum(self) -> None:
         """Test case for MockConcreteEnum class."""
@@ -57,7 +73,10 @@ class TestABCEnumMeta:
                 A = "a"
                 B = "b"
 
-        assert str(error_info.value).endswith("without an implementation for abstract method 'test_method'")
+        assert (
+            str(error_info.value)
+            == "Can't instantiate abstract class 'InvalidMockConcreteEnum' without an implementation for abstract method 'test_method'"
+        )
 
     def test_abc_enum_meta_attribute_error(self) -> None:
         """Test instantiation of class with ABCEnumMeta where no abstract methods attribute is present."""


### PR DESCRIPTION
## Description
We've discussed this yesterday. I think this should fix it. We now check if the expected TypeError is raised and not accidentally another TypeError.

Fixes #327 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
