### PR TITLE
395 feature request add formulas from chapter 5873 from nen en 1992 1 1

### DIFF
--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_28.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_28.py
@@ -1,0 +1,73 @@
+"""Formula 5.28 from NEN-EN 1992-1-1+C2:2011: Chapter 5 - Structural Analysis."""
+
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011 import NEN_EN_1992_1_1_C2_2011
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula
+from blueprints.type_alias import KN, KNM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form5Dot28TotalDesignMoment(Formula):
+    """Class representing formula 5.28 for the calculation of the total design moment, :math:`M_{Ed}`."""
+
+    label = "5.28"
+    source_document = NEN_EN_1992_1_1_C2_2011
+
+    def __init__(
+        self,
+        m_0ed: KN,
+        beta: float,
+        n_ed: KN,
+        n_b: KN,
+    ) -> None:
+        """[:math:`M_{Ed}`] Total design moment [:math:`kNm`].
+
+        NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(2) - Formula (5.28)
+
+        Parameters
+        ----------
+        m_0ed : KN
+            [:math:`M_{0Ed}`] First order moment; see also 5.8.8.2 (2) [:math:`kNm`].
+        beta : float
+            [:math:`β`] Factor which depends on distribution of 1st and 2nd order moments, see 5.8.7.3 (2)-(3) [-].
+        n_ed : KN
+            [:math:`N_{Ed}`] Design value of axial load [:math:`kN`].
+        n_b : KN
+            [:math:`N_{B}`] Buckling load based on nominal stiffness [:math:`kN`].
+        """
+        super().__init__()
+        self.m_0ed = m_0ed
+        self.beta = beta
+        self.n_ed = n_ed
+        self.n_b = n_b
+
+    @staticmethod
+    def _evaluate(
+        m_0ed: KNM,
+        beta: float,
+        n_ed: KN,
+        n_b: KN,
+    ) -> KN:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(
+            m_0ed=m_0ed,
+            beta=beta,
+            n_b=n_b,
+        )
+        raise_if_less_or_equal_to_zero(n_ed=n_ed)
+
+        # When n_b / n_ed is equal to 1, the formula will divide by zero.
+        # The spirit of the equation is to raise the second order moment to infinity when n_b / n_ed is equal to 1.
+        # This is not possible in numeric calculations, so we will use a large number instead.
+        return m_0ed * 1000000.0 if n_b / n_ed == 1 else m_0ed * (1 + beta / (n_b / n_ed - 1))
+
+    def latex(self) -> LatexFormula:
+        """Returns LatexFormula object for formula 5.28."""
+        return LatexFormula(
+            return_symbol=r"M_{Ed}",
+            result=f"{self:.3f}",
+            equation=r"M_{0Ed} \cdot \left(1 + \frac{\beta}{\frac{N_{B}}{N_{Ed}} - 1}\right)",
+            numeric_equation=rf"{self.m_0ed:.3f} \cdot \left(1 + \frac{{{self.beta:.3f}}}{{\frac{{{self.n_b:.3f}}}{{{self.n_ed:.3f}}} - 1}}\right)",
+            comparison_operator_label="=",
+            unit="kNm",
+        )

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_28.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_28.py
@@ -3,7 +3,7 @@
 from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011 import NEN_EN_1992_1_1_C2_2011
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula
-from blueprints.type_alias import KN, KNM
+from blueprints.type_alias import DIMENSIONLESS, KN, KNM
 from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
 
 
@@ -16,7 +16,7 @@ class Form5Dot28TotalDesignMoment(Formula):
     def __init__(
         self,
         m_0ed: KN,
-        beta: float,
+        beta: DIMENSIONLESS,
         n_ed: KN,
         n_b: KN,
     ) -> None:
@@ -44,7 +44,7 @@ class Form5Dot28TotalDesignMoment(Formula):
     @staticmethod
     def _evaluate(
         m_0ed: KNM,
-        beta: float,
+        beta: DIMENSIONLESS,
         n_ed: KN,
         n_b: KN,
     ) -> KN:

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_28.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_28.py
@@ -59,7 +59,7 @@ class Form5Dot28TotalDesignMoment(Formula):
         # When n_b / n_ed is equal to 1, the formula will divide by zero.
         # The spirit of the equation is to raise the second order moment to infinity when n_b / n_ed is equal to 1.
         # This is not possible in numeric calculations, so we will use a large number instead.
