### PR TITLE
Fix bug in _structural_class_delta_design_working_life table 4.3 of 1…

### DIFF
--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/table_4_3.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/table_4_3.py
@@ -65,8 +65,13 @@ class ConcreteStructuralClassCalculator(AbstractConcreteStructuralClassCalculato
         In accordance with:
         NNEN-EN 1992-1-1+C2:2011 Concrete - General
         """
-        if self.design_working_life >= DESIGN_WORKING_LIFE_100:
-            self.update_structural_class(2, f"{DESIGN_WORKING_LIFE_100} years")
+        if self.design_working_life > DESIGN_WORKING_LIFE_DEFAULT:
+            explanation = (
+                f"{DESIGN_WORKING_LIFE_100} years"
+                if self.design_working_life == DESIGN_WORKING_LIFE_100
+                else f"{self.design_working_life} > {DESIGN_WORKING_LIFE_DEFAULT} => {DESIGN_WORKING_LIFE_100} years"
+            )
+            self.update_structural_class(2, explanation)
         else:
             self.update_structural_class(0, f"{DESIGN_WORKING_LIFE_DEFAULT} years")
 

--- a/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/test_table_4_3.py
+++ b/tests/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/test_table_4_3.py
@@ -43,7 +43,7 @@ class TestConcreteStructuralClassCalculator:
 
     @pytest.mark.parametrize(
         ("design_working_life", "expected_structural_class", "expected_explanation"),
-        [(50, 4, " + 0 class (50 years)"), (90, 4, " + 0 class (50 years)"), (100, 6, " + 2 classes (100 years)")],
+        [(50, 4, " + 0 class (50 years)"), (90, 6, " + 2 classes (90 > 50 => 100 years)"), (100, 6, " + 2 classes (100 years)")],
     )
     def test_structural_class_delta_design_working_life(
         self, design_working_life: YEARS, expected_structural_class: int, expected_explanation: str


### PR DESCRIPTION
## Description

The calculation of structural class was wrong for design working life between 50 and 100 (excluding both).
Problem was that for a design life of 70 for example, it assumed it's 50 and did not add to the structural class, but that's wrong. Because the limit for not adding to structural class is 50 and anything above that should add "2" to structural class.

This PR fixes that.

Fixes #482 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue): The result for the calculation of structural class is obviously different now, before it was wrong for the cases mentioned above. 

## Checklist:

- [x] I have adjusted tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
