### PR TITLE
Implement nominal concrete cover check

### DIFF
--- a/blueprints/checks/nominal_concrete_cover/__init__.py
+++ b/blueprints/checks/nominal_concrete_cover/__init__.py
@@ -1,0 +1,1 @@
+"""Nominal concrete cover."""

--- a/blueprints/checks/nominal_concrete_cover/constants_nen_en_1992_1_1_c2_2011.py
+++ b/blueprints/checks/nominal_concrete_cover/constants_nen_en_1992_1_1_c2_2011.py
@@ -1,0 +1,29 @@
+"""Constants for the calculation of nominal concrete cover according to NEN-EN 1992-1-1+C2:2011."""
+
+from blueprints.checks.nominal_concrete_cover.definitions import AbrasionClass, CastingSurface
+from blueprints.type_alias import MM
+
+# According to art. 4.4.1.2 (11) from NEN-EN 1992-1-1+C2:2011
+COVER_INCREASE_FOR_UNEVEN_SURFACE: MM = 5
+
+# According to art. 4.4.1.2 (13) from NEN-EN 1992-1-1+C2:2011
+COVER_INCREATSE_FOR_ABRASION_CLASS: dict[AbrasionClass, MM] = {
+    AbrasionClass.NA: 0,
+    AbrasionClass.XM1: 0,
+    AbrasionClass.XM2: 0,
+    AbrasionClass.XM3: 0,
+}
+
+# According to art. 4.4.1.3 (1) from NEN-EN 1992-1-1+C2:2011
+DEFAULT_DELTA_C_DEV: MM = 5
+
+
+def minimum_cover_with_regard_to_casting_surface(c_min_dur: MM, casting_surface: CastingSurface) -> MM:
+    """Calculate the minimum cover with regard to casting surface according to art. 4.4.1.3 (4) from NEN-EN 1992-1-1+C2:2011."""
+    match casting_surface:
+        case CastingSurface.PERMANENTLY_EXPOSED | CastingSurface.FORMWORK:
+            return 0  # No additional requirements
+        case CastingSurface.PREPARED_GROUND:
+            return c_min_dur + 10  # k1 ≥ c_min,dur + 10
+        case CastingSurface.DIRECTLY_AGAINST_SOIL:
+            return c_min_dur + 50  # k2 ≥ c_min,dur + 50

--- a/blueprints/checks/nominal_concrete_cover/definitions.py
+++ b/blueprints/checks/nominal_concrete_cover/definitions.py
@@ -1,0 +1,27 @@
+"""Definitions for the nominal concrete cover check according to art. 4.4.1 (Concrete cover) from NEN-EN 1992-1-1+C2:2011."""
+
+from enum import Enum
+
+
+class AbrasionClass(Enum):
+    """Enum representing the abrasion class of the concrete surface.
+
+    According to art. 4.4.1.2 (13) from NEN-EN 1992-1-1+C2:2011
+    """
+
+    NA = "Not applicable"
+    XM1 = "XM1"
+    XM2 = "XM2"
+    XM3 = "XM3"
+
+
+class CastingSurface(Enum):
+    """Enum representing the casting surface of the concrete.
+
+    According to art. 4.4.1.3 (4) from NEN-EN 1992-1-1+C2:2011
+    """
+
+    PERMANENTLY_EXPOSED = "Permanently exposed"
+    FORMWORK = "Formwork"
+    PREPARED_GROUND = "Prepared ground (including blinding)"
+    DIRECTLY_AGAINST_SOIL = "Directly against soil"