-        return 1e9 if n_b / n_ed == 1 else m_0ed * (1 + beta / (n_b / n_ed - 1))
+        return 1e9 if n_b == n_ed else m_0ed * (1 + beta / (n_b / n_ed - 1))
 
     def latex(self) -> LatexFormula:
         """Returns LatexFormula object for formula 5.28."""

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_29.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_29.py
@@ -43,7 +43,7 @@ class Form5Dot29BetaFactor(Formula):
     def latex(self) -> LatexFormula:
         """Returns LatexFormula object for formula 5.29."""
         return LatexFormula(
-            return_symbol=r"β",
+            return_symbol=r"\beta",
             result=f"{self:.3f}",
             equation=r"\frac{\pi^2}{c_0}",
             numeric_equation=rf"\frac{{\pi^2}}{{{self.c_0:.3f}}}",

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_29.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_29.py
@@ -1,0 +1,52 @@
+"""Formula 5.29 from NEN-EN 1992-1-1+C2:2011: Chapter 5 - Structural Analysis."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011 import NEN_EN_1992_1_1_C2_2011
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula
+from blueprints.type_alias import DIMENSIONLESS
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form5Dot29BetaFactor(Formula):
+    """Class representing formula 5.29 for the calculation of the beta factor, :math:`β`."""
+
+    label = "5.29"
+    source_document = NEN_EN_1992_1_1_C2_2011
+
+    def __init__(
+        self,
+        c_0: DIMENSIONLESS,
+    ) -> None:
+        """[:math:`β`] Factor which depends on the distribution of first order moment [-].
+
+        NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(3) - Formula (5.29)
+
+        Parameters
+        ----------
+        c_0 : float
+            Coefficient which depends on the distribution of first order moment [-].
+            For instance, c_0 = 8 for a constant first order moment, c_0 = 9.6 for a parabolic and 12 for a symmetric triangular distribution.
+        """
+        super().__init__()
+        self.c_0 = c_0
+
+    @staticmethod
+    def _evaluate(
+        c_0: float,
+    ) -> float:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(c_0=c_0)
+        return (np.pi**2) / c_0
+
+    def latex(self) -> LatexFormula:
+        """Returns LatexFormula object for formula 5.29."""
+        return LatexFormula(
+            return_symbol=r"β",
+            result=f"{self:.3f}",
+            equation=r"\frac{\pi^2}{c_0}",
+            numeric_equation=rf"\frac{{\pi^2}}{{{self.c_0:.3f}}}",
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_30.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_30.py
@@ -1,35 +1,32 @@
-"""Formula 5.28 from NEN-EN 1992-1-1+C2:2011: Chapter 5 - Structural Analysis."""
+"""Formula 5.30 from NEN-EN 1992-1-1+C2:2011: Chapter 5 - Structural Analysis."""
 
 from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011 import NEN_EN_1992_1_1_C2_2011
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula
-from blueprints.type_alias import DIMENSIONLESS, KN, KNM
+from blueprints.type_alias import KN, KNM
 from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
 
 
-class Form5Dot28TotalDesignMoment(Formula):
-    """Class representing formula 5.28 for the calculation of the total design moment, :math:`M_{Ed}`."""
+class Form5Dot30TotalDesignMoment(Formula):
+    """Class representing formula 5.30 for the calculation of the total design moment, :math:`M_{Ed}`."""
 
-    label = "5.28"
+    label = "5.30"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(
         self,
-        m_0ed: KN,
-        beta: DIMENSIONLESS,
+        m_0ed: KNM,
         n_ed: KN,
         n_b: KN,
     ) -> None:
         """[:math:`M_{Ed}`] Total design moment [:math:`kNm`].
 
-        NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(2) - Formula (5.28)
+        NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(2) - Formula (5.30)
 
         Parameters
         ----------
         m_0ed : KNM
             [:math:`M_{0Ed}`] First order moment; see also 5.8.8.2 (2) [:math:`kNm`].
-        beta : float
-            [:math:`β`] Factor which depends on distribution of 1st and 2nd order moments, see 5.8.7.3 (2)-(3) [-].
         n_ed : KN
             [:math:`N_{Ed}`] Design value of axial load [:math:`kN`].
         n_b : KN
@@ -37,37 +34,34 @@ class Form5Dot28TotalDesignMoment(Formula):
         """
         super().__init__()
         self.m_0ed = m_0ed
-        self.beta = beta
         self.n_ed = n_ed
         self.n_b = n_b
 
     @staticmethod
     def _evaluate(
         m_0ed: KNM,
-        beta: DIMENSIONLESS,
         n_ed: KN,
         n_b: KN,
     ) -> KN:
         """Evaluates the formula, for more information see the __init__ method."""
         raise_if_negative(
             m_0ed=m_0ed,
-            beta=beta,
-            n_b=n_b,
+            n_ed=n_ed,
         )
-        raise_if_less_or_equal_to_zero(n_ed=n_ed)
+        raise_if_less_or_equal_to_zero(n_b=n_b)
 
-        # When n_b / n_ed is equal to 1, the formula will divide by zero.
-        # The spirit of the equation is to raise the second order moment to infinity when n_b / n_ed is equal to 1.
+        # When n_ed / n_b is equal to 1, the formula will divide by zero.
+        # The spirit of the equation is to raise the second order moment to infinity when n_ed / n_b is equal to 1.
         # This is not possible in numeric calculations, so we will use a large number instead.
-        return 1e9 if n_b / n_ed == 1 else m_0ed * (1 + beta / (n_b / n_ed - 1))
+        return 1e9 if n_ed / n_b == 1 else m_0ed / (1 - (n_ed / n_b))
 
     def latex(self) -> LatexFormula:
-        """Returns LatexFormula object for formula 5.28."""
+        """Returns LatexFormula object for formula 5.30."""
         return LatexFormula(
             return_symbol=r"M_{Ed}",
             result=f"{self:.3f}",
-            equation=r"M_{0Ed} \cdot \left(1 + \frac{\beta}{\frac{N_{B}}{N_{Ed}} - 1}\right)",
-            numeric_equation=rf"{self.m_0ed:.3f} \cdot \left(1 + \frac{{{self.beta:.3f}}}{{\frac{{{self.n_b:.3f}}}{{{self.n_ed:.3f}}} - 1}}\right)",
+            equation=r"\frac{M_{0Ed}}{1 - \left(\frac{N_{Ed}}{N_{B}}\right)}",
+            numeric_equation=rf"\frac{{{self.m_0ed:.3f}}}{{1 - \left(\frac{{{self.n_ed:.3f}}}{{{self.n_b:.3f}}}\right)}}",
             comparison_operator_label="=",
             unit="kNm",
         )

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_30.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_30.py
@@ -53,7 +53,7 @@ class Form5Dot30TotalDesignMoment(Formula):
         # When n_ed / n_b is equal to 1, the formula will divide by zero.
         # The spirit of the equation is to raise the second order moment to infinity when n_ed / n_b is equal to 1.
         # This is not possible in numeric calculations, so we will use a large number instead.
-        return 1e9 if n_ed / n_b == 1 else m_0ed / (1 - (n_ed / n_b))
+        return 1e9 if n_ed == n_b else m_0ed / (1 - (n_ed / n_b))
 
     def latex(self) -> LatexFormula:
         """Returns LatexFormula object for formula 5.30."""

--- a/docs/source/codes/eurocode/ec2_1992_1_1_2011/formulas.md
+++ b/docs/source/codes/eurocode/ec2_1992_1_1_2011/formulas.md
@@ -76,7 +76,7 @@ Total of 304 formulas present.
 | 5.27           |        :x:         |         |                                                           |
 | 5.28           | :heavy_check_mark: |         | Form5Dot28TotalDesignMoment                               |
 | 5.29           | :heavy_check_mark: |         | Form5Dot29BetaFactor                                      |
-| 5.30           |        :x:         |         |                                                           |
+| 5.30           | :heavy_check_mark: |         | Form5Dot30TotalDesignMoment                               |
 | 5.31           |        :x:         |         |                                                           |
 | 5.32           |        :x:         |         |                                                           |
 | 5.33           |        :x:         |         |                                                           |

--- a/docs/source/codes/eurocode/ec2_1992_1_1_2011/formulas.md
+++ b/docs/source/codes/eurocode/ec2_1992_1_1_2011/formulas.md
@@ -74,7 +74,7 @@ Total of 304 formulas present.
 | 5.25           |        :x:         |         |                                                           |
 | 5.26           |        :x:         |         |                                                           |
 | 5.27           |        :x:         |         |                                                           |
-| 5.28           |        :x:         |         |                                                           |
+| 5.28           | :heavy_check_mark: |         | Form5Dot28TotalDesignMoment                               |
 | 5.29           |        :x:         |         |                                                           |
 | 5.30           |        :x:         |         |                                                           |
 | 5.31           |        :x:         |         |                                                           |

--- a/docs/source/codes/eurocode/ec2_1992_1_1_2011/formulas.md
+++ b/docs/source/codes/eurocode/ec2_1992_1_1_2011/formulas.md
@@ -75,7 +75,7 @@ Total of 304 formulas present.
 | 5.26           |        :x:         |         |                                                           |
 | 5.27           |        :x:         |         |                                                           |
 | 5.28           | :heavy_check_mark: |         | Form5Dot28TotalDesignMoment                               |
-| 5.29           |        :x:         |         |                                                           |
+| 5.29           | :heavy_check_mark: |         | Form5Dot29BetaFactor                                      |
 | 5.30           |        :x:         |         |                                                           |
 | 5.31           |        :x:         |         |                                                           |
 | 5.32           |        :x:         |         |                                                           |

--- a/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_28.py
+++ b/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_28.py
@@ -1,0 +1,86 @@
+"""Testing formula 5.28 of NEN-EN 1992-1-1+C2:2011."""
+
+import pytest
+
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011.chapter_5_structural_analysis.formula_5_28 import Form5Dot28TotalDesignMoment
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm5Dot28TotalDesignMoment:
+    """Validation for formula 5.28 from NEN-EN 1992-1-1+C2:2011."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        m_0ed = 50.0
+        beta = 0.2
+        n_ed = 100.0
+        n_b = 200.0
+
+        # Object to test
+        formula = Form5Dot28TotalDesignMoment(m_0ed=m_0ed, beta=beta, n_ed=n_ed, n_b=n_b)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 60.0  # kNm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_at_capacity_normalforce(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        m_0ed = 50.0
+        beta = 0.2
+        n_ed = 200.0
+        n_b = 200.0
+
+        # Object to test
+        formula = Form5Dot28TotalDesignMoment(m_0ed=m_0ed, beta=beta, n_ed=n_ed, n_b=n_b)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 50000000.0  # kNm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("m_0ed", "beta", "n_ed", "n_b"),
+        [
+            (-50.0, 0.2, 100.0, 200.0),  # m_0ed is negative
+            (50.0, -0.2, 100.0, 200.0),  # beta is negative
+            (50.0, 0.2, -100.0, 200.0),  # n_ed is negative
+            (50.0, 0.2, 100.0, -200.0),  # n_b is negative
+            (50.0, 0.2, 0.0, 200.0),  # n_ed is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, m_0ed: float, beta: float, n_ed: float, n_b: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form5Dot28TotalDesignMoment(m_0ed=m_0ed, beta=beta, n_ed=n_ed, n_b=n_b)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"M_{Ed} = M_{0Ed} \cdot \left(1 + \frac{\beta}{\frac{N_{B}}{N_{Ed}} - 1}\right) "
+                r"= 50.000 \cdot \left(1 + \frac{0.200}{\frac{200.000}{100.000} - 1}\right) = 60.000 kNm",
+            ),
+            ("short", r"M_{Ed} = 60.000 kNm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        m_0ed = 50.0
+        beta = 0.2
+        n_ed = 100.0
+        n_b = 200.0
+
+        # Object to test
+        latex = Form5Dot28TotalDesignMoment(m_0ed=m_0ed, beta=beta, n_ed=n_ed, n_b=n_b).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_28.py
+++ b/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_28.py
@@ -37,7 +37,7 @@ class TestForm5Dot28TotalDesignMoment:
         formula = Form5Dot28TotalDesignMoment(m_0ed=m_0ed, beta=beta, n_ed=n_ed, n_b=n_b)
 
         # Expected result, manually calculated
-        manually_calculated_result = 50000000.0  # kNm
+        manually_calculated_result = 1e9  # kNm
 
         assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
 

--- a/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_29.py
+++ b/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_29.py
@@ -1,0 +1,60 @@
+"""Testing formula 5.29 of NEN-EN 1992-1-1+C2:2011."""
+
+import pytest
+
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011.chapter_5_structural_analysis.formula_5_29 import Form5Dot29BetaFactor
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm5Dot29BetaFactor:
+    """Validation for formula 5.29 from NEN-EN 1992-1-1+C2:2011."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        c_0 = 8.0
+
+        # Object to test
+        formula = Form5Dot29BetaFactor(c_0=c_0)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1.2337  # dimensionless
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("c_0"),
+        [
+            (-8.0),  # c_0 is negative
+            (0.0),  # c_0 is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, c_0: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form5Dot29BetaFactor(c_0=c_0)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"β = \frac{\pi^2}{c_0} = \frac{\pi^2}{8.000} = 1.234 -",
+            ),
+            ("short", r"β = 1.234 -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        c_0 = 8.0
+
+        # Object to test
+        latex = Form5Dot29BetaFactor(c_0=c_0).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_29.py
+++ b/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_29.py
@@ -39,9 +39,9 @@ class TestForm5Dot29BetaFactor:
         [
             (
                 "complete",
-                r"β = \frac{\pi^2}{c_0} = \frac{\pi^2}{8.000} = 1.234 -",
+                r"\beta = \frac{\pi^2}{c_0} = \frac{\pi^2}{8.000} = 1.234 -",
             ),
-            ("short", r"β = 1.234 -"),
+            ("short", r"\beta = 1.234 -"),
         ],
     )
     def test_latex(self, representation: str, expected: str) -> None:

--- a/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_30.py
+++ b/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/test_formula_5_30.py
@@ -1,0 +1,82 @@
+"""Testing formula 5.30 of NEN-EN 1992-1-1+C2:2011."""
+
+import pytest
+
+from blueprints.codes.eurocode.nen_en_1992_1_1_c2_2011.chapter_5_structural_analysis.formula_5_30 import Form5Dot30TotalDesignMoment
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm5Dot30TotalDesignMoment:
+    """Validation for formula 5.30 from NEN-EN 1992-1-1+C2:2011."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        m_0ed = 50.0
+        n_ed = 100.0
+        n_b = 200.0
+
+        # Object to test
+        formula = Form5Dot30TotalDesignMoment(m_0ed=m_0ed, n_ed=n_ed, n_b=n_b)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 100.0  # kNm
+
+        assert formula == pytest.approx(manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_at_capacity_normalforce(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        m_0ed = 50.0
+        n_ed = 200.0
+        n_b = 200.0
+
+        # Object to test
+        formula = Form5Dot30TotalDesignMoment(m_0ed=m_0ed, n_ed=n_ed, n_b=n_b)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1e9  # kNm
+
+        assert formula == pytest.approx(manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("m_0ed", "n_ed", "n_b"),
+        [
+            (-50.0, 100.0, 200.0),  # m_0ed is negative
+            (50.0, -100.0, 200.0),  # n_ed is negative
+            (50.0, 100.0, -200.0),  # n_b is negative
+            (50.0, 100.0, 0.0),  # n_b is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, m_0ed: float, n_ed: float, n_b: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form5Dot30TotalDesignMoment(m_0ed=m_0ed, n_ed=n_ed, n_b=n_b)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"M_{Ed} = \frac{M_{0Ed}}{1 - \left(\frac{N_{Ed}}{N_{B}}\right)} = "
+                r"\frac{50.000}{1 - \left(\frac{100.000}{200.000}\right)} = 100.000 kNm",
+            ),
+            ("short", r"M_{Ed} = 100.000 kNm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        m_0ed = 50.0
+        n_ed = 100.0
+        n_b = 200.0
+
+        # Object to test
+        latex = Form5Dot30TotalDesignMoment(m_0ed=m_0ed, n_ed=n_ed, n_b=n_b).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Description

add formulas from chapter 5.8.7.3. (5.28-5.30) from nen-en-1992-1-1.

please note: when N_Ed and N_B (in equations 28 and 30) are of equal size, the formula crashes. because the spirit of the equation is to amplify the M_Ed to infinite, thats also what I simulated with the 1e9 kNm.

Fixes #395

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
