### PR TITLE
Add docstrings to type alias

### DIFF
--- a/blueprints/type_alias.py
+++ b/blueprints/type_alias.py
@@ -2,81 +2,126 @@
 
 # <editor-fold desc="DISTANCES">
 MM = float
+"""Millimeters (mm), represented as a float."""
 CM = float
+"""Centimeters (cm), represented as a float."""
 M = float
+"""Meters (m), represented as a float."""
 KM = float
+"""Kilometers (km), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="ROTATIONS">
 DEG = float
+"""Degrees (deg), represented as a float."""
 RAD = float
+"""Radians (rad), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="WEIGHTS">
-KG = float
 G = float
+"""Grams (g), represented as a float."""
+KG = float
+"""Kilograms (kg), represented as a float."""
 KG_M3 = float
+"""Kilograms per cubic meter (kg/m³), represented as a float."""
 KG_M = float
+"""Kilograms per meter (kg/m), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="FORCES">
 N = float
+"""Newtons (N), represented as a float."""
 KN = float
+"""Kilonewtons (kN), value represented as a float."""
 KN_M = float
+"""Kilonewtons per meter (kN/m), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="MOMENTS">
 NM = float
+"""Newton-meters (Nm), represented as a float."""
 KNM = float
+"""Kilonewton-meters (kNm), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="STRESSES">
-MPA = float
 KPA = float
+"""Kilopascals (KPa), represented as a float."""
+MPA = float
+"""Megapascals (MPa), represented as a float."""
 GPA = float
+"""Gigapascals (GPa), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="AREAS">
 MM2 = float
+"""Square millimeters (mm²), represented as a float."""
 MM2_M = float
+"""Square millimeters per meter, (mm²/m), represented as a float."""
 CM2 = float
+"""Square centimeters (cm²), represented as a float."""
 DM2 = float
+"""Square decimeters (dm²), represented as a float."""
 M2 = float
+"""Square meters (m²), represented as a float."""
 KM2 = float
+"""Square kilometers (km²), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="VOLUMES">
 MM3 = float
+"""Cubic millimeters (mm³), represented as a float."""
 CM3 = float
+"""Cubic centimeters (cm³), represented as a float."""
 M3 = float
+"""Cubic meters (m³), represented as a float."""
 M3_M = float
+"""Cubic meters per meter (m³/m), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="BI-QUADRATIC">
 MM4 = float
+"""Millimeters to the fourth power (mm⁴), represented as a float."""
 CM4 = float
+"""Centimeters to the fourth power (cm⁴), represented as a float."""
 M4 = float
+"""Meters to the fourth power (m⁴), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="COMPOUNDS">
 N_M2 = float
+"""Newton per square meter (N/m²), represented as a float."""
 KN_M2 = float
+"""Kilonewton per square meter (kN/m²), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="TIME">
 HOURS = float
+"""Hours (h), represented as a float."""
 MINUTES = float
+"""Minutes (min), represented as a float."""
 SECONDS = float
+"""Seconds (sec), represented as a float."""
 DAYS = float
+"""Days (days), represented as a float."""
 WEEKS = float
+"""Weeks (weeks), represented as a float."""
 MONTHS = float
+"""Months (months), represented as a float."""
 YEARS = float
+"""Years (years), represented as a float."""
 # </editor-fold>
 
 # <editor-fold desc="Ratio's">
 RATIO = float
+"""Ratio, represented as a float."""
 PERCENTAGE = float
+"""Percentage (%), represented as a float."""
 DIMENSIONLESS = float
+"""Dimensionless, represented as a float."""
 PER_MILLE = float
+"""Per mille (‰), represented as a float."""
 PER_DEGREE = float
+"""Per degree (1/°), represented as a float."""
 # </editor-fold>

--- a/blueprints/type_alias.py
+++ b/blueprints/type_alias.py
@@ -97,12 +97,12 @@ KN_M2 = float
 # </editor-fold>
 
 # <editor-fold desc="TIME">
-HOURS = float
-"""Hours (h), represented as a float."""
-MINUTES = float
-"""Minutes (min), represented as a float."""
 SECONDS = float
 """Seconds (sec), represented as a float."""
+MINUTES = float
+"""Minutes (min), represented as a float."""
+HOURS = float
+"""Hours (h), represented as a float."""
 DAYS = float
 """Days (days), represented as a float."""
 WEEKS = float
@@ -113,15 +113,18 @@ YEARS = float
 """Years (years), represented as a float."""
 # </editor-fold>
 
+# <editor-fold desc="Percentages">
+PERCENTAGE = float
+"""Percentage (%), represented as a float."""
+PER_MILLE = float
+"""Per mille (‰), represented as a float."""
+# </editor-fold>
+
 # <editor-fold desc="Ratio's">
 RATIO = float
 """Ratio, represented as a float."""
-PERCENTAGE = float
-"""Percentage (%), represented as a float."""
-DIMENSIONLESS = float
-"""Dimensionless, represented as a float."""
-PER_MILLE = float
-"""Per mille (‰), represented as a float."""
 PER_DEGREE = float
 """Per degree (1/°), represented as a float."""
+DIMENSIONLESS = float
+"""Dimensionless, represented as a float."""
 # </editor-fold>


### PR DESCRIPTION
## Description

Updated docstrings in type aliases, so the units are more clear.

Fixes # (#436)

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