--- a/blueprints/checks/nominal_concrete_cover/nominal_concrete_cover.py
+++ b/blueprints/checks/nominal_concrete_cover/nominal_concrete_cover.py
@@ -1,0 +1,106 @@
+"""Calculation of nominal concrete cover from NEN-EN 1992-1-1+C2:2011: Chapter 4 - Durability and cover to reinforcement."""
+
+from blueprints.checks.nominal_concrete_cover.constants_nen_en_1992_1_1_c2_2011 import (
+    COVER_INCREASE_FOR_UNEVEN_SURFACE,
+    COVER_INCREATSE_FOR_ABRASION_CLASS,
+    DEFAULT_DELTA_C_DEV,
+    minimum_cover_with_regard_to_casting_surface,
+)
+from blueprints.checks.nominal_concrete_cover.definitions import AbrasionClass, CastingSurface
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011 import NEN_EN_1992_1_1_C2_2011
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011.chapter_4_durability_and_cover.formula_4_1 import Form4Dot1NominalConcreteCover
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011.chapter_4_durability_and_cover.formula_4_2 import Form4Dot2MinimumConcreteCover
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011.chapter_4_durability_and_cover.table_4_2 import Table4Dot2MinimumCoverWithRegardToBond
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011.chapter_4_durability_and_cover.table_4_4n import (
+    Table4Dot4nMinimumCoverDurabilityReinforcementSteel,
+)
+from blueprints.codes.formula import Formula
+from blueprints.type_alias import MM
+
+
+class NominalConcreteCover(Formula):
+    """Class responsible for the calculation of the nominal concrete cover :math:`c_{nom}` [:math:`mm`]."""
+
+    label = "Nominal concrete cover"
+    source_document = NEN_EN_1992_1_1_C2_2011
+
+    def __init__(  # noqa: PLR0913
+        self,
+        c_min_b: Table4Dot2MinimumCoverWithRegardToBond,
+        c_min_dur: Table4Dot4nMinimumCoverDurabilityReinforcementSteel,
+        delta_c_dur_gamma: MM = 0,
+        delta_c_dur_st: MM = 0,
+        delta_c_dur_add: MM = 0,
+        casting_surface: CastingSurface = CastingSurface.PERMANENTLY_EXPOSED,
+        uneven_surface: bool = False,
+        abrasion_class: AbrasionClass = AbrasionClass.NA,
+    ) -> None:
+        """[:math:`c_{nom}`] Calculates the nominal concrete cover [:math:`mm`]. It takes considerations of art.4.4.1.2 and 4.4.1.3 into account.
+
+        Parameters
+        ----------
+        c_min_b: Table4Dot2MinimumCoverWithRegardToBond
+            [:math:`c_{min,b}`] The minimum concrete cover based on the adhesion requirements based on art. 4.4.1.2 (3) [:math:`mm`].
+        c_min_dur: Table4Dot4nMinimumCoverDurabilityReinforcementSteel
+            [:math:`c_{min,dur}`] The minimum concrete cover based on environmental conditions based on art. 4.4.1.2 (5) [:math:`mm`].
+        delta_c_dur_gamma: MM
+            [:math:`Δc_{dur,γ}`] An additional safety requirement based on art. 4.4.1.2 (6) [:math:`mm`].
+            The value of [:math:`Δc_{dur,γ}`] for use in a Country may be found in its National Annex.
+            The recommended value is O mm. 0 mm is the default value in the formula if not specified otherwise.
+        delta_c_dur_st: MM
+            [:math:`Δc_{dur,st}`] A reduction of minimum concrete cover when using stainless steel based on art. 4.4.1.2 (7) [:math:`mm`].
+            The value of [:math:`Δc_{dur,st}`] for use in a Country may be found in its National Annex.
+            The recommended value, without further specification, is 0 mm. 0 mm is the default value in the formula if not specified otherwise.
+        delta_c_dur_add: MM
+            [:math:`Δc_{dur,add}`] A reduction of minimum concrete cover when using additional protection based on art. 4.4.1.2 (8) [:math:`mm`].
+            The value of [:math:`Δc_{dur,add}`] for use in a Country may be found in its National Annex.
+            The recommended value, without further specification, is 0 mm. 0 mm is the default value in the formula if not specified otherwise.
+        casting_surface: CastingSurface
+            The casting surface of the concrete according to art. 4.4.1.3 (4).
+            The default value is "Permanently exposed".
+        uneven_surface: bool
+            Is the surface uneven according to art. 4.4.1.2 (11)?
+            The default value is False.
+        abrasion_class: AbrasionClass
+            The abrasion class of the concrete surface according to art. 4.4.1.2 (13).
+            The default value is "Not applicable".
+        """
+        super().__init__()
+        self.c_min_b = c_min_b
+        self.c_min_dur = c_min_dur
+        self.delta_c_dur_gamma = delta_c_dur_gamma
+        self.delta_c_dur_st = delta_c_dur_st
+        self.delta_c_dur_add = delta_c_dur_add
+        self.casting_surface = casting_surface
+        self.uneven_surface = uneven_surface
+        self.abrasion_class = abrasion_class
+
+    @staticmethod
+    def _evaluate(
+        c_min_b: MM,
+        c_min_dur: MM,
+        delta_c_dur_gamma: MM = 0,
+        delta_c_dur_st: MM = 0,
+        delta_c_dur_add: MM = 0,
+        casting_surface: CastingSurface = CastingSurface.PERMANENTLY_EXPOSED,
+        uneven_surface: bool = False,
+        abrasion_class: AbrasionClass = AbrasionClass.NA,
+    ) -> MM:
+        """For more detailed documentation see the class docstring."""
+        c_min = Form4Dot2MinimumConcreteCover(
+            c_min_b=c_min_b,
+            c_min_dur=c_min_dur,
+            delta_c_dur_gamma=delta_c_dur_gamma,
+            delta_c_dur_st=delta_c_dur_st,
+            delta_c_dur_add=delta_c_dur_add,
+        )
+
+        # According to art. 4.4.1.2 (11) from NEN-EN 1992-1-1+C2:2011
+        c_min += COVER_INCREASE_FOR_UNEVEN_SURFACE * uneven_surface  # type: ignore[assignment]
+        # According to art. 4.4.1.2 (13) from NEN-EN 1992-1-1+C2:2011
+        c_min += COVER_INCREATSE_FOR_ABRASION_CLASS[abrasion_class]  # type: ignore[assignment]
+
+        return max(
+            Form4Dot1NominalConcreteCover(c_min=c_min, delta_c_dev=DEFAULT_DELTA_C_DEV),
+            minimum_cover_with_regard_to_casting_surface(c_min_dur, casting_surface),
+        )

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/formula_4_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/formula_4_1.py
@@ -20,6 +20,8 @@ class Form4Dot1NominalConcreteCover(Formula):
     ) -> None:
         """[:math:`c_{nom}`] Calculates the nominal concrete cover [:math:`mm`].
 
+        Please be advised that this formula does not take various considerations in art.4.4.1.2 and 4.4.1.3 into account.
+
         NEN-EN 1992-1-1+C2:2011 art.4.4.1.1 (2) - Formula (4.1)
 
         Parameters


### PR DESCRIPTION
## Description

- Check class implemented as a subclass to Formula. Is that acceptable? Or do we want to avoid this?
- The check depends strongly on the release year and the national annex of the Eurocode. Current implementation is semi-flexibel (all specific values are stored in a separate file, but are referenced directly in the check, so no choice for other EC version implemented ). We might want to come up with a protocol for that!
- Eurocode allows for marginal reduction of cover (Δc_dev to be precise). That is not implemented. I've never seen it being used and the conditions are too specific.


## Progress
- [x] Check class/function for nominal concrete cover
- [x] implementation of design allowance for deviation
- [ ] LateX report
- [ ] tests
- [ ] example for documentation

Fixes #343 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
