### PR TITLE
493 documentation issue wrong latex rendering in docs fix homereadme

### DIFF
--- a/.github/prompts/casus_formula.prompt.md
+++ b/.github/prompts/casus_formula.prompt.md
@@ -32,14 +32,14 @@ class Form6Dot10abNStrengthReductionFactor(Formula):
         self,
         f_ck: MPA,
     ) -> None:
-        r"""[$$\nu_{1}$$] Strength reduction factor for concrete cracked in shear [-].
+        r"""[$\nu_{1}$] Strength reduction factor for concrete cracked in shear [-].
 
         NEN-EN 1992-1-1+C2:2011 art.6.2.2(1) - Formula (6.10.aN and 6.10.bN)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic compressive strength of concrete [$$MPa$$].
+            [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
         """
         super().__init__()
         self.f_ck = f_ck

--- a/.github/prompts/comparison_formula.prompt.md
+++ b/.github/prompts/comparison_formula.prompt.md
@@ -40,9 +40,9 @@ class Form5Dot38aCheckRelativeSlendernessRatio(Formula):
         Parameters
         ----------
         lambda_y : DIMENSIONLESS
-            [$$\lambda_{y}$$] Slenderness ratio in y-direction [-].
+            [$\lambda_{y}$] Slenderness ratio in y-direction [-].
         lambda_z : DIMENSIONLESS
-            [$$\lambda_{z}$$] Slenderness ratio in z-direction [$$N$$].
+            [$\lambda_{z}$] Slenderness ratio in z-direction [$N$].
         """
         super().__init__()
         self.lambda_y = lambda_y

--- a/.github/prompts/equation_formula.prompt.md
+++ b/.github/prompts/equation_formula.prompt.md
@@ -24,7 +24,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form6Dot41W1Rectangular(Formula):
-    r"""Class representing formula 6.41 for the calculation of [$$W_1$$]."""
+    r"""Class representing formula 6.41 for the calculation of [$W_1$]."""
 
     label = "6.41"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -35,18 +35,18 @@ class Form6Dot41W1Rectangular(Formula):
         c_2: MM,
         d: MM,
     ) -> None:
-        r"""[$$W_1$$] Calculation of the area [$$mm^2$$].
+        r"""[$W_1$] Calculation of the area [$mm^2$].
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.3(3) - Formula (6.41)
 
         Parameters
         ----------
         c_1 : MM
-            [$$c_1$$] Column dimension parallel to the eccentricity of the load [$$mm$$].
+            [$c_1$] Column dimension parallel to the eccentricity of the load [$mm$].
         c_2 : MM
-            [$$c_2$$] Column dimension perpendicular to the eccentricity of the load [$$mm$$].
+            [$c_2$] Column dimension perpendicular to the eccentricity of the load [$mm$].
         d : MM
-            [$$d$$] Mean effective depth of the slab [$$mm$$].
+            [$d$] Mean effective depth of the slab [$mm$].
         """
         super().__init__()
         self.c_1 = c_1

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/source/_static/blueprints_banner.png">
-  <source media="(prefers-color-scheme: light)" srcset="docs/source/_static/blueprints_banner.png">
-  <img alt="blueprints banner" src="docs/source/_static/blueprints_banner.png">
+  <source media="(prefers-color-scheme: dark)" srcset="docs/_overrides/assets/images/blueprints_banner.png">
+  <source media="(prefers-color-scheme: light)" srcset="docs/_overrides/assets/images/blueprints_banner.png">
+  <img alt="blueprints banner" src="docs/_overrides/assets/images/blueprints_banner.png">
 </picture>
 
 Welcome to `Blueprints`, the go-to repository for civil engineering professionals and enthusiasts!

--- a/blueprints/checks/nominal_concrete_cover/nominal_concrete_cover.py
+++ b/blueprints/checks/nominal_concrete_cover/nominal_concrete_cover.py
@@ -28,15 +28,15 @@ from blueprints.type_alias import MM
 
 @dataclass(frozen=True)
 class NominalConcreteCover:
-    r"""Class responsible for the calculation of the nominal concrete cover [$$c_{nom}$$] [$$mm$$].
+    r"""Class responsible for the calculation of the nominal concrete cover [$c_{nom}$] [$mm$].
     It takes considerations of art.4.4.1.2 and 4.4.1.3 into account.
 
     Parameters
     ----------
     reinforcement_diameter: MM
-        The diameter of the reinforcement [$$mm$$].
+        The diameter of the reinforcement [$mm$].
     nominal_max_aggregate_size: MM
-        The nominal maximum aggregate size [$$mm$$].
+        The nominal maximum aggregate size [$mm$].
     constants: ConstantsBase
         The constants for the calculation of the nominal concrete cover.
     structural_class: ConcreteStructuralClassBase | int
@@ -49,16 +49,16 @@ class NominalConcreteCover:
     chloride_seawater: ChlorideSeawater | Literal["XS1", "XS2", "XS3", "NA"]
         The classification of corrosion induced by chlorides from sea water. Default is "Not applicable".
     delta_c_dur_gamma: MM
-        [$$\Delta c_{dur,\gamma}$$] An additional safety requirement based on art. 4.4.1.2 (6) [$$mm$$].
-        The value of [$$\Delta c_{dur,\gamma}$$] for use in a Country may be found in its National Annex.
+        [$\Delta c_{dur,\gamma}$] An additional safety requirement based on art. 4.4.1.2 (6) [$mm$].
+        The value of [$\Delta c_{dur,\gamma}$] for use in a Country may be found in its National Annex.
         The recommended value is 0 mm. 0 mm is the default value in the formula if not specified otherwise.
     delta_c_dur_st: MM
-        [$$\Delta c_{dur,st}$$] A reduction of minimum concrete cover when using stainless steel based on art. 4.4.1.2 (7) [$$mm$$].
-        The value of [$$\Delta c_{dur,st}$$] for use in a Country may be found in its National Annex.
+        [$\Delta c_{dur,st}$] A reduction of minimum concrete cover when using stainless steel based on art. 4.4.1.2 (7) [$mm$].
+        The value of [$\Delta c_{dur,st}$] for use in a Country may be found in its National Annex.
         The recommended value, without further specification, is 0 mm. 0 mm is the default value in the formula if not specified otherwise.
     delta_c_dur_add: MM
-        [$$\Delta c_{dur,add}$$] A reduction of minimum concrete cover when using additional protection based on art. 4.4.1.2 (8) [$$mm$$].
-        The value of [$$\Delta c_{dur,add}$$] for use in a Country may be found in its National Annex.
+        [$\Delta c_{dur,add}$] A reduction of minimum concrete cover when using additional protection based on art. 4.4.1.2 (8) [$mm$].
+        The value of [$\Delta c_{dur,add}$] for use in a Country may be found in its National Annex.
         The recommended value, without further specification, is 0 mm. 0 mm is the default value in the formula if not specified otherwise.
     casting_surface: CastingSurface
         The casting surface of the concrete according to art. 4.4.1.3 (4).

--- a/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_1_general_rules/formula_1_0_1.py
+++ b/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_1_general_rules/formula_1_0_1.py
@@ -10,22 +10,22 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form1Dot0Dot1EquivalentPilePointCenterline(Formula):
-    r"""Class representing formula 1.0.1 for the calculation of the equivalent pile point centerline [$$D_{eq}$$] in [$$m$$]."""
+    r"""Class representing formula 1.0.1 for the calculation of the equivalent pile point centerline [$D_{eq}$] in [$m$]."""
 
     label = "1.0.1"
     source_document = NEN_9997_1_C2_2017
 
     def __init__(self, a: M, b: M) -> None:
-        r"""[$$D_{eq}$$] Equivalent pile point centerline.
+        r"""[$D_{eq}$] Equivalent pile point centerline.
 
         NEN 9997-1+C2:2017 art.1.5.2.106a - Formula (1.0.1)
 
         Parameters
         ----------
         a : M
-            [$$a$$] minor dimension of the largest cross-section at the pile tip [$$m$$].
+            [$a$] minor dimension of the largest cross-section at the pile tip [$m$].
         b : M
-            [$$b$$] major dimension of the largest cross-section at the pile tip [$$m$$].
+            [$b$] major dimension of the largest cross-section at the pile tip [$m$].
 
             Where: b ≤ 1.5 * a
         """

--- a/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_2_basic_of_geotechnical_design/formula_2_1_a.py
+++ b/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_2_basic_of_geotechnical_design/formula_2_1_a.py
@@ -8,22 +8,22 @@ from blueprints.validations import raise_if_negative
 
 
 class Form2Dot1aDesignValueLoad(Formula):
-    """Class representing formula 2.1a for the calculation of the design value [$$F_{d}$$] of actions."""
+    """Class representing formula 2.1a for the calculation of the design value [$F_{d}$] of actions."""
 
     label = "2.1a"
     source_document = NEN_9997_1_C2_2017
 
     def __init__(self, gamma_f: DIMENSIONLESS, f_rep: DIMENSIONLESS) -> None:
-        r"""[$$F_{d}$$] Design value of actions.
+        r"""[$F_{d}$] Design value of actions.
 
         NEN 9997-1+C2:2017 art.2.4.6.1(2) - (Formula 2.1a)
 
         Parameters
         ----------
         gamma_f : DIMENSIONLESS
-            [$$\gamma_{F}$$] partial factor for actions for persistent and transient situations defined in annex A [$$-$$].
+            [$\gamma_{F}$] partial factor for actions for persistent and transient situations defined in annex A [$-$].
         f_rep : DIMENSIONLESS
-            [$$F_{rep}$$] Representative value of actions.
+            [$F_{rep}$] Representative value of actions.
 
             Use your own implementation for this value or use :class:`Form2Dot1bRepresentativeValue`.
         """

--- a/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_2_basic_of_geotechnical_design/formula_2_1_b.py
+++ b/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_2_basic_of_geotechnical_design/formula_2_1_b.py
@@ -8,22 +8,22 @@ from blueprints.validations import raise_if_negative
 
 
 class Form2Dot1bRepresentativeValue(Formula):
-    """Class representing formula 2.1b for the calculation of the representative value [$$F_{rep}$$] of actions."""
+    """Class representing formula 2.1b for the calculation of the representative value [$F_{rep}$] of actions."""
 
     label = "2.1b"
     source_document = NEN_9997_1_C2_2017
 
     def __init__(self, psi: DIMENSIONLESS, f_k: DIMENSIONLESS) -> None:
-        r"""[$$F_{rep}$$] Representative value of actions.
+        r"""[$F_{rep}$] Representative value of actions.
 
         NEN 9997-1+C2:2017 art.2.4.6.1(2) - Formula (2.1b)
 
         Parameters
         ----------
         psi : DIMENSIONLESS
-            [$$\Psi$$] factor for converting the characteristic value to the representative value [$$-$$].
+            [$\Psi$] factor for converting the characteristic value to the representative value [$-$].
         f_k : DIMENSIONLESS
-            [$$F_{k}$$] Characteristic value of actions [$$-$$].
+            [$F_{k}$] Characteristic value of actions [$-$].
         """
         super().__init__()
         self.psi = psi

--- a/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_2_basic_of_geotechnical_design/formula_2_2.py
+++ b/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_2_basic_of_geotechnical_design/formula_2_2.py
@@ -8,22 +8,22 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form2Dot2DesignValueGeotechnicalParameter(Formula):
-    """Class representing formula 2.2 for the calculation of the design value [$$X_d$$] of geotechnical parameter [$$X$$]."""
+    """Class representing formula 2.2 for the calculation of the design value [$X_d$] of geotechnical parameter [$X$]."""
 
     label = "2.2"
     source_document = NEN_9997_1_C2_2017
 
     def __init__(self, x_k: DIMENSIONLESS, gamma_m: DIMENSIONLESS) -> None:
-        r"""[$$X_d$$] Design value of geotechnical parameter [$$X$$].
+        r"""[$X_d$] Design value of geotechnical parameter [$X$].
 
         NEN 9997-1+C2:2017 art.2.4.6.2(1) - Formula (2.2)
 
         Parameters
         ----------
         x_k : DIMENSIONLESS
-            [$$X_{k}$$] Characteristic value of geotechnical parameter [$$X$$].
+            [$X_{k}$] Characteristic value of geotechnical parameter [$X$].
         gamma_m : DIMENSIONLESS
-            [$$\gamma_M$$] material partial factor [$$-$$].
+            [$\gamma_M$] material partial factor [$-$].
         """
         super().__init__()
         self.x_k = x_k

--- a/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_2_basic_of_geotechnical_design/formula_2_4.py
+++ b/blueprints/codes/eurocode/nen_9997_1_c2_2017/chapter_2_basic_of_geotechnical_design/formula_2_4.py
@@ -12,7 +12,7 @@ class Form2Dot4DesignValueGeotechnicalParameter:
     r"""Class representing formula 2.4 for the check of
     the destabilizing load effect
     against the stabilizing load effect and friction resistance
-    [$$E_{dst;d} \leq E_{stb;d} + T_d$$].
+    [$E_{dst;d} \leq E_{stb;d} + T_d$].
     """
 
     label = "2.4"
@@ -21,18 +21,18 @@ class Form2Dot4DesignValueGeotechnicalParameter:
     def __init__(self, e_dst_d: KN, e_stb_d: KN, t_d: KN) -> None:
         r"""Check of the destabilizing load effect
         against the stabilizing load effect and friction resistance
-        [$$E_{dst;d} \leq E_{stb;d} + T_d$$].
+        [$E_{dst;d} \leq E_{stb;d} + T_d$].
 
         NEN 9997-1+C2:2017 art.2.4.7.2(1) - Formula (2.4)
 
         Parameters
         ----------
         E_dst_d : KN
-            [$$E_{dst;d}$$] Design value of destabilizing load effect [$$kN$$].
+            [$E_{dst;d}$] Design value of destabilizing load effect [$kN$].
         E_stb_d : KN
-            [$$E_{stb;d}$$] Design value of stabilizing load effect [$$kN$$].
+            [$E_{stb;d}$] Design value of stabilizing load effect [$kN$].
         T_d : KN
-            [$$T_d$$] Design value of friction resistance [$$kN$$].
+            [$T_d$] Design value of friction resistance [$kN$].
         """
         self.e_dst_d = e_dst_d
         self.e_stb_d = e_stb_d

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_1.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form3Dot1EstimationConcreteCompressiveStrength(Formula):
-    r"""Class representing formula 3.1 for the estimation of the concrete compressive strength, [$$f_{cm}(t)$$], after t days
+    r"""Class representing formula 3.1 for the estimation of the concrete compressive strength, [$f_{cm}(t)$], after t days
     with an average temperature of 20 degrees Celsius.
     """
 
@@ -20,16 +20,16 @@ class Form3Dot1EstimationConcreteCompressiveStrength(Formula):
         beta_cc_t: DIMENSIONLESS,
         f_cm: MPA,
     ) -> None:
-        r"""[$$f_{cm}(t)$$] The estimated concrete compressive strength [$$MPa$$].
+        r"""[$f_{cm}(t)$] The estimated concrete compressive strength [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.2(6) - Formula (3.1)
 
         Parameters
         ----------
         beta_cc_t : DIMENSIONLESS
-            [$$\beta_{cc}(t)$$] Coefficient dependent of the age of concrete [$$-$$].
+            [$\beta_{cc}(t)$] Coefficient dependent of the age of concrete [$-$].
         f_cm : MPA
-            [$$f_{cm}$$] Average concrete compressive strength on day 28 based on table 3.1 [$$MPa$$].
+            [$f_{cm}$] Average concrete compressive strength on day 28 based on table 3.1 [$MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_10.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_10.py
@@ -20,18 +20,18 @@ class Form3Dot10CoefficientAgeConcreteDryingShrinkage(Formula):
         t_s: DAYS,
         h_0: MM,
     ) -> None:
-        r"""[$$\beta_{ds}(t, t_s)$$] Coefficient for drying shrinkage due to age of concrete [$$-$$].
+        r"""[$\beta_{ds}(t, t_s)$] Coefficient for drying shrinkage due to age of concrete [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(6) - Formula (3.10)
 
         Parameters
         ----------
         t : DAYS
-            [$$t$$] Age in days of the concrete at the considered moment [$$days$$].
+            [$t$] Age in days of the concrete at the considered moment [$days$].
         t_s : DAYS
-            [$$t_s$$] Age in days of the concrete at the start of the drying shrinkage [$$days$$].
+            [$t_s$] Age in days of the concrete at the start of the drying shrinkage [$days$].
         h_0 : MM
-            [$$h_0$$] fictional thickness of cross-section [$$mm$$].
+            [$h_0$] fictional thickness of cross-section [$mm$].
             = 2 * Ac / u
             Use your own implementation of this formula or use the SubForm3Dot10FictionalCrossSection class.
 
@@ -83,16 +83,16 @@ class SubForm3Dot10FictionalCrossSection(Formula):
         a_c: MM2,
         u: MM,
     ) -> None:
-        r"""[$$h_0$$] Fictional thickness of the cross-section [$$mm$$].
+        r"""[$h_0$] Fictional thickness of the cross-section [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(6) - h0
 
         Parameters
         ----------
         a_c : MM2
-            [$$A_c$$] Area of the cross-section of the concrete [$$mm^2$$].
+            [$A_c$] Area of the cross-section of the concrete [$mm^2$].
         u : MM
-            [$$u$$] Circumference of part that is subjected to drying [$$mm$$].
+            [$u$] Circumference of part that is subjected to drying [$mm$].
         """
         super().__init__()
         self.a_c = a_c

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_11.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_11.py
@@ -17,18 +17,18 @@ class Form3Dot11AutogeneShrinkage(Formula):
         beta_as_t: DIMENSIONLESS,
         epsilon_ca_inf: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\epsilon_{ca}(t)$$] Autogene shrinkage [$$-$$].
+        r"""[$\epsilon_{ca}(t)$] Autogene shrinkage [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(6) - Formula (3.11)
 
         Parameters
         ----------
         beta_as_t : DIMENSIONLESS
-            [$$\beta_{as}(t)$$] Coefficient dependent on time in days for autogene shrinkage [$$-$$].
+            [$\beta_{as}(t)$] Coefficient dependent on time in days for autogene shrinkage [$-$].
             = 1 - exp(-0.2 * t^0.5)
             Use your own implementation of this formula or use the Form3Dot13CoefficientTimeAutogeneShrinkage class
         epsilon_ca_inf : DIMENSIONLESS
-            [$$\epsilon_{ca}(\infty)$$] Autogene shrinkage at infinity [$$-$$].
+            [$\epsilon_{ca}(\infty)$] Autogene shrinkage at infinity [$-$].
             = 2.5 * (fck - 10) E-6
             Use your own implementation of this formula or use the Form3Dot12AutogeneShrinkageInfinity class.
 

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_12.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_12.py
@@ -16,14 +16,14 @@ class Form3Dot12AutogeneShrinkageInfinity(Formula):
         self,
         f_ck: MPA,
     ) -> None:
-        r"""[$$\epsilon_{ca}(\infty)$$] Autogene shrinkage at infinity [$$$$-].
+        r"""[$\epsilon_{ca}(\infty)$] Autogene shrinkage at infinity [$$-].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(6) - Formula (3.12)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] Compressive strength concrete [$$MPa$$].
+            [$f_{ck}$] Compressive strength concrete [$MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_13.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_13.py
@@ -18,14 +18,14 @@ class Form3Dot13CoefficientTimeAutogeneShrinkage(Formula):
         self,
         t: DAYS,
     ) -> None:
-        r"""[$$\beta_{as}(t)$$] Coefficient dependent on time in days for autogene shrinkage [$$-$$].
+        r"""[$\beta_{as}(t)$] Coefficient dependent on time in days for autogene shrinkage [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(6) - Formula (3.13)
 
         Parameters
         ----------
         t : DAYS
-            [$$t$$] Time in days [$$days$$].
+            [$t$] Time in days [$days$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_14.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_14.py
@@ -17,19 +17,19 @@ class Form3Dot14StressStrainForShortTermLoading(Formula):
         k: DIMENSIONLESS,
         eta: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\sigma_c / f_{cm}$$] Compressive stress-strength ratio [$$-$$].
+        r"""[$\sigma_c / f_{cm}$] Compressive stress-strength ratio [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.5(1) - Formula (3.14)
 
         Parameters
         ----------
         k : DIMENSIONLESS
-            [$$k$$] [$$-$$].
-            = 1.05 * Ecm * |$$\epsilon_{c1}$$| / fcm
+            [$k$] [$-$].
+            = 1.05 * Ecm * |$\epsilon_{c1}$| / fcm
             Use your own implementation of this formula or use the SubForm3Dot14K class.
         eta : DIMENSIONLESS
-            [$$\eta$$] Strain - peak-strain ratio [$$-$$].
-            = $$\epsilon_c / \epsilon_{c1}$$
+            [$\eta$] Strain - peak-strain ratio [$-$].
+            = $\epsilon_c / \epsilon_{c1}$
             Use your own implementation of this formula or use the SubForm3Dot14Eta class.
 
         Returns
@@ -74,16 +74,16 @@ class SubForm3Dot14Eta(Formula):
         epsilon_c: DIMENSIONLESS,
         epsilon_c1: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\eta$$] Strain - peak-strain ratio [$$-$$].
+        r"""[$\eta$] Strain - peak-strain ratio [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.5(1) - η
 
         Parameters
         ----------
         epsilon_c : DIMENSIONLESS
-            [$$\epsilon_c$$] Strain concrete [$$-$$].
+            [$\epsilon_c$] Strain concrete [$-$].
         epsilon_c1 : DIMENSIONLESS
-            [$$\epsilon_{c1}$$] Strain concrete at peak-stress following table 3.1 [$$-$$].
+            [$\epsilon_{c1}$] Strain concrete at peak-stress following table 3.1 [$-$].
         """
         super().__init__()
         self.epsilon_c = epsilon_c
@@ -115,18 +115,18 @@ class SubForm3Dot14K(Formula):
     label = "3.14"
 
     def __init__(self, e_cm: MPA, epsilon_c1: DIMENSIONLESS, f_cm: MPA) -> None:
-        r"""[$$k$$] [-].
+        r"""[$k$] [-].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.5(1) - k
 
         Parameters
         ----------
         e_cm : MPA
-            [$$E_{cm}$$] Elastic modulus concrete [$$MPa$$].
+            [$E_{cm}$] Elastic modulus concrete [$MPa$].
         epsilon_c1 : DIMENSIONLESS
-            [$$\epsilon_{c1}$$] Strain concrete at peak-stress following table 3.1 [$$-$$].
+            [$\epsilon_{c1}$] Strain concrete at peak-stress following table 3.1 [$-$].
         f_cm : MPA
-            [$$f_{cm}$$] Compressive strength concrete [$$MPa$$].
+            [$f_{cm}$] Compressive strength concrete [$MPa$].
         """
         super().__init__()
         self.e_cm = e_cm

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_15.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_15.py
@@ -18,20 +18,20 @@ class Form3Dot15DesignValueCompressiveStrength(Formula):
         f_ck: MPA,
         gamma_c: DIMENSIONLESS,
     ) -> None:
-        r"""[$$f_{cd}$$] Design value concrete compressive strength [$$MPa$$].
+        r"""[$f_{cd}$] Design value concrete compressive strength [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.6(1) - Formula (3.15)
 
         Parameters
         ----------
         alpha_cc : DIMENSIONLESS
-            [$$\alpha_{cc}$$] Coefficient taking long term effects on compressive strength into
-            account and unfavorable effect due to positioning loading [$$-$$]
+            [$\alpha_{cc}$] Coefficient taking long term effects on compressive strength into
+            account and unfavorable effect due to positioning loading [$-$]
             Normally between 0.8 and 1, see national appendix. Recommended value: 1.0
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic compressive strength [$$MPa$$].
+            [$f_{ck}$] Characteristic compressive strength [$MPa$].
         gamma_c : DIMENSIONLESS
-            [$$\gamma_{c}$$] Partial safety factor concrete, see 2.4.2.4 [$$-$$].
+            [$\gamma_{c}$] Partial safety factor concrete, see 2.4.2.4 [$-$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_16.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_16.py
@@ -18,20 +18,20 @@ class Form3Dot16DesignValueTensileStrength(Formula):
         f_ctk_0_05: MPA,
         gamma_c: DIMENSIONLESS,
     ) -> None:
-        r"""[$$f_{cd}$$] Design value concrete tensile strength [$$MPa$$].
+        r"""[$f_{cd}$] Design value concrete tensile strength [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.6(2) - Formula (3.16)
 
         Parameters
         ----------
         alpha_ct : DIMENSIONLESS
-            [$$\alpha_{ct}$$] Coefficient taking long term effects on tensile strength into
-            account and unfavorable effect due to positioning loading [$$-$$]
+            [$\alpha_{ct}$] Coefficient taking long term effects on tensile strength into
+            account and unfavorable effect due to positioning loading [$-$]
             See national appendix. Recommended value: 1.0
         f_ctk_0_05 : MPA
-            [$$f_{ctk,0.05}$$] Characteristic tensile strength 5% [$$MPa$$].
+            [$f_{ctk,0.05}$] Characteristic tensile strength 5% [$MPa$].
         gamma_c : DIMENSIONLESS
-            [$$\gamma_{c}$$] Partial safety factor concrete, see 2.4.2.4 [$$-$$].
+            [$\gamma_{c}$] Partial safety factor concrete, see 2.4.2.4 [$-$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_17.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_17.py
@@ -19,18 +19,18 @@ class Form3Dot17CompressiveStressConcrete(Formula):
         epsilon_c2: DIMENSIONLESS,
         n: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\sigma_c$$] Compressive stress in concrete using stress-strain diagram of figure 3.3 [$$MPa$$].
+        r"""[$\sigma_c$] Compressive stress in concrete using stress-strain diagram of figure 3.3 [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.7(1) - Formula (3.17)
 
         Parameters
         ----------
         f_cd : MPA
-            [$$f_{cd}$$] Design value compressive strength concrete [$$MPa$$].
+            [$f_{cd}$] Design value compressive strength concrete [$MPa$].
         epsilon_c : DIMENSIONLESS
-            [$$\epsilon_c$$] Strain in concrete [$$-$$].
+            [$\epsilon_c$] Strain in concrete [$-$].
         epsilon_c2 : DIMENSIONLESS
-            [$$\epsilon_{c2}$$] Strain in concrete when reaching maximum strength following table 3.1 [$$-$$].
+            [$\epsilon_{c2}$] Strain in concrete when reaching maximum strength following table 3.1 [$-$].
         n : DIMENSIONLESS
             Exponent following table 3.1.
 

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_18.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_18.py
@@ -16,14 +16,14 @@ class Form3Dot18CompressiveStressConcrete(Formula):
         self,
         f_cd: MPA,
     ) -> None:
-        r"""[$$\sigma_c$$] Compressive stress in concrete using stress-strain diagram of figure 3.3 [$$MPa$$].
+        r"""[$\sigma_c$] Compressive stress in concrete using stress-strain diagram of figure 3.3 [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.7(1) - Formula (3.18)
 
         Parameters
         ----------
         f_cd : MPA
-            [$$f_{cd}$$] Design value compressive strength concrete [$$MPa$$].
+            [$f_{cd}$] Design value compressive strength concrete [$MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_19_20.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_19_20.py
@@ -16,15 +16,15 @@ class Form3Dot19And20EffectivePressureZoneHeight(Formula):
         self,
         f_ck: MPA,
     ) -> None:
-        r"""[$$\lambda$$] Factor effective pressure zone height [$$-$$].
+        r"""[$\lambda$] Factor effective pressure zone height [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.7(3) - Formula (3.19) and (3.20)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic compressive strength concrete [$$MPa$$].
-            Valid range: [$$f_{ck} \leq 90$$].
+            [$f_{ck}$] Characteristic compressive strength concrete [$MPa$].
+            Valid range: [$f_{ck} \leq 90$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_2.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_2.py
@@ -9,7 +9,7 @@ from blueprints.type_alias import DAYS, DIMENSIONLESS
 
 
 class Form3Dot2CoefficientDependentOfConcreteAge(Formula):
-    r"""Class representing formula 3.2 for the coefficient [$$\beta_{cc}(t)$$] which is dependent of the age of concrete."""
+    r"""Class representing formula 3.2 for the coefficient [$\beta_{cc}(t)$] which is dependent of the age of concrete."""
 
     label = "3.2"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -19,20 +19,20 @@ class Form3Dot2CoefficientDependentOfConcreteAge(Formula):
         s: DIMENSIONLESS,
         t: DAYS,
     ) -> None:
-        r"""[$$\beta_{cc}(t)$$] Coefficient which is dependent of the age of concrete in days [$$-$$].
+        r"""[$\beta_{cc}(t)$] Coefficient which is dependent of the age of concrete in days [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.2(6) - Formula (3.2)
 
         Parameters
         ----------
         s : DIMENSIONLESS
-            [$$s$$] Coefficient dependent on the kind of cement [$$-$$].
+            [$s$] Coefficient dependent on the kind of cement [$-$].
             = 0.20 for cement of strength classes CEM 42.5 R, CEM 52.5 N, and CEM 52.5 R (class R);
             = 0.25 for cement of strength classes CEM 32.5 R, CEM 42.5 N (class N);
             = 0.38 for cement of strength class CEM 32.5 N (class S).
             Use your own implementation of this formula or use the SubForm3Dot2CoefficientTypeOfCementS class.
         t : DAYS
-            [$$t$$] Age of concrete in days [$$\text{days}$$].
+            [$t$] Age of concrete in days [$\text{days}$].
 
         Returns
         -------
@@ -66,7 +66,7 @@ class Form3Dot2CoefficientDependentOfConcreteAge(Formula):
 
 
 class SubForm3Dot2CoefficientTypeOfCementS(Formula):
-    r"""Class representing sub-formula for formula 3.2, which calculates the coefficient [$$s$$] which is dependent on the cement class."""
+    r"""Class representing sub-formula for formula 3.2, which calculates the coefficient [$s$] which is dependent on the cement class."""
 
     source_document = NEN_EN_1992_1_1_C2_2011
     label = "3.2"
@@ -75,14 +75,14 @@ class SubForm3Dot2CoefficientTypeOfCementS(Formula):
         self,
         cement_class: str,
     ) -> None:
-        r"""[$$s$$] Coefficient that depends on the type of cement [$$-$$].
+        r"""[$s$] Coefficient that depends on the type of cement [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.2(6) - s
 
         Parameters
         ----------
         cement_class : str
-            [$$cement\_class$$] Class of the cement.
+            [$cement\_class$] Class of the cement.
                 = 'R' for cement of strength classes CEM 42.5 R, CEM 52.5 N, and CEM 52.5 R (class R);
                 = 'N' for cement of strength classes CEM 32.5 R, CEM 42.5 N (class N);
                 = 'S' for cement of strength class CEM 32.5 N (class S).

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_21_22.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_21_22.py
@@ -7,7 +7,7 @@ from blueprints.type_alias import DIMENSIONLESS, MPA
 
 
 class Form3Dot21And22EffectiveStrength(Formula):
-    r"""[$$\eta$$] Class representing formula 3.21 and 3.22 for the calculation of the factor for the effective strength [$$-$$]."""
+    r"""[$\eta$] Class representing formula 3.21 and 3.22 for the calculation of the factor for the effective strength [$-$]."""
 
     label = "3.21 - 3.22"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -16,15 +16,15 @@ class Form3Dot21And22EffectiveStrength(Formula):
         self,
         f_ck: MPA,
     ) -> None:
-        r"""[$$\eta$$] Factor effective strength [$$-$$].
+        r"""[$\eta$] Factor effective strength [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.7(3) - Formula (3.21) and (3.22)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic compressive strength concrete [$$MPa$$].
-            Valid range: [$$f_{ck} \leq 90 MPa$$].
+            [$f_{ck}$] Characteristic compressive strength concrete [$MPa$].
+            Valid range: [$f_{ck} \leq 90 MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_23.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_23.py
@@ -17,16 +17,16 @@ class Form3Dot23FlexuralTensileStrength(Formula):
         h: MM,
         f_ctm: MPA,
     ) -> None:
-        r"""[$$f_{ctm,fl}$$] Mean flexural tensile strength of reinforced concrete members  [$$MPa$$].
+        r"""[$f_{ctm,fl}$] Mean flexural tensile strength of reinforced concrete members  [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.8(1) - Formula (3.23)
 
         Parameters
         ----------
         h : MM
-            [$${h}$$] Total member depth [mm].
+            [${h}$] Total member depth [mm].
         f_ctm : MPA
-            [$${f_{ctm}}$$] Mean axial tensile strength following from table 3.1 [$$MPa$$].
+            [${f_{ctm}}$] Mean axial tensile strength following from table 3.1 [$MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_24_25.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_24_25.py
@@ -18,17 +18,17 @@ class Form3Dot24And25IncreasedCharacteristicCompressiveStrength(Formula):
         f_ck: MPA,
         sigma_2: MPA,
     ) -> None:
-        r"""[$$f_{ck,c}$$] Increased characteristic compressive strength due to enclosed concrete [$$MPa$$].
+        r"""[$f_{ck,c}$] Increased characteristic compressive strength due to enclosed concrete [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.9(2) - Formula (3.24 and 3.25)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic compressive strength concrete [$$MPa$$].
-            Valid range: [$$f_{ck} \leq 90 \, MPa$$].
+            [$f_{ck}$] Characteristic compressive strength concrete [$MPa$].
+            Valid range: [$f_{ck} \leq 90 \, MPa$].
         sigma_2 : MPA
-            [$$\sigma_2$$] Effective compressive stress in transverse direction [$$MPa$$].
+            [$\sigma_2$] Effective compressive stress in transverse direction [$MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_26.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_26.py
@@ -18,19 +18,19 @@ class Form3Dot26IncreasedStrainAtMaxStrength(Formula):
         f_ck_c: MPA,
         epsilon_c2: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\epsilon_{c2,c}$$] Increased strain at the maximum strength due to enclosed concrete. [$$-$$].
+        r"""[$\epsilon_{c2,c}$] Increased strain at the maximum strength due to enclosed concrete. [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.9(2) - Formula (3.26)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic compressive strength [$$MPa$$]
+            [$f_{ck}$] Characteristic compressive strength [$MPa$]
         f_ck_c : MPA
-            [$$f_{ck,c}$$] Increased characteristic compressive strength due to enclosed concrete [$$MPa$$].
+            [$f_{ck,c}$] Increased characteristic compressive strength due to enclosed concrete [$MPa$].
             See classes Form3Dot24IncreasedCharacteristicCompressiveStrength and/or Form3Dot25IncreasedCharacteristicCompressiveStrength
         epsilon_c2 : DIMENSIONLESS
-            [$$\epsilon_{c2}$$] Strain at maximum strength [$$-$$]
+            [$\epsilon_{c2}$] Strain at maximum strength [$-$]
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_27.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_27.py
@@ -18,18 +18,18 @@ class Form3Dot27IncreasedStrainLimitValue(Formula):
         sigma_2: MPA,
         epsilon_cu2: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\epsilon_{cu2,c}$$] Increased strain limit value due to enclosed concrete. [$$-$$].
+        r"""[$\epsilon_{cu2,c}$] Increased strain limit value due to enclosed concrete. [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.9(2) - Formula (3.27)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic compressive strength [$$MPa$$]
+            [$f_{ck}$] Characteristic compressive strength [$MPa$]
         sigma_2 : MPA
-            [$$\sigma_{2}$$] Effective compressive stress in transverse direction [$$MPa$$]
+            [$\sigma_{2}$] Effective compressive stress in transverse direction [$MPa$]
         epsilon_cu2 : DIMENSIONLESS
-            [$$\epsilon_{cu2}$$] Strain limit value [$$-$$]
+            [$\epsilon_{cu2}$] Strain limit value [$-$]
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_28.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_28.py
@@ -20,20 +20,20 @@ class Form3Dot28RatioLossOfPreStressClass1(Formula):
         mu: DIMENSIONLESS,
         t: HOURS,
     ) -> None:
-        r"""[$$\frac{\Delta \sigma_{pr}}{\sigma_{pi}}$$] Ratio between loss of pre-stress and initial pre-stress for class 2 [$$-$$].
+        r"""[$\frac{\Delta \sigma_{pr}}{\sigma_{pi}}$] Ratio between loss of pre-stress and initial pre-stress for class 2 [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.3.2(7) - Formula (3.28)
 
         Parameters
         ----------
         rho_1000 : PERCENTAGE
-            [$$\rho_{1000}$$] Value of relaxation loss at 1000h after prestressing at an average temperature of 20 degrees Celsius [$$-$$]
+            [$\rho_{1000}$] Value of relaxation loss at 1000h after prestressing at an average temperature of 20 degrees Celsius [$-$]
         mu : DIMENSIONLESS
-            [$$\mu$$] Ratio between initial pre-stress and characteristic tensile strength [$$-$$]
-            = [$$\frac{\sigma_{pi}}{f_{pk}}$$]
+            [$\mu$] Ratio between initial pre-stress and characteristic tensile strength [$-$]
+            = [$\frac{\sigma_{pi}}{f_{pk}}$]
             Use your own implementation of this formula or use sub_formula_3_28_39_30 class SubForm3Dot282930Mu.
         t : HOURS
-            [$$t$$] Time after prestressing [$$hours$$]
+            [$t$] Time after prestressing [$hours$]
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_29.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_29.py
@@ -20,20 +20,20 @@ class Form3Dot29RatioLossOfPreStressClass2(Formula):
         mu: DIMENSIONLESS,
         t: HOURS,
     ) -> None:
-        r"""[$$\frac{\Delta \sigma_{pr}}{\sigma_{pi}}$$] Ratio between loss of pre-stress and initial pre-stress for class 2. [$$-$$].
+        r"""[$\frac{\Delta \sigma_{pr}}{\sigma_{pi}}$] Ratio between loss of pre-stress and initial pre-stress for class 2. [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.3.2(7) - Formula (3.29)
 
         Parameters
         ----------
         rho_1000 : PERCENTAGE
-            [$$\rho_{1000}$$] Value of relaxation loss at 1000h after prestressing at an average temperature of 20 degrees Celsius [$$%$$]
+            [$\rho_{1000}$] Value of relaxation loss at 1000h after prestressing at an average temperature of 20 degrees Celsius [$%$]
         mu : DIMENSIONLESS
-            [$$\mu$$] Ratio between initial pre-stress and characteristic tensile strength [$$-$$]
-            = [$$\sigma_{pi} / f_{pk}$$]
+            [$\mu$] Ratio between initial pre-stress and characteristic tensile strength [$-$]
+            = [$\sigma_{pi} / f_{pk}$]
             Use your own implementation of this formula or use sub_formula_3_28_39_30 class SubForm3Dot282930Mu.
         t : HOURS
-            [$$t$$] Time after prestressing [$$hours$$]
+            [$t$] Time after prestressing [$hours$]
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_3.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_3.py
@@ -7,7 +7,7 @@ from blueprints.type_alias import MPA
 
 
 class Form3Dot3AxialTensileStrengthFromTensileSplittingStrength(Formula):
-    """Class representing formula 3.3 for the approximated axial tensile strength, [$$f_{ct}$$], determined by tensile splitting strength."""
+    """Class representing formula 3.3 for the approximated axial tensile strength, [$f_{ct}$], determined by tensile splitting strength."""
 
     label = "3.3"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -16,15 +16,15 @@ class Form3Dot3AxialTensileStrengthFromTensileSplittingStrength(Formula):
         self,
         f_ct_sp: MPA,
     ) -> None:
-        r"""[$$f_{ct}$$] The approximated axial tensile strength when tensile strength is determined as coefficient
-        which is dependent of the age of concrete [$$MPa$$].
+        r"""[$f_{ct}$] The approximated axial tensile strength when tensile strength is determined as coefficient
+        which is dependent of the age of concrete [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.2(8) - Formula (3.3)
 
         Parameters
         ----------
         f_ct_sp : MPA
-            [$$f_{ct,sp}$$] Tensile strength determined by tensile splitting strength [$$MPa$$].
+            [$f_{ct,sp}$] Tensile strength determined by tensile splitting strength [$MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_30.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_30.py
@@ -20,20 +20,20 @@ class Form3Dot30RatioLossOfPreStressClass3(Formula):
         mu: DIMENSIONLESS,
         t: HOURS,
     ) -> None:
-        r"""[$$\frac{\Delta \sigma_{pr}}{\sigma_{pi}}$$] Ratio between loss of pre-stress and initial pre-stress for class 3. [$$-$$].
+        r"""[$\frac{\Delta \sigma_{pr}}{\sigma_{pi}}$] Ratio between loss of pre-stress and initial pre-stress for class 3. [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.3.2(7) - Formula (3.30)
 
         Parameters
         ----------
         rho_1000 : PERCENTAGE
-            [$$\rho_{1000}$$] Value of relaxation loss at 1000h after prestressing at an average temperature of 20 degrees Celsius [$$%$$]
+            [$\rho_{1000}$] Value of relaxation loss at 1000h after prestressing at an average temperature of 20 degrees Celsius [$%$]
         mu : DIMENSIONLESS
-            [$$\mu$$] Ratio between initial pre-stress and characteristic tensile strength [$$-$$]
-            = [$$\frac{\sigma_{pi}}{f_{pk}}$$]
+            [$\mu$] Ratio between initial pre-stress and characteristic tensile strength [$-$]
+            = [$\frac{\sigma_{pi}}{f_{pk}}$]
             Use your own implementation of this formula or use sub_formula_3_28_39_30 class SubForm3Dot282930Mu.
         t : HOURS
-            [$$t$$] Time after prestressing [$$hours$$]
+            [$t$] Time after prestressing [$hours$]
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_4.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_4.py
@@ -18,21 +18,21 @@ class Form3Dot4DevelopmentTensileStrength(Formula):
         alpha: DIMENSIONLESS,
         f_ctm: MPA,
     ) -> None:
-        r"""[$$f_{ctm}(t)$$] The initial estimation of the tensile strength after t days [MPa].
+        r"""[$f_{ctm}(t)$] The initial estimation of the tensile strength after t days [MPa].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.2(9) - Formula (3.4)
 
         Parameters
         ----------
         beta_cc_t : DIMENSIONLESS
-            [$$\beta_{cc}(t)$$] Coefficient dependent of the age of concrete [-].
+            [$\beta_{cc}(t)$] Coefficient dependent of the age of concrete [-].
         alpha : DIMENSIONLESS
-            [$$\alpha$$] Factor dependent of the age of concrete [-]
+            [$\alpha$] Factor dependent of the age of concrete [-]
             alpha = 1 for t < 28 days
             alpha = 2/3 for t >= 28 days
             Use your own implementation of this value or use the SubForm3Dot4CoefficientAgeConcreteAlpha class.
         f_ctm : MPA
-            [$$f_{ctm}$$] Tensile strength from table 3.1 [MPa].
+            [$f_{ctm}$] Tensile strength from table 3.1 [MPa].
 
         Returns
         -------
@@ -79,14 +79,14 @@ class SubForm3Dot4CoefficientAgeConcreteAlpha(Formula):
         self,
         t: DAYS,
     ) -> None:
-        r"""[$$\alpha$$] Factor dependent of the age of concrete [$$-$$].
+        r"""[$\alpha$] Factor dependent of the age of concrete [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.2(9) - α
 
         Parameters
         ----------
         t : DAYS
-            [$$t$$] Age of concrete in days [$$days$$].
+            [$t$] Age of concrete in days [$days$].
         """
         super().__init__()
         self.t = t

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_5.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_5.py
@@ -18,18 +18,18 @@ class Form3Dot5ApproximationVarianceElasticModulusOverTime(Formula):
         f_cm: MPA,
         e_cm: MPA,
     ) -> None:
-        r"""[$$E_{cm}(t)$$] The approximated elastic modulus at day t [$$MPa$$].
+        r"""[$E_{cm}(t)$] The approximated elastic modulus at day t [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.3(3) - Formula (3.5)
 
         Parameters
         ----------
         f_cm_t : MPA
-            [$$f_{cm}(t)$$] Compressive strength concrete at t days [$$MPa$$].
+            [$f_{cm}(t)$] Compressive strength concrete at t days [$MPa$].
         f_cm : MPA
-            [$$f_{cm}$$] Average concrete compressive strength on day 28 based on table 3.1 [$$MPa$$].
+            [$f_{cm}$] Average concrete compressive strength on day 28 based on table 3.1 [$MPa$].
         e_cm : MPA
-            [$$E_{cm}$$] Average elastic modulus on day 28 [$$MPa$$].
+            [$E_{cm}$] Average elastic modulus on day 28 [$MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_6.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_6.py
@@ -19,18 +19,18 @@ class Form3Dot6CreepDeformationOfConcrete(Formula):
         e_c: MPA,
     ) -> None:
         r"""εcc(∞,t0) Creep deformation of concrete at the time t = ∞ for a constant concrete
-        compressive stress [$$\sigma_c$$] applied at time [$$t_0$$] [$$-$$].
+        compressive stress [$\sigma_c$] applied at time [$t_0$] [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(3) - Formula (3.6)
 
         Parameters
         ----------
         phi_inf_t0 : DIMENSIONLESS
-            [$$\varphi(\infty, t_0)$$] Creep coefficient if high accuracy is not required use figure 3.1 else use appendix B [$$-$$].
+            [$\varphi(\infty, t_0)$] Creep coefficient if high accuracy is not required use figure 3.1 else use appendix B [$-$].
         sigma_c : MPA
-            [$$\sigma_c$$] Concrete compressive stress [$$MPa$$].
+            [$\sigma_c$] Concrete compressive stress [$MPa$].
         e_c : MPA
-            [$$E_c$$] tangent modulus = 1.05 * [$$E_{cm}$$]. According to art.3.1.4(2) [$$MPa$$].
+            [$E_c$] tangent modulus = 1.05 * [$E_{cm}$]. According to art.3.1.4(2) [$MPa$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_7.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_7.py
@@ -23,16 +23,16 @@ class Form3Dot7NonLinearCreepCoefficient(Formula):
         phi_inf_t0: DIMENSIONLESS,
         k_sigma: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\varphi_{nl}(\infty,t_0)$$] The non-linear creep coefficient [$$-$$].
+        r"""[$\varphi_{nl}(\infty,t_0)$] The non-linear creep coefficient [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(4) - Formula (3.7)
 
         Parameters
         ----------
         phi_inf_t0 : DIMENSIONLESS
-            [$$\varphi(\infty, t_0)$$] Creep coefficient if high accuracy is not required use figure 3.1 and/or use appendix B [$$-$$].
+            [$\varphi(\infty, t_0)$] Creep coefficient if high accuracy is not required use figure 3.1 and/or use appendix B [$-$].
         k_sigma : DIMENSIONLESS
-            [$$k_{\sigma}$$] Stress-strength ratio [$$\sigma_c / f_{ck}(t_0)$$] [$$-$$].
+            [$k_{\sigma}$] Stress-strength ratio [$\sigma_c / f_{ck}(t_0)$] [$-$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_8.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_8.py
@@ -17,16 +17,16 @@ class Form3Dot8TotalShrinkage(Formula):
         epsilon_cd: DIMENSIONLESS,
         epsilon_ca: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\epsilon_{cs}$$] The total shrinkage [-].
+        r"""[$\epsilon_{cs}$] The total shrinkage [-].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(6) - Formula (3.8)
 
         Parameters
         ----------
         epsilon_cd : DIMENSIONLESS
-            [$$\epsilon_{cd}$$] Drying shrinkage [$$-$$].
+            [$\epsilon_{cd}$] Drying shrinkage [$-$].
         epsilon_ca : DIMENSIONLESS
-            [$$\epsilon_{ca}$$] Autogene shrinkage [$$-$$].
+            [$\epsilon_{ca}$] Autogene shrinkage [$-$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_9.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/formula_3_9.py
@@ -18,22 +18,22 @@ class Form3Dot9DryingShrinkage(Formula):
         k_h: DIMENSIONLESS,
         epsilon_cd_0: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\epsilon_{cd}(t)$$] Development of the drying shrinkage [$$-$$].
+        r"""[$\epsilon_{cd}(t)$] Development of the drying shrinkage [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.3.1.4(6) - Formula (3.9)
 
         Parameters
         ----------
         beta_ds_tt_s : DIMENSIONLESS
-            [$$\beta_{ds}(t, t_s)$$] Coefficient that depends on the age t (in days) of the concrete for the drying shrinkage [$$-$$].
+            [$\beta_{ds}(t, t_s)$] Coefficient that depends on the age t (in days) of the concrete for the drying shrinkage [$-$].
         k_h : DIMENSIONLESS
-            [$$k_h$$] Coefficient depending on the fictional thickness $$h_0$$ following table 3.3 [$$-$$].
-            $$h_0 = 100 \rightarrow k_h = 1.0$$
-            $$h_0 = 200 \rightarrow k_h = 0.85$$
-            $$h_0 = 300 \rightarrow k_h = 0.75$$
-            $$h_0 \geq 500 \rightarrow k_h = 0.70$$
+            [$k_h$] Coefficient depending on the fictional thickness $h_0$ following table 3.3 [$-$].
+            $h_0 = 100 \rightarrow k_h = 1.0$
+            $h_0 = 200 \rightarrow k_h = 0.85$
+            $h_0 = 300 \rightarrow k_h = 0.75$
+            $h_0 \geq 500 \rightarrow k_h = 0.70$
         epsilon_cd_0 : DIMENSIONLESS
-            [$$\epsilon_{cd,0}$$] Nominal unobstructed drying shrinkage, formula in appendix B or use table 3.2 [$$-$$].
+            [$\epsilon_{cd,0}$] Nominal unobstructed drying shrinkage, formula in appendix B or use table 3.2 [$-$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/sub_formula_3_28_29_30.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_3_materials/sub_formula_3_28_29_30.py
@@ -17,16 +17,16 @@ class SubForm3Dot282930Mu(Formula):
         sigma_pi: MPA,
         f_pk: MPA,
     ) -> None:
-        r"""[$$\mu$$] Ratio between initial pre-stress and characteristic tensile strength  [$$\sigma_{pi} / f_{pk}$$] [$$-$$].
+        r"""[$\mu$] Ratio between initial pre-stress and characteristic tensile strength  [$\sigma_{pi} / f_{pk}$] [$-$].
 
-        NEN-EN 1992-1-1+C2:2011 art.3.3.2(7) - [$$\mu$$]
+        NEN-EN 1992-1-1+C2:2011 art.3.3.2(7) - [$\mu$]
 
         Parameters
         ----------
         sigma_pi : MPA
-            [$$\sigma_{pi}$$] Initial pre-stress [$$MPa$$]
+            [$\sigma_{pi}$] Initial pre-stress [$MPa$]
         f_pk : MPA
-            [$$f_{pk}$$] Characteristic tensile strength of pre-stress steel [$$MPa$$]
+            [$f_{pk}$] Characteristic tensile strength of pre-stress steel [$MPa$]
 
         Returns
         -------
@@ -47,7 +47,7 @@ class SubForm3Dot282930Mu(Formula):
         return sigma_pi / f_pk
 
     def latex(self) -> LatexFormula:
-        r"""Returns LatexFormula object for [$$\mu$$] in formula 3.28 and 3.29 and 3.30."""
+        r"""Returns LatexFormula object for [$\mu$] in formula 3.28 and 3.29 and 3.30."""
         return LatexFormula(
             return_symbol=r"\mu",
             result=f"{self:.3f}",

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/formula_4_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/formula_4_1.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form4Dot1NominalConcreteCover(Formula):
-    r"""Class representing the formula 4.1 for the calculation of the nominal concrete cover [$$c_{nom}$$] [$$mm$$]."""
+    r"""Class representing the formula 4.1 for the calculation of the nominal concrete cover [$c_{nom}$] [$mm$]."""
 
     label = "4.1"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -18,7 +18,7 @@ class Form4Dot1NominalConcreteCover(Formula):
         c_min: MM,
         delta_c_dev: MM,
     ) -> None:
-        r"""[$$c_{nom}$$] Calculates the nominal concrete cover [$$mm$$].
+        r"""[$c_{nom}$] Calculates the nominal concrete cover [$mm$].
 
         Please be advised that this formula does not take various considerations in art.4.4.1.2 and 4.4.1.3 into account.
         For a more detailed calculation, please refer to the NominalConcreteCover class.
@@ -28,9 +28,9 @@ class Form4Dot1NominalConcreteCover(Formula):
         Parameters
         ----------
         c_min: MM
-            [$$c_{min}$$] Minimum concrete cover based on art. 4.4.1.2 [$$mm$$].
+            [$c_{min}$] Minimum concrete cover based on art. 4.4.1.2 [$mm$].
         delta_c_dev: MM
-            [$$\Delta c_{dev}$$] Construction tolerance based on art. 4.4.1.3 [$$mm$$].
+            [$\Delta c_{dev}$] Construction tolerance based on art. 4.4.1.3 [$mm$].
         """
         super().__init__()
         self.c_min = c_min

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/formula_4_2.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/formula_4_2.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form4Dot2MinimumConcreteCover(Formula):
-    """Class representing the formula 4.2 for the calculation of the minimum concrete cover [$$c_{min}$$] [$$mm$$]."""
+    """Class representing the formula 4.2 for the calculation of the minimum concrete cover [$c_{min}$] [$mm$]."""
 
     label = "4.2"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -21,7 +21,7 @@ class Form4Dot2MinimumConcreteCover(Formula):
         delta_c_dur_st: MM = 0,
         delta_c_dur_add: MM = 0,
     ) -> None:
-        r"""[$$c_{min}$$] Calculates the minimum concrete cover [$$mm$$].
+        r"""[$c_{min}$] Calculates the minimum concrete cover [$mm$].
 
         A minimum concrete cover of 10 mm is required, even if the calculated value is lower.
 
@@ -30,20 +30,20 @@ class Form4Dot2MinimumConcreteCover(Formula):
         Parameters
         ----------
         c_min_b: MM
-            [$$c_{min,b}$$] The minimum concrete cover based on the adhesion requirements based on art. 4.4.1.2 (3) [$$mm$$].
+            [$c_{min,b}$] The minimum concrete cover based on the adhesion requirements based on art. 4.4.1.2 (3) [$mm$].
         c_min_dur: MM
-            [$$c_{min,dur}$$] The minimum concrete cover based on environmental conditions based on art. 4.4.1.2 (5) [$$mm$$].
+            [$c_{min,dur}$] The minimum concrete cover based on environmental conditions based on art. 4.4.1.2 (5) [$mm$].
         delta_c_dur_gamma: MM
-            [$$\Delta c_{dur,\gamma}$$] An additional safety requirement based on art. 4.4.1.2 (6) [$$mm$$].
-            The value of [$$\Delta c_{dur,\gamma}$$] for use in a Country may be found in its National Annex.
+            [$\Delta c_{dur,\gamma}$] An additional safety requirement based on art. 4.4.1.2 (6) [$mm$].
+            The value of [$\Delta c_{dur,\gamma}$] for use in a Country may be found in its National Annex.
             The recommended value is 0 mm. 0 mm is the default value in the formula if not specified otherwise.
         delta_c_dur_st: MM
-            [$$\Delta c_{dur,st}$$] A reduction of minimum concrete cover when using stainless steel based on art. 4.4.1.2 (7) [$$mm$$].
-            The value of [$$\Delta c_{dur,st}$$] for use in a Country may be found in its National Annex.
+            [$\Delta c_{dur,st}$] A reduction of minimum concrete cover when using stainless steel based on art. 4.4.1.2 (7) [$mm$].
+            The value of [$\Delta c_{dur,st}$] for use in a Country may be found in its National Annex.
             The recommended value, without further specification, is 0 mm. 0 mm is the default value in the formula if not specified otherwise.
         delta_c_dur_add: MM
-            [$$\Delta c_{dur,add}$$] A reduction of minimum concrete cover when using additional protection based on art. 4.4.1.2 (8) [$$mm$$].
-            The value of [$$\Delta c_{dur,add}$$] for use in a Country may be found in its National Annex.
+            [$\Delta c_{dur,add}$] A reduction of minimum concrete cover when using additional protection based on art. 4.4.1.2 (8) [$mm$].
+            The value of [$\Delta c_{dur,add}$] for use in a Country may be found in its National Annex.
             The recommended value, without further specification, is 0 mm. 0 mm is the default value in the formula if not specified otherwise.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/table_4_2.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/table_4_2.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Table4Dot2MinimumCoverWithRegardToBond(Formula):
-    """Class representing the table 4.2 for the calculation of the minimum cover [$$c_{min,b}$$] [$$mm$$] requirements with regard to bond."""
+    """Class representing the table 4.2 for the calculation of the minimum cover [$c_{min,b}$] [$mm$] requirements with regard to bond."""
 
     label = "4.2"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -18,18 +18,18 @@ class Table4Dot2MinimumCoverWithRegardToBond(Formula):
         diameter: MM,
         nominal_max_aggregate_size_greater_than_32_mm: bool,
     ) -> None:
-        r"""[$$c_{min,b}$$] Calculates the minimum concrete cover with regard to bond [$$mm$$].
+        r"""[$c_{min,b}$] Calculates the minimum concrete cover with regard to bond [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.4.4.1.2 (3) - Table (4.2)
 
         Parameters
         ----------
         diameter: MM
-            Diameter of the reinforcement [$$mm$$].
-            In case of bundled bars, the equivalent diameter [$$Ø_{n}$$] as defined in par. 8.9.1 should be used.
+            Diameter of the reinforcement [$mm$].
+            In case of bundled bars, the equivalent diameter [$Ø_{n}$] as defined in par. 8.9.1 should be used.
             Use your own implementation of this value or use the :class:`Form8Dot14EquivalentDiameterBundledBars` class.
         nominal_max_aggregate_size_greater_than_32_mm: bool
-            Is the nominal maximum aggregate size greater than 32 [$$mm$$]?
+            Is the nominal maximum aggregate size greater than 32 [$mm$]?
         """
         super().__init__()
         self.diameter = diameter

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/table_4_4n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/table_4_4n.py
@@ -10,7 +10,7 @@ from blueprints.type_alias import MM
 
 class Table4Dot4nMinimumCoverDurabilityReinforcementSteel(Formula):
     r"""Class representing the table 4.4N
-    for the calculation of the minimum cover [$$c_{min,dur}$$] [$$mm$$] requirements with regard to durability
+    for the calculation of the minimum cover [$c_{min,dur}$] [$mm$] requirements with regard to durability
     for reinforcement steel.
     """
 
@@ -22,16 +22,16 @@ class Table4Dot4nMinimumCoverDurabilityReinforcementSteel(Formula):
         exposure_classes: ExposureClassesBase,
         structural_class: ConcreteStructuralClassBase,
     ) -> None:
-        r"""[$$c_{min,dur}$$] Calculates the minimum concrete cover with regard to durability [$$mm$$] for reinforcement steel.
+        r"""[$c_{min,dur}$] Calculates the minimum concrete cover with regard to durability [$mm$] for reinforcement steel.
 
         NEN-EN 1992-1-1+C2:2011 art.4.4.1.2 (5) - Table (4.4N)
 
         Parameters
         ----------
         exposure_classes: ExposureClassesBase
-            The exposure classes of the concrete. Use the [$$Table4Dot1ExposureClasses$$] class. [$$-$$]
+            The exposure classes of the concrete. Use the [$Table4Dot1ExposureClasses$] class. [$-$]
         structural_class: ConcreteStructuralClassBase
-            The structural class of the concrete. Use the [$$Table4Dot3ConcreteStructuralClass$$] class. [$$-$$]
+            The structural class of the concrete. Use the [$Table4Dot3ConcreteStructuralClass$] class. [$-$]
         """
         super().__init__()
         self.exposure_classes = exposure_classes

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/table_4_5n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_4_durability_and_cover/table_4_5n.py
@@ -10,7 +10,7 @@ from blueprints.type_alias import MM
 
 class Table4Dot5nMinimumCoverDurabilityPrestressingSteel(Formula):
     r"""Class representing the table 4.5N
-    for the calculation of the minimum cover [$$c_{min,dur}$$] [$$mm$$] requirements with regard to durability
+    for the calculation of the minimum cover [$c_{min,dur}$] [$mm$] requirements with regard to durability
     for prestressing steel.
     """
 
@@ -22,16 +22,16 @@ class Table4Dot5nMinimumCoverDurabilityPrestressingSteel(Formula):
         exposure_classes: ExposureClassesBase,
         structural_class: ConcreteStructuralClassBase,
     ) -> None:
-        r"""[$$c_{min,dur}$$] Calculates the minimum concrete cover with regard to durability [$$mm$$] for prestressing steel.
+        r"""[$c_{min,dur}$] Calculates the minimum concrete cover with regard to durability [$mm$] for prestressing steel.
 
         NEN-EN 1992-1-1+C2:2011 art.4.4.1.2 (5) - Table (4.5N)
 
         Parameters
         ----------
         exposure_classes: ExposureClassesBase
-            The exposure classes of the concrete. Use the [$$Table4Dot1ExposureClasses$$] class. [$$-$$]
+            The exposure classes of the concrete. Use the [$Table4Dot1ExposureClasses$] class. [$-$]
         structural_class: ConcreteStructuralClassBase
-            The structural class of the concrete. Use the [$$Table4Dot3ConcreteStructuralClass$$] class. [$$-$$]
+            The structural class of the concrete. Use the [$Table4Dot3ConcreteStructuralClass$] class. [$-$]
         """
         super().__init__()
         self.exposure_classes = exposure_classes

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_1.py
@@ -10,7 +10,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form5Dot1Imperfections(Formula):
-    r"""Class representing formula 5.1 for the calculation of initial inclination imperfections, [$$\Theta_i$$]."""
+    r"""Class representing formula 5.1 for the calculation of initial inclination imperfections, [$\Theta_i$]."""
 
     label = "5.1"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -21,21 +21,21 @@ class Form5Dot1Imperfections(Formula):
         alpha_h: DIMENSIONLESS,
         alpha_m: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\\Theta_i$$] Initial inclination imperfections, [$$\\Theta_i$$], is a ratio between height and inclination of the member [-].
+        r"""[$\\Theta_i$] Initial inclination imperfections, [$\\Theta_i$], is a ratio between height and inclination of the member [-].
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(5) - Formula (5.1)
 
         Parameters
         ----------
         theta_0 : float
-            [$$\\Theta_0$$] Basic value [-].
-            Note: The value of [$$\\Theta_0$$] for use in a Country may be found in its National Annex.
+            [$\\Theta_0$] Basic value [-].
+            Note: The value of [$\\Theta_0$] for use in a Country may be found in its National Annex.
             The recommended value is 1/200
         alpha_h : float
-            [$$\alpha_h$$] Reduction factor for length or height [-].
+            [$\alpha_h$] Reduction factor for length or height [-].
             Use your own implementation of this value or use the SubForm5Dot1ReductionFactorLengthOrHeight class.
         alpha_m : float
-            [$$\alpha_m$$] Reduction factor for number of members [-].
+            [$\alpha_m$] Reduction factor for number of members [-].
             Use your own implementation of this value or use the SubForm5Dot1ReductionFactorNumberOfMembers class.
         """
         super().__init__()
@@ -65,7 +65,7 @@ class Form5Dot1Imperfections(Formula):
 
 
 class SubForm5Dot1ReductionFactorLengthOrHeight(Formula):
-    r"""Class representing sub-formula 5.1 for the calculation of the reduction factor for length or height, [$$\alpha_h$$]."""
+    r"""Class representing sub-formula 5.1 for the calculation of the reduction factor for length or height, [$\alpha_h$]."""
 
     label = "5.1"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -74,16 +74,16 @@ class SubForm5Dot1ReductionFactorLengthOrHeight(Formula):
         self,
         length: M,
     ) -> None:
-        r"""[$$\alpha_h$$] Reduction factor for length or height [-].
+        r"""[$\alpha_h$] Reduction factor for length or height [-].
 
-        The calculated value of [$$\alpha_h$$] is between 2/3 and 1.0.
+        The calculated value of [$\alpha_h$] is between 2/3 and 1.0.
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(5) - Formula (5.1)
 
         Parameters
         ----------
         length : M
-            [$$\text{length}$$] Length or height, see art.5.2(6) [$$m$$].
+            [$\text{length}$] Length or height, see art.5.2(6) [$m$].
         """
         super().__init__()
         self.length = length
@@ -114,7 +114,7 @@ class SubForm5Dot1ReductionFactorLengthOrHeight(Formula):
 
 
 class SubForm5Dot1ReductionFactorNumberOfMembers(Formula):
-    r"""Class representing sub-formula 5.1 for the calculation of the reduction factor for number of members, [$$\alpha_m$$]."""
+    r"""Class representing sub-formula 5.1 for the calculation of the reduction factor for number of members, [$\alpha_m$]."""
 
     label = "5.1"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -123,14 +123,14 @@ class SubForm5Dot1ReductionFactorNumberOfMembers(Formula):
         self,
         members: int,
     ) -> None:
-        r"""[$$\alpha_m$$] Reduction factor for number of members [-].
+        r"""[$\alpha_m$] Reduction factor for number of members [-].
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(5) - Formula (5.1)
 
         Parameters
         ----------
         members : int
-            [$$m$$] Number of vertical members contributing to the total effect [-].
+            [$m$] Number of vertical members contributing to the total effect [-].
         """
         super().__init__()
         self.members = members

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_10a.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_10a.py
@@ -7,28 +7,28 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form5Dot10aRedistributionOfMomentsLowerFck:
-    r"""Class representing formula 5.10a for the redistribution of moments in continuous beams or slabs when [$$f_{ck} \leq 50 MPa$$]."""
+    r"""Class representing formula 5.10a for the redistribution of moments in continuous beams or slabs when [$f_{ck} \leq 50 MPa$]."""
 
     label = "5.10a"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, delta: DIMENSIONLESS, k1: DIMENSIONLESS, k2: DIMENSIONLESS, xu: M, d: M) -> None:
-        r"""[$$\delta$$] Redistribution of moments in continuous beams or slabs when [$$f_{ck} \leq 50 MPa$$].
+        r"""[$\delta$] Redistribution of moments in continuous beams or slabs when [$f_{ck} \leq 50 MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.5(4) - Formula (5.10a)
 
         Parameters
         ----------
         delta : DIMENSIONLESS
-            [$$\delta$$] is the ratio of the redistributed moment to the elastic moment.
+            [$\delta$] is the ratio of the redistributed moment to the elastic moment.
         k1 : DIMENSIONLESS
-            [$$k_1$$] is a coefficient for redistribution.
+            [$k_1$] is a coefficient for redistribution.
         k2 : DIMENSIONLESS
-            [$$k_2$$] is a coefficient for redistribution.
+            [$k_2$] is a coefficient for redistribution.
         xu : M
-            [$$x_u$$] is the depth of the compression zone in the ultimate limit state after redistribution.
+            [$x_u$] is the depth of the compression zone in the ultimate limit state after redistribution.
         d : M
-            [$$d$$] is the effective depth of the section.
+            [$d$] is the effective depth of the section.
         """
         super().__init__()
         self.delta = delta

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_10b.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_10b.py
@@ -7,28 +7,28 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form5Dot10bRedistributionOfMomentsUpperFck:
-    r"""Class representing formula 5.10b for the redistribution of moments in continuous beams or slabs when [$$f_{ck} > 50 MPa$$]."""
+    r"""Class representing formula 5.10b for the redistribution of moments in continuous beams or slabs when [$f_{ck} > 50 MPa$]."""
 
     label = "5.10b"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, delta: DIMENSIONLESS, k3: DIMENSIONLESS, k4: DIMENSIONLESS, xu: M, d: M) -> None:
-        r"""[$$\delta$$] Redistribution of moments in continuous beams or slabs when [$$f_{ck} > 50 MPa$$].
+        r"""[$\delta$] Redistribution of moments in continuous beams or slabs when [$f_{ck} > 50 MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.5(4) - Formula (5.10b)
 
         Parameters
         ----------
         delta : DIMENSIONLESS
-            [$$\delta$$] is the ratio of the redistributed moment to the elastic moment.
+            [$\delta$] is the ratio of the redistributed moment to the elastic moment.
         k3 : DIMENSIONLESS
-            [$$k_3$$] is a coefficient for redistribution.
+            [$k_3$] is a coefficient for redistribution.
         k4 : DIMENSIONLESS
-            [$$k_4$$] is a coefficient for redistribution.
+            [$k_4$] is a coefficient for redistribution.
         xu : M
-            [$$x_u$$] is the depth of the compression zone in the ultimate limit state after redistribution.
+            [$x_u$] is the depth of the compression zone in the ultimate limit state after redistribution.
         d : M
-            [$$d$$] is the effective depth of the section.
+            [$d$] is the effective depth of the section.
         """
         super().__init__()
         self.delta = delta

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_11n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_11n.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form5Dot11nShearSlendernessCorrectionFactor(Formula):
-    """Class representing formula 5.11N for the calculation of the shear slenderness correction factor [$$k_{λ}$$]."""
+    """Class representing formula 5.11N for the calculation of the shear slenderness correction factor [$k_{λ}$]."""
 
     label = "5.11N"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -17,15 +17,15 @@ class Form5Dot11nShearSlendernessCorrectionFactor(Formula):
         self,
         lambda_factor: DIMENSIONLESS,
     ) -> None:
-        r"""[$$k_{λ}$$] Shear slenderness correction factor.
+        r"""[$k_{λ}$] Shear slenderness correction factor.
 
         NEN-EN 1992-1-1+C2:2011 art.5.6.3(4) - Formula (5.11N)
 
         Parameters
         ----------
         lambda_factor : DIMENSIONLESS
-            [$$λ$$] ratio of the distance between point of zero and maximum moment after redistribution and
-        effective depth, d [$$-$$]
+            [$λ$] ratio of the distance between point of zero and maximum moment after redistribution and
+        effective depth, d [$-$]
 
         Use your own implementation for this value or use :class:`Form5Dot12nRatioDistancePointZeroAndMaxMoment`.
         """

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_12n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_12n.py
@@ -12,7 +12,7 @@ class Form5Dot12nRatioDistancePointZeroAndMaxMoment(Formula):
 
     Note:
     Ratio of the distance between point of zero and maximum moment after redistribution and
-    effective depth, d. [$$λ$$]
+    effective depth, d. [$λ$]
     """
 
     label = "5.12N"
@@ -24,19 +24,19 @@ class Form5Dot12nRatioDistancePointZeroAndMaxMoment(Formula):
         v_sd: KN,
         d: M,
     ) -> None:
-        r"""[$$λ$$] ratio of the distance between point of zero and maximum moment after redistribution and
-        effective depth, d [$$-$$].
+        r"""[$λ$] ratio of the distance between point of zero and maximum moment after redistribution and
+        effective depth, d [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.6.3(4) - Formula (5.12N)
 
         Parameters
         ----------
         m_sd : KNM
-            [$$M_{sd}$$] Design moment at the section [$$kNm$$].
+            [$M_{sd}$] Design moment at the section [$kNm$].
         v_sd : KN
-            [$$V_{sd}$$] Design shear force at the section [$$kN$$].
+            [$V_{sd}$] Design shear force at the section [$kN$].
         d : M
-            [$$d$$] Effective depth [$$m$$].
+            [$d$] Effective depth [$m$].
         """
         super().__init__()
         self.m_sd = m_sd

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_14.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_14.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form5Dot14SlendernessRatio(Formula):
-    r"""Class representing formula 5.14 for the calculation of the slenderness ratio, [$$\lambda$$]."""
+    r"""Class representing formula 5.14 for the calculation of the slenderness ratio, [$\lambda$]."""
 
     label = "5.14"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -18,18 +18,18 @@ class Form5Dot14SlendernessRatio(Formula):
         l_0: M,
         i: M,
     ) -> None:
-        r"""[$$\lambda$$] Slenderness ratio [$$-$$].
+        r"""[$\lambda$] Slenderness ratio [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.3.2(1) - Formula (5.14)
 
         Parameters
         ----------
         l_0 : M
-            [$$l_{0}$$] Effective length [$$m$$].
+            [$l_{0}$] Effective length [$m$].
             Use your own implementation of this value or use :class: `Form5Dot15EffectiveLengthBraced`
             or :class: `Form5Dot15EffectiveLengthUnbraced`.
         i : M
-            [$$i$$] Radius of gyration of the uncracked concrete section [$$m$$].
+            [$i$] Radius of gyration of the uncracked concrete section [$m$].
         """
         super().__init__()
         self.l_0 = l_0

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_15.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_15.py
@@ -10,24 +10,24 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot15EffectiveLengthBraced(Formula):
-    r"""Class representing formula 5.15 for the calculation of the effective length of braced members, [$$l_0$$]."""
+    r"""Class representing formula 5.15 for the calculation of the effective length of braced members, [$l_0$]."""
 
     label = "5.15"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, k_1: DIMENSIONLESS, k_2: DIMENSIONLESS, height: M) -> None:
-        r"""[$$l_{0}$$] Effective length for braced members [$$m$$].
+        r"""[$l_{0}$] Effective length for braced members [$m$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.3.2(3) - Formula (5.15)
 
         Parameters
         ----------
         k_1 : DIMENSIONLESS
-            [$$k_{1}$$] Relative flexibility of rotational constraint at end 1 [$$-$$].
+            [$k_{1}$] Relative flexibility of rotational constraint at end 1 [$-$].
         k_2 : DIMENSIONLESS
-            [$$k_{2}$$] Relative flexibility of rotational constraint at end 2 [$$-$$].
+            [$k_{2}$] Relative flexibility of rotational constraint at end 2 [$-$].
         height : M
-            [$$l$$] Clear height of compression member between end constraints [$$m$$].
+            [$l$] Clear height of compression member between end constraints [$m$].
         """
         super().__init__()
         self.k_1 = k_1

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_16.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_16.py
@@ -10,24 +10,24 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot16EffectiveLengthUnbraced(Formula):
-    """Class representing formula 5.16 for the calculation of effective length of unbraced members, [$$l_0$$]."""
+    """Class representing formula 5.16 for the calculation of effective length of unbraced members, [$l_0$]."""
 
     label = "5.16"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, k_1: DIMENSIONLESS, k_2: DIMENSIONLESS, height: M) -> None:
-        r"""[$$l_{0}$$] Effective length for unbraced members [$$m$$].
+        r"""[$l_{0}$] Effective length for unbraced members [$m$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.3.2(3) - Formula (5.16)
 
         Parameters
         ----------
         k_1 : DIMENSIONLESS
-            [$$k_{1}$$] Relative flexibility of rotational constraint at end 1 [$$-$$].
+            [$k_{1}$] Relative flexibility of rotational constraint at end 1 [$-$].
         k_2 : DIMENSIONLESS
-            [$$k_{2}$$] Relative flexibility of rotational constraint at end 2 [$$-$$].
+            [$k_{2}$] Relative flexibility of rotational constraint at end 2 [$-$].
         height : M
-            [$$l$$] Clear height of compression member between end constraint [$$m$$].
+            [$l$] Clear height of compression member between end constraint [$m$].
         """
         super().__init__()
         self.k_1 = k_1

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_17.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_17.py
@@ -11,24 +11,24 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 class Form5Dot17EffectiveLengthBucklingLoad(Formula):
     r"""Class representing formula 5.17 for the calculation of effective length of unbraced members, in the
-    case where criteria (2) and (3) do not apply such as by variable loading, [$$l_0$$].
+    case where criteria (2) and (3) do not apply such as by variable loading, [$l_0$].
     """
 
     label = "5.17"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, ei: KN_M2, n_b: KN) -> None:
-        r"""[$$l_{0}$$] Effective length for unbraced members [$$m$$].
+        r"""[$l_{0}$] Effective length for unbraced members [$m$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.3.2(6) - Formula (5.17)
 
         Parameters
         ----------
         ei : KN_M2
-            [$$EI$$] is a representative bending stiffness [$$kN/m^2$$].
+            [$EI$] is a representative bending stiffness [$kN/m^2$].
         n_b : KN
-            [$$N_{b}$$] is the buckling load expressed in terms of EI (in equation (5.14) i should correspond
-            to this EI). [$$kN$$].
+            [$N_{b}$] is the buckling load expressed in terms of EI (in equation (5.14) i should correspond
+            to this EI). [$kN$].
         """
         super().__init__()
         self.ei = ei

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_18.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_18.py
@@ -14,25 +14,25 @@ class Form5Dot18ComparisonGeneralSecondOrderEffects:
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, f_ved: KN, k_1: DIMENSIONLESS, n_s: DIMENSIONLESS, length: M, e_cd: MPA, i_c: MM4) -> None:
-        r"""[$$CHECK$$] Criteria met, based on damage accumulation.
+        r"""[$CHECK$] Criteria met, based on damage accumulation.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.3.3(1) - Formula (5.18)
 
         Parameters
         ----------
         f_ved : KN
-            [$$F_{v,ed}$$] Total vertical load (on braced and bracing members) [$$kN$$].
+            [$F_{v,ed}$] Total vertical load (on braced and bracing members) [$kN$].
         k_1 : DIMENSIONLESS
-            [$$k_1$$] The value of k1 for use in a Country may be found in its National Annex. Recommend value is
-            0.31 [$$-$$].
+            [$k_1$] The value of k1 for use in a Country may be found in its National Annex. Recommend value is
+            0.31 [$-$].
         n_s : DIMENSIONLESS
-            [$$n_s$$] is the total number of storeys [$$-$$].
+            [$n_s$] is the total number of storeys [$-$].
         length : M
-            [$$L$$] is the total height of the building above level of moment restraint. [$$m$$].
+            [$L$] is the total height of the building above level of moment restraint. [$m$].
         e_cd : MPa
-            [$$E_{cd}$$] is the design value of the modulus of elasticity of concrete. [$$MPa$$].
+            [$E_{cd}$] is the design value of the modulus of elasticity of concrete. [$MPa$].
         i_c : MM4
-            [$$I_c$$] is the second moment of area (uncracked concrete section) of bracing member(s). [$$mm^4$$].
+            [$I_c$] is the second moment of area (uncracked concrete section) of bracing member(s). [$mm^4$].
         """
         self.f_ved = f_ved
         self.k_1 = k_1

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_19.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_19.py
@@ -14,18 +14,18 @@ class Form5Dot19EffectiveCreepCoefficient(Formula):
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, phi_inf_t0: DIMENSIONLESS, m0_eqp: KNM, m0_ed: KNM) -> None:
-        r"""[$$\phi_{ef}$$] Effective creep coefficient.
+        r"""[$\phi_{ef}$] Effective creep coefficient.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.4(2) - Formula (5.19)
 
         Parameters
         ----------
         phi_inf_t0 : DIMENSIONLESS
-            [$$\phi (\infty,t_0)$$] is the final value of the creep coefficient according to art. 3.1.4.
+            [$\phi (\infty,t_0)$] is the final value of the creep coefficient according to art. 3.1.4.
         m0_eqp : KNM
-            [$$M_{0,Eqp}$$] is the first-order bending moment in the quasi-permanent load combination (SLS).
+            [$M_{0,Eqp}$] is the first-order bending moment in the quasi-permanent load combination (SLS).
         m0_ed : KNM
-            [$$M_{0,Ed}$$] is the first-order bending moment in the ultimate limit state (ULS).
+            [$M_{0,Ed}$] is the first-order bending moment in the ultimate limit state (ULS).
         """
         super().__init__()
         self.phi_inf_t0 = phi_inf_t0

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_2.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_2.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form5Dot2Eccentricity(Formula):
-    """Class representing formula 5.2 for the calculation of eccentricity, [$$e_i$$]."""
+    """Class representing formula 5.2 for the calculation of eccentricity, [$e_i$]."""
 
     label = "5.2"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -18,17 +18,17 @@ class Form5Dot2Eccentricity(Formula):
         theta_i: DIMENSIONLESS,
         l_0: M,
     ) -> None:
-        r"""[$$e_i$$] Eccentricity, [$$e_i$$], for isolated members [$$m$$].
+        r"""[$e_i$] Eccentricity, [$e_i$], for isolated members [$m$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(7) - Formula (5.2)
 
         Parameters
         ----------
         theta_i : DIMENSIONLESS
-            [$$\Theta_i$$] Eccentricity, initial inclination imperfections [-].
+            [$\Theta_i$] Eccentricity, initial inclination imperfections [-].
             Use your own implementation of this value or use the Form5Dot2Imperfections class.
         l_0 : M
-            [$$l_0$$] Effective length of the member, see 5.8.3.2 [$$m$$].
+            [$l_0$] Effective length of the member, see 5.8.3.2 [$m$].
         """
         super().__init__()
         self.theta_i = theta_i

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_20.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_20.py
@@ -8,22 +8,22 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form5Dot20DesignModulusElasticity(Formula):
-    """Class representing formula 5.20 for the calculation of the design modulus of elasticity, [$$E_{cd}$$]."""
+    """Class representing formula 5.20 for the calculation of the design modulus of elasticity, [$E_{cd}$]."""
 
     label = "5.20"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, e_cm: MPA, gamma_ce: DIMENSIONLESS = 1.2) -> None:
-        r"""[$$E_{cd}$$] Design modulus of elasticity.
+        r"""[$E_{cd}$] Design modulus of elasticity.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.6(3) - Formula (5.20)
 
         Parameters
         ----------
         e_cm : MPA
-            [$$E_{cm}$$] is the characteristic modulus of elasticity of concrete.
+            [$E_{cm}$] is the characteristic modulus of elasticity of concrete.
         gamma_ce : DIMENSIONLESS, optional
-            [$$\gamma_{cE}$$] is the factor for the design value of the modulus of elasticity. Default is 1.2 which is the recommended value.
+            [$\gamma_{cE}$] is the factor for the design value of the modulus of elasticity. Default is 1.2 which is the recommended value.
         """
         super().__init__()
         self.e_cm = e_cm

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_21.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_21.py
@@ -9,31 +9,31 @@ from blueprints.validations import raise_if_negative
 
 class Form5Dot21NominalStiffness(Formula):
     r"""Class representing formula 5.21 for the calculation of the nominal stiffness of slender compression members
-    with arbitrary cross-section, [$$EI$$] [$$Nmm^2$$].
+    with arbitrary cross-section, [$EI$] [$Nmm^2$].
     """
 
     label = "5.21"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, k_c: DIMENSIONLESS, e_cd: MPA, i_c: MM4, k_s: DIMENSIONLESS, e_s: MPA, i_s: MM4) -> None:
-        r"""[$$EI$$] Nominal stiffness of slender compression members with arbitrary cross-section.
+        r"""[$EI$] Nominal stiffness of slender compression members with arbitrary cross-section.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.7.2(2) or (3) - Formula (5.21)
 
         Parameters
         ----------
         k_c : DIMENSIONLESS
-            [$$K_{c}$$] is a factor for effects of cracking, creep etc. see 5.8.7.2 (2) or (3).
+            [$K_{c}$] is a factor for effects of cracking, creep etc. see 5.8.7.2 (2) or (3).
         e_cd : MPA
-            [$$E_{cd}$$] is the design value of the modulus of elasticity of concrete, see 5.8.6 (3)
+            [$E_{cd}$] is the design value of the modulus of elasticity of concrete, see 5.8.6 (3)
         i_c : MPA
-            [$$I_{c}$$] is the moment of inertia of concrete cross section.
+            [$I_{c}$] is the moment of inertia of concrete cross section.
         k_s : DIMENSIONLESS
-            [$$K_{s}$$] is a factor for contribution of reinforcement, see 5.8.7.2 (2) or (3).
+            [$K_{s}$] is a factor for contribution of reinforcement, see 5.8.7.2 (2) or (3).
         e_s : MPA
-            [$$E_{s}$$] is the design value of the modulus of elasticity of reinforcement, 5.8.6 (3).
+            [$E_{s}$] is the design value of the modulus of elasticity of reinforcement, 5.8.6 (3).
         i_s : MPA
-            [$$I_{s}$$] is the second moment of area of reinforcement, about the centre of area of the concrete.
+            [$I_{s}$] is the second moment of area of reinforcement, about the centre of area of the concrete.
         """
         super().__init__()
         self.k_c = k_c

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_22.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_22.py
@@ -14,14 +14,14 @@ class Form5Dot22FactorKs(Formula):
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, rho: DIMENSIONLESS) -> None:
-        r"""[$$K_s$$] Factor K_s = 1.
+        r"""[$K_s$] Factor K_s = 1.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.7.2(2) - Formula (5.22)
 
         Parameters
         ----------
         rho : DIMENSIONLESS
-            [$$\rho$$] Geometric reinforcement ratio, As/Ac. Must be >= 0.002.
+            [$\rho$] Geometric reinforcement ratio, As/Ac. Must be >= 0.002.
         """
         super().__init__()
         self.rho = rho
@@ -51,20 +51,20 @@ class Form5Dot22FactorKc(Formula):
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, k1: DIMENSIONLESS, k2: DIMENSIONLESS, phi_ef: DIMENSIONLESS, rho: float) -> None:
-        r"""[$$K_c$$] Factor K_c = k_1 * k_2 / (1 + \phi_{ef}).
+        r"""[$K_c$] Factor K_c = k_1 * k_2 / (1 + \phi_{ef}).
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.7.2(2) - Formula (5.22)
 
         Parameters
         ----------
         k1 : DIMENSIONLESS
-            [$$k_1$$] Factor which depends on concrete strength class, Expression (5.23).
+            [$k_1$] Factor which depends on concrete strength class, Expression (5.23).
         k2 : DIMENSIONLESS
-            [$$k_2$$] Factor which depends on axial force and slenderness, Expression (5.24).
+            [$k_2$] Factor which depends on axial force and slenderness, Expression (5.24).
         phi_ef : DIMENSIONLESS
-            [$$\phi_{ef}$$] Effective creep ratio, see 5.8.4.
+            [$\phi_{ef}$] Effective creep ratio, see 5.8.4.
         rho : DIMENSIONLESS
-            [$$\rho$$] Geometric reinforcement ratio, As/Ac. Must be >= 0.002.
+            [$\rho$] Geometric reinforcement ratio, As/Ac. Must be >= 0.002.
         """
         super().__init__()
         self.k1 = k1

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_23.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_23.py
@@ -8,20 +8,20 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot23FactorConcreteStrengthClass(Formula):
-    """Class representing formula 5.23 for the calculation of the factor for concrete strength class, [$$k_{1}$$]."""
+    """Class representing formula 5.23 for the calculation of the factor for concrete strength class, [$k_{1}$]."""
 
     label = "5.23"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, f_ck: MPA) -> None:
-        r"""[$$k_{1}$$] Factor for concrete strength class.
+        r"""[$k_{1}$] Factor for concrete strength class.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.6(3) - Formula (5.23)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] is the characteristic compressive strength of concrete.
+            [$f_{ck}$] is the characteristic compressive strength of concrete.
         """
         super().__init__()
         self.f_ck = f_ck

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_24.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_24.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot24AxialForceCorrectionFactor(Formula):
-    """Class representing formula 5.24 for the calculation of the axial force correction factor [$$k_{2}$$]."""
+    """Class representing formula 5.24 for the calculation of the axial force correction factor [$k_{2}$]."""
 
     label = "5.24"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -18,20 +18,20 @@ class Form5Dot24AxialForceCorrectionFactor(Formula):
         n: DIMENSIONLESS,
         lambda_factor: DIMENSIONLESS,
     ) -> None:
-        r"""[$$k_{2}$$] Axial force correction factor.
+        r"""[$k_{2}$] Axial force correction factor.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.3 - Formula (5.24)
 
         Parameters
         ----------
         n : DIMENSIONLESS
-            [$$n$$] Relative axial force, [$$N_{ed} / (A_{c} * f_{cd})$$] [-].
+            [$n$] Relative axial force, [$N_{ed} / (A_{c} * f_{cd})$] [-].
         lambda_factor : DIMENSIONLESS
-            [$$λ$$] Slenderness ratio, see 5.8.3 [-].
+            [$λ$] Slenderness ratio, see 5.8.3 [-].
 
         Notes
         -----
-        The value of [$$k_{2}$$] cannot be larger than 0.20.
+        The value of [$k_{2}$] cannot be larger than 0.20.
         """
         super().__init__()
         self.n = n

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_25.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_25.py
@@ -8,20 +8,20 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot25AxialForceCorrectionFactor(Formula):
-    """Class representing formula 5.25 for the calculation of the axial force correction factor [$$k_{2}$$]."""
+    """Class representing formula 5.25 for the calculation of the axial force correction factor [$k_{2}$]."""
 
     label = "5.25"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, n: DIMENSIONLESS) -> None:
-        r"""[$$k_{2}$$] Axial force correction factor.
+        r"""[$k_{2}$] Axial force correction factor.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.6(3) - Formula (5.25)
 
         Parameters
         ----------
         n : DIMENSIONLESS
-            [$$n$$] Relative axial force, [$$N_{ed} / (A_{c} * f_{cd})$$] [-].
+            [$n$] Relative axial force, [$N_{ed} / (A_{c} * f_{cd})$] [-].
         """
         super().__init__()
         self.n = n

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_26.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_26.py
@@ -14,14 +14,14 @@ class Form5Dot26FactorKs(Formula):
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, rho: float) -> None:
-        r"""[$$K_s$$] Factor $$K_s = 0$$.
+        r"""[$K_s$] Factor $K_s = 0$.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.7.2(2) - Formula (5.26)
 
         Parameters
         ----------
         rho : float
-            [$$\rho$$] Geometric reinforcement ratio, As/Ac. Must be >= 0.01.
+            [$\rho$] Geometric reinforcement ratio, As/Ac. Must be >= 0.01.
         """
         super().__init__()
         self.rho = rho
@@ -51,16 +51,16 @@ class Form5Dot26FactorKc(Formula):
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, phi_ef: DIMENSIONLESS, rho: float) -> None:
-        r"""[$$K_c$$] Factor $$K_c = \frac{0.3}{1 + 0.5 \cdot \phi_{ef}}$$.
+        r"""[$K_c$] Factor $K_c = \frac{0.3}{1 + 0.5 \cdot \phi_{ef}}$.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.7.2(2) - Formula (5.26)
 
         Parameters
         ----------
         phi_ef : DIMENSIONLESS
-            [$$\phi_{ef}$$] Effective creep ratio, see 5.8.4.
+            [$\phi_{ef}$] Effective creep ratio, see 5.8.4.
         rho : float
-            [$$\rho$$] Geometric reinforcement ratio, As/Ac. Must be > 0.01.
+            [$\rho$] Geometric reinforcement ratio, As/Ac. Must be > 0.01.
         """
         super().__init__()
         self.phi_ef = phi_ef

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_27.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_27.py
@@ -8,22 +8,22 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot27EffectiveDesignModulusElasticity(Formula):
-    """Class representing formula 5.27 for the calculation of the effective design modulus of elasticity, [$$E_{cd,eff}$$]."""
+    """Class representing formula 5.27 for the calculation of the effective design modulus of elasticity, [$E_{cd,eff}$]."""
 
     label = "5.27"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, e_cd: MPA, phi_ef: DIMENSIONLESS) -> None:
-        r"""[$$E_{cd,eff}$$] Effective design modulus of elasticity.
+        r"""[$E_{cd,eff}$] Effective design modulus of elasticity.
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.6(3) - Formula (5.27)
 
         Parameters
         ----------
         e_cd : MPA
-            [$$E_{cd}$$] is the design modulus of elasticity of concrete according to 5.8.6 (3).
+            [$E_{cd}$] is the design modulus of elasticity of concrete according to 5.8.6 (3).
         phi_ef : DIMENSIONLESS
-            [$$\phi_{ef}$$] is the effective creep coefficient; same value as for columns may be used.
+            [$\phi_{ef}$] is the effective creep coefficient; same value as for columns may be used.
         """
         super().__init__()
         self.e_cd = e_cd

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_28.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_28.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form5Dot28TotalDesignMoment(Formula):
-    """Class representing formula 5.28 for the calculation of the total design moment, [$$M_{Ed}$$]."""
+    """Class representing formula 5.28 for the calculation of the total design moment, [$M_{Ed}$]."""
 
     label = "5.28"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -20,20 +20,20 @@ class Form5Dot28TotalDesignMoment(Formula):
         n_ed: KN,
         n_b: KN,
     ) -> None:
-        r"""[$$M_{Ed}$$] Total design moment [$$kNm$$].
+        r"""[$M_{Ed}$] Total design moment [$kNm$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(2) - Formula (5.28)
 
         Parameters
         ----------
         m_0ed : KNM
-            [$$M_{0Ed}$$] First order moment; see also 5.8.8.2 (2) [$$kNm$$].
+            [$M_{0Ed}$] First order moment; see also 5.8.8.2 (2) [$kNm$].
         beta : float
-            [$$\beta$$] Factor which depends on distribution of 1st and 2nd order moments, see 5.8.7.3 (2)-(3) [-].
+            [$\beta$] Factor which depends on distribution of 1st and 2nd order moments, see 5.8.7.3 (2)-(3) [-].
         n_ed : KN
-            [$$N_{Ed}$$] Design value of axial load [$$kN$$].
+            [$N_{Ed}$] Design value of axial load [$kN$].
         n_b : KN
-            [$$N_{B}$$] Buckling load based on nominal stiffness [$$kN$$].
+            [$N_{B}$] Buckling load based on nominal stiffness [$kN$].
         """
         super().__init__()
         self.m_0ed = m_0ed

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_29.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_29.py
@@ -10,7 +10,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form5Dot29BetaFactor(Formula):
-    r"""Class representing formula 5.29 for the calculation of the beta factor, [$$\beta$$]."""
+    r"""Class representing formula 5.29 for the calculation of the beta factor, [$\beta$]."""
 
     label = "5.29"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -19,7 +19,7 @@ class Form5Dot29BetaFactor(Formula):
         self,
         c_0: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\beta$$] Factor which depends on the distribution of first order moment [-].
+        r"""[$\beta$] Factor which depends on the distribution of first order moment [-].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(3) - Formula (5.29)
 

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_30.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_30.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form5Dot30TotalDesignMoment(Formula):
-    """Class representing formula 5.30 for the calculation of the total design moment, [$$M_{Ed}$$]."""
+    """Class representing formula 5.30 for the calculation of the total design moment, [$M_{Ed}$]."""
 
     label = "5.30"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -19,18 +19,18 @@ class Form5Dot30TotalDesignMoment(Formula):
         n_ed: KN,
         n_b: KN,
     ) -> None:
-        r"""[$$M_{Ed}$$] Total design moment [$$kNm$$].
+        r"""[$M_{Ed}$] Total design moment [$kNm$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(2) - Formula (5.30)
 
         Parameters
         ----------
         m_0ed : KNM
-            [$$M_{0Ed}$$] First order moment; see also 5.8.8.2 (2) [$$kNm$$].
+            [$M_{0Ed}$] First order moment; see also 5.8.8.2 (2) [$kNm$].
         n_ed : KN
-            [$$N_{Ed}$$] Design value of axial load [$$kN$$].
+            [$N_{Ed}$] Design value of axial load [$kN$].
         n_b : KN
-            [$$N_{B}$$] Buckling load based on nominal stiffness [$$kN$$].
+            [$N_{B}$] Buckling load based on nominal stiffness [$kN$].
         """
         super().__init__()
         self.m_0ed = m_0ed

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_31.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_31.py
@@ -7,7 +7,7 @@ from blueprints.type_alias import KNM
 
 
 class Form5Dot31DesignMoment(Formula):
-    """Class representing formula 5.31 for the calculation of the design moment, [$$M_{Ed}$$]."""
+    """Class representing formula 5.31 for the calculation of the design moment, [$M_{Ed}$]."""
 
     label = "5.31"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -17,16 +17,16 @@ class Form5Dot31DesignMoment(Formula):
         m_0ed: KNM,
         m_2: KNM,
     ) -> None:
-        r"""[$$M_{Ed}$$] Design moment [$$kNm$$].
+        r"""[$M_{Ed}$] Design moment [$kNm$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(2) - Formula (5.31)
 
         Parameters
         ----------
         m_0ed : KNM
-            [$$M_{0Ed}$$] First order moment, including the effect of imperfections; see also 5.8.8.2 (2) [$$kNm$$].
+            [$M_{0Ed}$] First order moment, including the effect of imperfections; see also 5.8.8.2 (2) [$kNm$].
         m_2 : KNM
-            [$$M_{2}$$] Nominal 2nd order moment; see 5.8.8.2 (3) [$$kNm$$].
+            [$M_{2}$] Nominal 2nd order moment; see 5.8.8.2 (3) [$kNm$].
         """
         super().__init__()
         self.m_0ed = m_0ed

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_32.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_32.py
@@ -7,7 +7,7 @@ from blueprints.type_alias import KNM
 
 
 class Form5Dot32EquivalentFirstOrderEndMoment(Formula):
-    """Class representing formula 5.32 for the calculation of the equivalent first order end moment, [$$M_{0e}$$]."""
+    """Class representing formula 5.32 for the calculation of the equivalent first order end moment, [$M_{0e}$]."""
 
     label = "5.32"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -17,16 +17,16 @@ class Form5Dot32EquivalentFirstOrderEndMoment(Formula):
         m_01: KNM,
         m_02: KNM,
     ) -> None:
-        r"""[$$M_{0e}$$] Equivalent first order end moment [$$kNm$$].
+        r"""[$M_{0e}$] Equivalent first order end moment [$kNm$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.2(2) - Formula (5.32)
 
         Parameters
         ----------
         m_01 : KNM
-            [$$M_{01}$$] The smaller first order end moment [$$kNm$$].
+            [$M_{01}$] The smaller first order end moment [$kNm$].
         m_02 : KNM
-            [$$M_{02}$$] The larger first order end moment [$$kNm$$].
+            [$M_{02}$] The larger first order end moment [$kNm$].
         """
         super().__init__()
         self.m_01 = m_01

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_33.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_33.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form5Dot33NominalSecondOrderMoment(Formula):
-    """Class representing formula 5.33 for the calculation of the nominal 2nd order moment, [$$M_{2}$$]."""
+    """Class representing formula 5.33 for the calculation of the nominal 2nd order moment, [$M_{2}$]."""
 
     label = "5.33"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -20,20 +20,20 @@ class Form5Dot33NominalSecondOrderMoment(Formula):
         l_o: M,
         c: DIMENSIONLESS,
     ) -> None:
-        r"""[$$M_{2}$$] Nominal 2nd order moment [$$kNm$$].
+        r"""[$M_{2}$] Nominal 2nd order moment [$kNm$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.2 - Formula (5.33)
 
         Parameters
         ----------
         n_ed : KN
-            [$$N_{Ed}$$] Design value of axial force [$$kN$$].
+            [$N_{Ed}$] Design value of axial force [$kN$].
         curvature : DIMENSIONLESS
-            [$$\frac{1}{r}$$] Curvature (1/r), see 5.8.8.3 [$$1/m$$].
+            [$\frac{1}{r}$] Curvature (1/r), see 5.8.8.3 [$1/m$].
         l_o : M
-            [$$l_{o}$$] Effective length, see 5.8.3.2 [$$m$$].
+            [$l_{o}$] Effective length, see 5.8.3.2 [$m$].
         c : DIMENSIONLESS
-            [$$c$$] Factor depending on the curvature distribution, see 5.8.8.2 (4). [-].
+            [$c$] Factor depending on the curvature distribution, see 5.8.8.2 (4). [-].
         """
         super().__init__()
         self.n_ed = n_ed

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_34.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_34.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form5Dot34Curvature(Formula):
-    r"""Class representing formula 5.34 for the calculation of the curvature, [$$\frac{1}{r}$$]."""
+    r"""Class representing formula 5.34 for the calculation of the curvature, [$\frac{1}{r}$]."""
 
     label = "5.34"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -21,22 +21,22 @@ class Form5Dot34Curvature(Formula):
         e_s: MPA,
         d: MM,
     ) -> None:
-        r"""[$$\frac{1}{r}$$] Curvature [$$1/mm$$].
+        r"""[$\frac{1}{r}$] Curvature [$1/mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.3 - Formula (5.34)
 
         Parameters
         ----------
         k_r : DIMENSIONLESS
-            [$$K_r$$] Correction factor depending on axial load, see 5.8.8.3 (3) [-].
+            [$K_r$] Correction factor depending on axial load, see 5.8.8.3 (3) [-].
         k_phi : DIMENSIONLESS
-            [$$K_\phi$$] Factor for taking account of creep, see 5.8.8.3 (4) [-].
+            [$K_\phi$] Factor for taking account of creep, see 5.8.8.3 (4) [-].
         f_yd : MPA
-            [$$f_{yd}$$] Design yield strength of reinforcement [$$MPa$$].
+            [$f_{yd}$] Design yield strength of reinforcement [$MPa$].
         e_s : MPA
-            [$$E_s$$] Modulus of elasticity of reinforcement [$$MPa$$].
+            [$E_s$] Modulus of elasticity of reinforcement [$MPa$].
         d : MM
-            [$$d$$] Effective depth; see also 5.8.8.3 (2) [$$mm$$].
+            [$d$] Effective depth; see also 5.8.8.3 (2) [$mm$].
         """
         super().__init__()
         self.k_r = k_r

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_35.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_35.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form5Dot35EffectiveDepth(Formula):
-    r"""Class representing formula 5.35 for the calculation of the effective depth, [$$d$$]."""
+    r"""Class representing formula 5.35 for the calculation of the effective depth, [$d$]."""
 
     label = "5.35"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -18,16 +18,16 @@ class Form5Dot35EffectiveDepth(Formula):
         h: MM,
         i_s: MM,
     ) -> None:
-        r"""[$$d$$] Effective depth [$$mm$$].
+        r"""[$d$] Effective depth [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.3 - Formula (5.35)
 
         Parameters
         ----------
         h : MM
-            [$$h$$] Total height of the section [$$mm$$].
+            [$h$] Total height of the section [$mm$].
         i_s : MM
-            [$$i_s$$] Radius of gyration of the total reinforcement area [$$mm$$].
+            [$i_s$] Radius of gyration of the total reinforcement area [$mm$].
         """
         super().__init__()
         self.h = h

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_36.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_36.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form5Dot36RelativeAxialForce(Formula):
-    r"""Class representing formula 5.36 for the calculation of the relative axial force, [$$K_{r}$$]."""
+    r"""Class representing formula 5.36 for the calculation of the relative axial force, [$K_{r}$]."""
 
     label = "5.36"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -22,24 +22,24 @@ class Form5Dot36RelativeAxialForce(Formula):
         fyd: MPA,
         n_bal: DIMENSIONLESS,
     ) -> None:
-        r"""[$$K_{r}$$] Relative axial force [-].
+        r"""[$K_{r}$] Relative axial force [-].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.3(3) - Formula (5.36)
 
         Parameters
         ----------
         n_ed : KN
-            [$$N_{Ed}$$] Design value of axial load [$$kN$$].
+            [$N_{Ed}$] Design value of axial load [$kN$].
         ac : MM2
-            [$$A_{c}$$] Area of concrete cross section [$$mm^2$$].
+            [$A_{c}$] Area of concrete cross section [$mm^2$].
         fcd : MPA
-            [$$f_{cd}$$] Design value of concrete compressive strength [$$MPa$$].
+            [$f_{cd}$] Design value of concrete compressive strength [$MPa$].
         as_ : MM2
-            [$$A_{s}$$] Total area of reinforcement [$$mm^2$$].
+            [$A_{s}$] Total area of reinforcement [$mm^2$].
         fyd : MPA
-            [$$f_{yd}$$] Design yield strength of reinforcement [$$MPa$$].
+            [$f_{yd}$] Design yield strength of reinforcement [$MPa$].
         n_bal : DIMENSIONLESS
-            [$$n_{bal}$$] Value of n at maximum moment resistance, 0.4 may be used [-].
+            [$n_{bal}$] Value of n at maximum moment resistance, 0.4 may be used [-].
         """
         super().__init__()
         self.n_ed = n_ed

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_37.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_37.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot37CreepFactor(Formula):
-    r"""Class representing formula 5.37 for the calculation of the creep factor, [$$K_{\phi}$$]."""
+    r"""Class representing formula 5.37 for the calculation of the creep factor, [$K_{\phi}$]."""
 
     label = "5.37"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -19,18 +19,18 @@ class Form5Dot37CreepFactor(Formula):
         lambda_: DIMENSIONLESS,
         phi_ef: DIMENSIONLESS,
     ) -> None:
-        r"""[$$K_{\phi}$$] Creep factor [$$-$$].
+        r"""[$K_{\phi}$] Creep factor [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.8.8.3(4) - Formula (5.37)
 
         Parameters
         ----------
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic compressive strength of concrete [$$MPa$$].
+            [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
         lambda_ : DIMENSIONLESS
-            [$$\lambda$$] Slenderness ratio, see 5.8.3.1 [-].
+            [$\lambda$] Slenderness ratio, see 5.8.3.1 [-].
         phi_ef : DIMENSIONLESS
-            [$$\phi_{ef}$$] Effective creep ratio, see 5.8.4 [-].
+            [$\phi_{ef}$] Effective creep ratio, see 5.8.4 [-].
         """
         super().__init__()
         self.f_ck = f_ck

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_38a.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_38a.py
@@ -25,9 +25,9 @@ class Form5Dot38aCheckRelativeSlendernessRatio(Formula):
         Parameters
         ----------
         lambda_y : DIMENSIONLESS
-            [$$\lambda_{y}$$] Slenderness ratio in y-direction [-].
+            [$\lambda_{y}$] Slenderness ratio in y-direction [-].
         lambda_z : DIMENSIONLESS
-            [$$\lambda_{z}$$] Slenderness ratio in z-direction [-].
+            [$\lambda_{z}$] Slenderness ratio in z-direction [-].
         """
         super().__init__()
         self.lambda_y = lambda_y

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_38b.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_38b.py
@@ -27,13 +27,13 @@ class Form5Dot38bCheckRelativeEccentricityRatio(Formula):
         Parameters
         ----------
         e_y : MM
-            [$$e_{y}$$] Eccentricity along y-axis [$$mm$$].
+            [$e_{y}$] Eccentricity along y-axis [$mm$].
         e_z : MM
-            [$$e_{z}$$] Eccentricity along z-axis [$$mm$$].
+            [$e_{z}$] Eccentricity along z-axis [$mm$].
         b_eq : MM
-            [$$b_{eq}$$] Equivalent width [$$mm$$].
+            [$b_{eq}$] Equivalent width [$mm$].
         h_eq : MM
-            [$$h_{eq}$$] Equivalent depth [$$mm$$].
+            [$h_{eq}$] Equivalent depth [$mm$].
         """
         super().__init__()
         self.e_y = e_y

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_39.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_39.py
@@ -28,15 +28,15 @@ class Form5Dot39SimplifiedCriterionBiaxialBending(Formula):
         Parameters
         ----------
         m_edz : KNM
-            [$$M_{Edz}$$] Design moment including second order moment in z-direction [$$kNm$$].
+            [$M_{Edz}$] Design moment including second order moment in z-direction [$kNm$].
         m_rdz : KNM
-            [$$M_{Rdz}$$] Design moment resistance in z-direction [$$kNm$$].
+            [$M_{Rdz}$] Design moment resistance in z-direction [$kNm$].
         m_edy : KNM
-            [$$M_{Edy}$$] Design moment including second order moment in y-direction [$$kNm$$].
+            [$M_{Edy}$] Design moment including second order moment in y-direction [$kNm$].
         m_rdy : KNM
-            [$$M_{Rdy}$$] Design moment resistance in y-direction [$$kNm$$].
+            [$M_{Rdy}$] Design moment resistance in y-direction [$kNm$].
         a : DIMENSIONLESS
-            [$$a$$] Exponent for the interaction formula, for circular and elliptical cross sections: a = 2, for rectangular see table [-].
+            [$a$] Exponent for the interaction formula, for circular and elliptical cross sections: a = 2, for rectangular see table [-].
         """
         super().__init__()
         self.m_edz = m_edz

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_3a.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_3a.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot3aTransverseForceUnbracedMembers(Formula):
-    """Class representing formula 5.3a for the calculation of the transverse force for unbraced members, [$$H_{i}$$].
+    """Class representing formula 5.3a for the calculation of the transverse force for unbraced members, [$H_{i}$].
 
     See Figure 5.1 a1.
     """
@@ -21,25 +21,25 @@ class Form5Dot3aTransverseForceUnbracedMembers(Formula):
         theta_i: DIMENSIONLESS,
         n_axial_force: KN,
     ) -> None:
-        r"""[$$H_{i}$$] Transverse force for unbraced members [$$kN$$].
+        r"""[$H_{i}$] Transverse force for unbraced members [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(7) - Formula (5.3a)
 
         Parameters
         ----------
         theta_i : DIMENSIONLESS
-            [$$\Theta_{i}$$] Eccentricity, initial inclination imperfections [-].
+            [$\Theta_{i}$] Eccentricity, initial inclination imperfections [-].
 
             Use your own implementation of this value or use the :class:`Form5Dot1Imperfections` class.
         n_axial_force : KN
-            [$$N$$] Axial force [$$kN$$].
+            [$N$] Axial force [$kN$].
 
             Positive values for compression, tension is not allowed.
 
         Notes
         -----
         Eccentricity is suitable for statically determinate members, whereas transverse load can be used for
-        both determinate and indeterminate members. The force [$$H_{i}$$] may be substituted by some other equivalent
+        both determinate and indeterminate members. The force [$H_{i}$] may be substituted by some other equivalent
         transverse action.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_3b.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_3b.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot3bTransverseForceBracedMembers(Formula):
-    """Class representing formula 5.3b for the calculation of the transverse force for braced members, [$$H_{i}$$].
+    """Class representing formula 5.3b for the calculation of the transverse force for braced members, [$H_{i}$].
 
     See Figure 5.1 a2.
     """
@@ -21,25 +21,25 @@ class Form5Dot3bTransverseForceBracedMembers(Formula):
         theta_i: DIMENSIONLESS,
         n_axial_force: KN,
     ) -> None:
-        r"""[$$H_{i}$$] Transverse force for braced members [$$kN$$].
+        r"""[$H_{i}$] Transverse force for braced members [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(7) - Formula (5.3b)
 
         Parameters
         ----------
         theta_i : DIMENSIONLESS
-            [$$Θ_{i}$$] Eccentricity, initial inclination imperfections [-].
+            [$Θ_{i}$] Eccentricity, initial inclination imperfections [-].
 
             Use your own implementation of this value or use the :class:`Form5Dot1Imperfections` class.
         n_axial_force : KN
-            [$$N$$] Axial force [$$kN$$].
+            [$N$] Axial force [$kN$].
 
             Positive values for compression, tension is not allowed.
 
         Notes
         -----
         Eccentricity is suitable for statically determinate members, whereas transverse load can be used for
-        both determinate and indeterminate members. The force [$$H_{i}$$] may be substituted by some other equivalent
+        both determinate and indeterminate members. The force [$H_{i}$] may be substituted by some other equivalent
         transverse action.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_4.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_4.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot4TransverseForceEffectBracingSystem(Formula):
-    """Class representing formula 5.4 for the calculation of the effect of the inclination on bracing systems, [$$H_{i}$$].
+    """Class representing formula 5.4 for the calculation of the effect of the inclination on bracing systems, [$H_{i}$].
 
     See Figure 5.1 b.
     """
@@ -22,22 +22,22 @@ class Form5Dot4TransverseForceEffectBracingSystem(Formula):
         n_a: KN,
         n_b: KN,
     ) -> None:
-        r"""[$$H_{i}$$] Effect of the inclination on bracing systems [$$kN$$].
+        r"""[$H_{i}$] Effect of the inclination on bracing systems [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(8) - Formula (5.4)
 
         Parameters
         ----------
         theta_i : DIMENSIONLESS
-            [$$Θ_{i}$$] Eccentricity, initial inclination imperfections [-].
+            [$Θ_{i}$] Eccentricity, initial inclination imperfections [-].
         n_a : KN
-            [$$N_{a}$$] Axial force in the member [$$kN$$].
+            [$N_{a}$] Axial force in the member [$kN$].
         n_b : KN
-            [$$N_{b}$$] Axial force in the member [$$kN$$].
+            [$N_{b}$] Axial force in the member [$kN$].
 
         Notes
         -----
-        where [$$N_{a}$$] and [$$N_{b}$$] are longitudinal forces contributing to [$$H_{i}$$].
+        where [$N_{a}$] and [$N_{b}$] are longitudinal forces contributing to [$H_{i}$].
         Positive values for compression, tension is not allowed.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_40a.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_40a.py
@@ -26,11 +26,11 @@ class Form5Dot40aCheckLateralInstability(Formula):
         Parameters
         ----------
         l_0t : M
-            [$$l_{0t}$$] is the distance between torsional restraints [$$m$$].
+            [$l_{0t}$] is the distance between torsional restraints [$m$].
         b : M
-            [$$b$$] is the width of compression flange [$$m$$].
+            [$b$] is the width of compression flange [$m$].
         h : M
-            [$$h$$] is the total depth of beam in central part of $$l_{0t}$$ [$$m$$].
+            [$h$] is the total depth of beam in central part of $l_{0t}$ [$m$].
         """
         super().__init__()
         self.l_0t = l_0t

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_40b.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_40b.py
@@ -26,11 +26,11 @@ class Form5Dot40bCheckLateralInstability(Formula):
         Parameters
         ----------
         l_0t : M
-            [$$l_{0t}$$] is the distance between torsional restraints [$$m$$].
+            [$l_{0t}$] is the distance between torsional restraints [$m$].
         b : M
-            [$$b$$] is the width of compression flange [$$m$$].
+            [$b$] is the width of compression flange [$m$].
         h : M
-            [$$h$$] is the total depth of beam in central part of [$$l_{0t}$$] [$$m$$].
+            [$h$] is the total depth of beam in central part of [$l_{0t}$] [$m$].
         """
         super().__init__()
         self.l_0t = l_0t

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_41.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_41.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot41MaxForceTendon(Formula):
-    r"""Class representing formula 5.41 for the calculation of the maximum force applied to a tendon, [$$P_{max}$$]."""
+    r"""Class representing formula 5.41 for the calculation of the maximum force applied to a tendon, [$P_{max}$]."""
 
     label = "5.41"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -21,22 +21,22 @@ class Form5Dot41MaxForceTendon(Formula):
         k_2: DIMENSIONLESS,
         f_p0_1k: MPA,
     ) -> None:
-        r"""[$$P_{max}$$] Maximum force applied to a tendon at active end [$$N$$].
+        r"""[$P_{max}$] Maximum force applied to a tendon at active end [$N$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.10.2.1(1) - Formula (5.41)
 
         Parameters
         ----------
         a_p : MM2
-            [$$A_{p}$$] Cross-sectional area of the tendon [$$mm^2$$].
+            [$A_{p}$] Cross-sectional area of the tendon [$mm^2$].
         k_1 : DIMENSIONLESS
-            [$$k_{1}$$] Coefficient for characteristic tensile strength, recommended value is 0.8 [$$-$$].
+            [$k_{1}$] Coefficient for characteristic tensile strength, recommended value is 0.8 [$-$].
         f_pk : MPA
-            [$$f_{pk}$$] Characteristic tensile strength of the tendon [$$MPa$$].
+            [$f_{pk}$] Characteristic tensile strength of the tendon [$MPa$].
         k_2 : DIMENSIONLESS
-            [$$k_{2}$$] Coefficient for 0.1% proof stress, recommended value is 0.9 [$$-$$].
+            [$k_{2}$] Coefficient for 0.1% proof stress, recommended value is 0.9 [$-$].
         f_p0_1k : MPA
-            [$$f_{p0.1k}$$] 0.1% proof stress of the tendon [$$MPa$$].
+            [$f_{p0.1k}$] 0.1% proof stress of the tendon [$MPa$].
         """
         super().__init__()
         self.a_p = a_p

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_42.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_42.py
@@ -25,9 +25,9 @@ class Form5Dot42ConcreteCompressiveStress(Formula):
         Parameters
         ----------
         sigma_c : MPA
-            [$$\sigma_{c}$$] Concrete compressive stress [MPa].
+            [$\sigma_{c}$] Concrete compressive stress [MPa].
         f_ck_t : MPA
-            [$$f_{ck}(t)$$] Characteristic compressive strength of concrete at time t [MPa].
+            [$f_{ck}(t)$] Characteristic compressive strength of concrete at time t [MPa].
         """
         super().__init__()
         self.sigma_c = sigma_c

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_43.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_43.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot43InitialPrestressForce(Formula):
-    r"""Class representing formula 5.43 for the calculation of the initial prestress force, [$$P_{m0}(x)$$]."""
+    r"""Class representing formula 5.43 for the calculation of the initial prestress force, [$P_{m0}(x)$]."""
 
     label = "5.43"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -21,22 +21,22 @@ class Form5Dot43InitialPrestressForce(Formula):
         k_8: DIMENSIONLESS,
         f_p0_1k: MPA,
     ) -> None:
-        r"""[$$P_{m0}(x)$$] Initial prestress force [$$N$$].
+        r"""[$P_{m0}(x)$] Initial prestress force [$N$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.10.3(2) - Formula (5.43)
 
         Parameters
         ----------
         a_p : MM2
-            [$$A_{p}$$] Area of prestressing steel [$$mm^2$$].
+            [$A_{p}$] Area of prestressing steel [$mm^2$].
         k_7 : DIMENSIONLESS
-            [$$k_{7}$$] Coefficient for characteristic tensile strength, recommended value is 0.75 [$$-$$].
+            [$k_{7}$] Coefficient for characteristic tensile strength, recommended value is 0.75 [$-$].
         f_pk : MPA
-            [$$f_{pk}$$] Characteristic tensile strength of prestressing steel [$$MPa$$].
+            [$f_{pk}$] Characteristic tensile strength of prestressing steel [$MPa$].
         k_8 : DIMENSIONLESS
-            [$$k_{8}$$] Coefficient for 0.1% proof stress, recommended value is 0.85 [$$-$$].
+            [$k_{8}$] Coefficient for 0.1% proof stress, recommended value is 0.85 [$-$].
         f_p0_1k : MPA
-            [$$f_{p0,1k}$$] 0.1% proof stress of prestressing steel [$$MPa$$].
+            [$f_{p0,1k}$] 0.1% proof stress of prestressing steel [$MPa$].
         """
         super().__init__()
         self.a_p = a_p

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_44.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_44.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_list
 
 
 class Form5Dot44PrestressLoss(Formula):
-    r"""Class representing formula 5.44 for the calculation of the prestress losses, [$$\Delta P_{el}$$]."""
+    r"""Class representing formula 5.44 for the calculation of the prestress losses, [$\Delta P_{el}$]."""
 
     label = "5.44"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -21,22 +21,22 @@ class Form5Dot44PrestressLoss(Formula):
         delta_sigma_c_t: list[MPA],
         e_cm_t: list[MPA],
     ) -> None:
-        r"""[$$\Delta P_{el}$$] Prestress loss [$$N$$].
+        r"""[$\Delta P_{el}$] Prestress loss [$N$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.10.5.1(2) - Formula (5.44)
 
         Parameters
         ----------
         a_p : MM2
-            [$$A_{p}$$] Cross-sectional area of the tendon [$$mm^2$$].
+            [$A_{p}$] Cross-sectional area of the tendon [$mm^2$].
         e_p : MPA
-            [$$E_{p}$$] Modulus of elasticity of the tendon [$$MPa$$].
+            [$E_{p}$] Modulus of elasticity of the tendon [$MPa$].
         j : list[DIMENSIONLESS]
-            [$$j$$] (n-1)/2n, with n the number of identical tendons successively prestressed [$$list[-]$$].
+            [$j$] (n-1)/2n, with n the number of identical tendons successively prestressed [$list[-]$].
         delta_sigma_c_t : list[MPA]
-            [$$\Delta \sigma_{c}(t)$$] variation of stress at the centre of gravity of the tendons applied at time t [$$list[MPa]$$].
+            [$\Delta \sigma_{c}(t)$] variation of stress at the centre of gravity of the tendons applied at time t [$list[MPa]$].
         e_cm_t: list[MPA]
-            [$$E_{cm}(t)$$] 0.1% proof stress of prestressing steel [$$list[MPa]$$].
+            [$E_{cm}(t)$] 0.1% proof stress of prestressing steel [$list[MPa]$].
         """
         super().__init__()
         self.a_p = a_p

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_45.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_45.py
@@ -10,7 +10,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot45LossesDueToFriction(Formula):
-    r"""Class representing formula 5.45 for the calculation of losses due to friction in post-tensioned tendons, [$$\Delta P_{\mu}(x)$$]."""
+    r"""Class representing formula 5.45 for the calculation of losses due to friction in post-tensioned tendons, [$\Delta P_{\mu}(x)$]."""
 
     label = "5.45"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -23,22 +23,22 @@ class Form5Dot45LossesDueToFriction(Formula):
         k: ONE_OVER_M,
         x: M,
     ) -> None:
-        r"""[$$\Delta P_{\mu}(x)$$] Losses due to friction [$$kN$$].
+        r"""[$\Delta P_{\mu}(x)$] Losses due to friction [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.10.5.2(1) - Formula (5.45)
 
         Parameters
         ----------
         p_max : KN
-            [$$P_{max}$$] Force at the active end during tensioning [$$kN$$].
+            [$P_{max}$] Force at the active end during tensioning [$kN$].
         mu : DIMENSIONLESS
-            [$$\mu$$] Coefficient of friction between the tendon and its duct [$$-$$].
+            [$\mu$] Coefficient of friction between the tendon and its duct [$-$].
         theta : DIMENSIONLESS
-            [$$\theta$$] Sum of the angular displacements over a distance x (irrespective of direction or sign) [$$-$$].
+            [$\theta$] Sum of the angular displacements over a distance x (irrespective of direction or sign) [$-$].
         k : ONE_OVER_M
-            [$$k$$] Unintentional angular displacement for internal tendons (per unit length) [$$1/m$$].
+            [$k$] Unintentional angular displacement for internal tendons (per unit length) [$1/m$].
         x : M
-            [$$x$$] Distance along tendon from point where the prestressing force equals Pmax (force at active end during tensioning) [$$m$$].
+            [$x$] Distance along tendon from point where the prestressing force equals Pmax (force at active end during tensioning) [$m$].
         """
         super().__init__()
         self.p_max = p_max

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_46.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_46.py
@@ -9,7 +9,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 class Form5Dot46Part1TimeDependentForceLosses(Formula):
     r"""Class representing formula 5.46 for the calculation of the time dependent pre- and post-tensioning losses at location
-    x under the permanent loads, [$$\Delta P_{c+s+r}$$].
+    x under the permanent loads, [$\Delta P_{c+s+r}$].
     """
 
     label = "5.46"
@@ -28,36 +28,36 @@ class Form5Dot46Part1TimeDependentForceLosses(Formula):
         i_c: MM4,
         z_cp: MM,
     ) -> None:
-        r"""[$$\Delta P_{c+s+r}$$] Time dependent pre- and post-tensioning losses at location x under the permanent loads [$$N$$].
+        r"""[$\Delta P_{c+s+r}$] Time dependent pre- and post-tensioning losses at location x under the permanent loads [$N$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.10.6(2) - Formula (5.46)
 
         Parameters
         ----------
         a_p : MM2
-            [$$A_p$$] Area of all the prestressing tendons at the location x [$$mm^2$$].
+            [$A_p$] Area of all the prestressing tendons at the location x [$mm^2$].
         epsilon_cs : DIMENSIONLESS
-            [$$\epsilon_{cs}$$] The estimated shrinkage strain according to 3.1.4(6) in absolute value [$$-$$].
+            [$\epsilon_{cs}$] The estimated shrinkage strain according to 3.1.4(6) in absolute value [$-$].
         e_p : MPA
-            [$$E_p$$] Modulus of elasticity for the prestressing steel, see 3.3.3 (9) [$$MPa$$].
+            [$E_p$] Modulus of elasticity for the prestressing steel, see 3.3.3 (9) [$MPa$].
         e_cm : MPA
-            [$$E_{cm}$$] Modulus of elasticity for the concrete (Table 3.1) [$$MPa$$].
+            [$E_{cm}$] Modulus of elasticity for the concrete (Table 3.1) [$MPa$].
         delta_sigma_pr : MPA
-            [$$\Delta \sigma_{pr}$$] is the absolute value of the variation of stress in the tendons at location x, at
+            [$\Delta \sigma_{pr}$] is the absolute value of the variation of stress in the tendons at location x, at
             time t, due to the relaxation of the prestressing steel. It is determined for a stress of
-            [$$\sigma_p = \sigma_p(G+P_{m0}+\Psi_2 Q)$$]where [$$\sigma_p = \sigma_p(G+P_{m0}+\Psi_2 Q)$$] is the initial
-            stress in the tendons due to initial prestress and quasi-permanent actions. [$$MPa$$].
+            [$\sigma_p = \sigma_p(G+P_{m0}+\Psi_2 Q)$]where [$\sigma_p = \sigma_p(G+P_{m0}+\Psi_2 Q)$] is the initial
+            stress in the tendons due to initial prestress and quasi-permanent actions. [$MPa$].
         phi_t_t0 : DIMENSIONLESS
-            [$$\phi(t, t_0)$$] Creep coefficient at a time t and load application at time t0 [$$-$$].
+            [$\phi(t, t_0)$] Creep coefficient at a time t and load application at time t0 [$-$].
         sigma_c_qp : MPA
-            [$$\sigma_{c,QP}$$] stress in the concrete adjacent to the tendons, due to self-weight and
-            initial prestress and other quasi-permanent actions where relevant. [$$MPa$$].
+            [$\sigma_{c,QP}$] stress in the concrete adjacent to the tendons, due to self-weight and
+            initial prestress and other quasi-permanent actions where relevant. [$MPa$].
         a_c : MM2
-            [$$A_c$$] Area of concrete section [$$mm^2$$].
+            [$A_c$] Area of concrete section [$mm^2$].
         i_c : MM4
-            [$$I_c$$] Second moment of area of concrete section [$$mm^4$$].
+            [$I_c$] Second moment of area of concrete section [$mm^4$].
         z_cp : MM
-            [$$z_{cp}$$] Distance between the centre of gravity of the concrete section and the tendons [$$mm$$].
+            [$z_{cp}$] Distance between the centre of gravity of the concrete section and the tendons [$mm$].
         """
         super().__init__()
         self.a_p = a_p
@@ -109,7 +109,7 @@ class Form5Dot46Part1TimeDependentForceLosses(Formula):
 
 class Form5Dot46Part2TimeDependentStressLosses(Formula):
     r"""Class representing formula 5.46 for the calculation of the time dependent pre- and post-tensioning losses at location
-    x under the permanent loads, [$$\Delta \sigma_{p,c+s+r}$$].
+    x under the permanent loads, [$\Delta \sigma_{p,c+s+r}$].
     """
 
     label = "5.46"
@@ -128,37 +128,37 @@ class Form5Dot46Part2TimeDependentStressLosses(Formula):
         i_c: MM4,
         z_cp: MM,
     ) -> None:
-        r"""[$$\Delta \sigma_{p,c+s+r}$$] Time dependent pre- and post-tensioning stress losses at
-        location x under the permanent loads [$$MPa$$].
+        r"""[$\Delta \sigma_{p,c+s+r}$] Time dependent pre- and post-tensioning stress losses at
+        location x under the permanent loads [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.10.6(2) - Formula (5.46)
 
         Parameters
         ----------
         a_p : MM2
-            [$$A_p$$] Area of all the prestressing tendons at the location x [$$mm^2$$].
+            [$A_p$] Area of all the prestressing tendons at the location x [$mm^2$].
         epsilon_cs : DIMENSIONLESS
-            [$$\epsilon_{cs}$$] The estimated shrinkage strain according to 3.1.4(6) in absolute value [$$-$$].
+            [$\epsilon_{cs}$] The estimated shrinkage strain according to 3.1.4(6) in absolute value [$-$].
         e_p : MPA
-            [$$E_p$$] Modulus of elasticity for the prestressing steel, see 3.3.3 (9) [$$MPa$$].
+            [$E_p$] Modulus of elasticity for the prestressing steel, see 3.3.3 (9) [$MPa$].
         e_cm : MPA
-            [$$E_{cm}$$] Modulus of elasticity for the concrete (Table 3.1) [$$MPa$$].
+            [$E_{cm}$] Modulus of elasticity for the concrete (Table 3.1) [$MPa$].
         delta_sigma_pr : MPA
-            [$$\Delta \sigma_{pr}$$] is the absolute value of the variation of stress in the tendons at location x, at
+            [$\Delta \sigma_{pr}$] is the absolute value of the variation of stress in the tendons at location x, at
             time t, due to the relaxation of the prestressing steel. It is determined for a stress of
-            [$$\sigma_p = \sigma_p(G+P_{m0}+\Psi_2 Q)$$]where [$$\sigma_p = \sigma_p(G+P_{m0}+\Psi_2 Q)$$] is the initial
-            stress in the tendons due to initial prestress and quasi-permanent actions. [$$MPa$$].
+            [$\sigma_p = \sigma_p(G+P_{m0}+\Psi_2 Q)$]where [$\sigma_p = \sigma_p(G+P_{m0}+\Psi_2 Q)$] is the initial
+            stress in the tendons due to initial prestress and quasi-permanent actions. [$MPa$].
         phi_t_t0 : DIMENSIONLESS
-            [$$\phi(t, t_0)$$] Creep coefficient at a time t and load application at time t0 [$$-$$].
+            [$\phi(t, t_0)$] Creep coefficient at a time t and load application at time t0 [$-$].
         sigma_c_qp : MPA
-            [$$\sigma_{c,QP}$$] stress in the concrete adjacent to the tendons, due to self-weight and
-            initial prestress and other quasi-permanent actions where relevant. [$$MPa$$].
+            [$\sigma_{c,QP}$] stress in the concrete adjacent to the tendons, due to self-weight and
+            initial prestress and other quasi-permanent actions where relevant. [$MPa$].
         a_c : MM2
-            [$$A_c$$] Area of concrete section [$$mm^2$$].
+            [$A_c$] Area of concrete section [$mm^2$].
         i_c : MM4
-            [$$I_c$$] Second moment of area of concrete section [$$mm^4$$].
+            [$I_c$] Second moment of area of concrete section [$mm^4$].
         z_cp : MM
-            [$$z_{cp}$$] Distance between the centre of gravity of the concrete section and the tendons [$$mm$$].
+            [$z_{cp}$] Distance between the centre of gravity of the concrete section and the tendons [$mm$].
         """
         super().__init__()
         self.a_p = a_p

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_47.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_47.py
@@ -9,7 +9,7 @@ from blueprints.validations import raise_if_negative
 
 class Form5Dot47UpperCharacteristicPrestressingValue(Formula):
     r"""Class representing formula 5.47 for the calculation of the upper characteristic value for the prestressing
-    value at SLS and Fatigue, [$$P_{k,sup}$$].
+    value at SLS and Fatigue, [$P_{k,sup}$].
     """
 
     label = "5.47"
@@ -20,17 +20,17 @@ class Form5Dot47UpperCharacteristicPrestressingValue(Formula):
         r_sup: DIMENSIONLESS,
         p_m_t: KN,
     ) -> None:
-        r"""[$$P_{k,sup}$$] Upper characteristic value for the prestressing value at SLS and Fatigue [$$kN$$].
+        r"""[$P_{k,sup}$] Upper characteristic value for the prestressing value at SLS and Fatigue [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.10.9(1) - Formula (5.47)
 
         Parameters
         ----------
         r_sup : DIMENSIONLESS
-            [$$r_{sup}$$] Factor for the upper characteristic value, recommended value is 1.05 for pre-tensioning or unbounded tendons,
-             1.10 for post-tensioning with bonded tendons. When appropriate measures are taken: 1.0 [$$-$$].
+            [$r_{sup}$] Factor for the upper characteristic value, recommended value is 1.05 for pre-tensioning or unbounded tendons,
+             1.10 for post-tensioning with bonded tendons. When appropriate measures are taken: 1.0 [$-$].
         p_m_t : KN
-            [$$P_{m,t}(x)$$] Mean value of the prestressing force at location x [$$kN$$].
+            [$P_{m,t}(x)$] Mean value of the prestressing force at location x [$kN$].
         """
         super().__init__()
         self.r_sup = r_sup

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_48.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_48.py
@@ -9,7 +9,7 @@ from blueprints.validations import raise_if_negative
 
 class Form5Dot48LowerCharacteristicPrestressingValue(Formula):
     r"""Class representing formula 5.48 for the calculation of the lower characteristic value for the prestressing
-    value at SLS and Fatigue, [$$P_{k,inf}$$].
+    value at SLS and Fatigue, [$P_{k,inf}$].
     """
 
     label = "5.48"
@@ -20,17 +20,17 @@ class Form5Dot48LowerCharacteristicPrestressingValue(Formula):
         r_inf: DIMENSIONLESS,
         p_m_t: KN,
     ) -> None:
-        r"""[$$P_{k,inf}$$] Lower characteristic value for the prestressing value at SLS and Fatigue [$$kN$$].
+        r"""[$P_{k,inf}$] Lower characteristic value for the prestressing value at SLS and Fatigue [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.10.9(1) - Formula (5.48)
 
         Parameters
         ----------
         r_inf : DIMENSIONLESS
-            [$$r_{inf}$$] Factor for the lower characteristic value, recommended value is 0.95 for pre-tensioning or unbounded tendons,
-             0.90 for post-tensioning with bonded tendons. When appropriate measures are taken: 1.0 [$$-$$].
+            [$r_{inf}$] Factor for the lower characteristic value, recommended value is 0.95 for pre-tensioning or unbounded tendons,
+             0.90 for post-tensioning with bonded tendons. When appropriate measures are taken: 1.0 [$-$].
         p_m_t : KN
-            [$$P_{m,t}(x)$$] Mean value of the prestressing force at location x [$$kN$$].
+            [$P_{m,t}(x)$] Mean value of the prestressing force at location x [$kN$].
         """
         super().__init__()
         self.r_inf = r_inf

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_5.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_5.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot5TransverseForceEffectFloorDiaphragm(Formula):
-    """Class representing formula 5.5 for the calculation of the effect of the inclination on floor diaphragm, [$$H_{i}$$].
+    """Class representing formula 5.5 for the calculation of the effect of the inclination on floor diaphragm, [$H_{i}$].
 
     See Figure 5.1 c1.
     """
@@ -22,22 +22,22 @@ class Form5Dot5TransverseForceEffectFloorDiaphragm(Formula):
         n_a: KN,
         n_b: KN,
     ) -> None:
-        r"""[$$H_{i}$$] Effect of the inclination on floor diaphragm [$$kN$$].
+        r"""[$H_{i}$] Effect of the inclination on floor diaphragm [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(8) - Formula (5.5)
 
         Parameters
         ----------
         theta_i : DIMENSIONLESS
-            [$$Θ_{i}$$] Eccentricity, initial inclination imperfections [-].
+            [$Θ_{i}$] Eccentricity, initial inclination imperfections [-].
         n_a : KN
-            [$$N_{a}$$] Axial force in the member [$$kN$$].
+            [$N_{a}$] Axial force in the member [$kN$].
         n_b : KN
-            [$$N_{b}$$] Axial force in the member [$$kN$$].
+            [$N_{b}$] Axial force in the member [$kN$].
 
         Notes
         -----
-        where [$$N_{a}$$] and [$$N_{b}$$] are longitudinal forces contributing to [$$H_{i}$$].
+        where [$N_{a}$] and [$N_{b}$] are longitudinal forces contributing to [$H_{i}$].
         Positive values for compression, tension is not allowed.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_6.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_6.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot6TransverseForceEffectRoofDiaphragm(Formula):
-    """Class representing formula 5.6 for the calculation of the effect of the inclination on roof diaphragm, [$$H_{i}$$].
+    """Class representing formula 5.6 for the calculation of the effect of the inclination on roof diaphragm, [$H_{i}$].
     See Figure 5.1 c2.
     """
 
@@ -20,20 +20,20 @@ class Form5Dot6TransverseForceEffectRoofDiaphragm(Formula):
         theta_i: DIMENSIONLESS,
         n_a: KN,
     ) -> None:
-        r"""[$$H_{i}$$] Effect of the inclination on roof diaphragm [$$kN$$].
+        r"""[$H_{i}$] Effect of the inclination on roof diaphragm [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.2(8) - Formula (5.6)
 
         Parameters
         ----------
         theta_i : DIMENSIONLESS
-            [$$Θ_{i}$$] Eccentricity, initial inclination imperfections [-].
+            [$Θ_{i}$] Eccentricity, initial inclination imperfections [-].
         n_a : KN
-            [$$N_{a}$$] Axial force in the member [$$kN$$].
+            [$N_{a}$] Axial force in the member [$kN$].
 
         Notes
         -----
-        where [$$N_{a}$$] is a longitudinal force contributing to [$$H_{i}$$].
+        where [$N_{a}$] is a longitudinal force contributing to [$H_{i}$].
         Positive values for compression, tension is not allowed.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_7.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_7.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot7EffectiveFlangeWidth(Formula):
-    """Class representing formula 5.7 for the calculation of effective flange width [$$b_{eff}$$] for a T beam or L beam.
+    """Class representing formula 5.7 for the calculation of effective flange width [$b_{eff}$] for a T beam or L beam.
     See Figure 5.3.
     """
 
@@ -21,22 +21,22 @@ class Form5Dot7EffectiveFlangeWidth(Formula):
         b_w: M,
         b: M,
     ) -> None:
-        r"""[$$b_{eff}$$] Effective flange width for a T beam or L beam [$$m$$].
+        r"""[$b_{eff}$] Effective flange width for a T beam or L beam [$m$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.3.2.1(3) - Formula (5.7)
 
         Parameters
         ----------
         b_eff_i : M
-            [$$b_{eff,i}$$] Effective flange width of the i-th flange [$$m$$].
+            [$b_{eff,i}$] Effective flange width of the i-th flange [$m$].
         b_w : M
-            [$$b_{w}$$] Width of the web [$$m$$].
+            [$b_{w}$] Width of the web [$m$].
         b : M
-            [$$b$$] Total width of the flange [$$m$$].
+            [$b$] Total width of the flange [$m$].
 
         Notes
         -----
-        where [$$b_{eff,i}$$] is the effective flange width of the i-th flange
+        where [$b_{eff,i}$] is the effective flange width of the i-th flange
         """
         super().__init__()
         self.b_eff_i = b_eff_i

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_7ab.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_7ab.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot7abFlangeEffectiveFlangeWidth(Formula):
-    """Class representing formula 5.7a and formula 5.7b for the calculation of effective flange width of the i-th flange [$$b_{eff,i}$$].
+    """Class representing formula 5.7a and formula 5.7b for the calculation of effective flange width of the i-th flange [$b_{eff,i}$].
     See Figure 5.3.
     """
 
@@ -20,16 +20,16 @@ class Form5Dot7abFlangeEffectiveFlangeWidth(Formula):
         b_i: M,
         l_0: M,
     ) -> None:
-        r"""[$$b_{eff,i}$$] Effective flange width of the i-th flange of a beam [$$m$$].
+        r"""[$b_{eff,i}$] Effective flange width of the i-th flange of a beam [$m$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.3.2.1(3) - Formula (5.7a) and (5.7b)
 
         Parameters
         ----------
         b_i : M
-            [$$b_{i}$$] Effective flange width of the i-th flange [$$m$$].
+            [$b_{i}$] Effective flange width of the i-th flange [$m$].
         l_0 : M
-            [$$l_{0}$$] distance between points of zero moment, which may be obtained from Figure 5.2 [$$m$$].
+            [$l_{0}$] distance between points of zero moment, which may be obtained from Figure 5.2 [$m$].
 
         Notes
         -----

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_8.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_8.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot8EffectiveSpan(Formula):
-    """Class representing formula 5.8 for calculating the effective span of beams and slabs, [$$l_{eff}$$].
+    """Class representing formula 5.8 for calculating the effective span of beams and slabs, [$l_{eff}$].
 
     See Figure 5.4
     """
@@ -22,20 +22,20 @@ class Form5Dot8EffectiveSpan(Formula):
         a_1: M,
         a_2: M,
     ) -> None:
-        r"""[$$l_{eff}$$] the effective span of a member [$$m$$].
+        r"""[$l_{eff}$] the effective span of a member [$m$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.3.2.2(1) - Formula (5.8)
 
         Parameters
         ----------
         l_n : M
-            [$$l_{n}$$] clear distance between the faces of the supports [$$m$$].
+            [$l_{n}$] clear distance between the faces of the supports [$m$].
         a_1 : M
-            [$$a_{1}$$] values for [$$a_{1}$$] and [$$a_{2}$$] at each end of the span, may be determined from the appropriate [$$a_{i}$$]
-                            values in Figure 5.4 where t is the width of the supporting element as shown. [$$m$$].
+            [$a_{1}$] values for [$a_{1}$] and [$a_{2}$] at each end of the span, may be determined from the appropriate [$a_{i}$]
+                            values in Figure 5.4 where t is the width of the supporting element as shown. [$m$].
         a_2 : M
-            [$$a_{2}$$] values for [$$a_{1}$$] and [$$a_{2}$$] at each end of the span, may be determined from the appropriate [$$a_{i}$$]
-                            values in Figure 5.4 where t is the width of the supporting element as shown. [$$m$$].
+            [$a_{2}$] values for [$a_{1}$] and [$a_{2}$] at each end of the span, may be determined from the appropriate [$a_{i}$]
+                            values in Figure 5.4 where t is the width of the supporting element as shown. [$m$].
         """
         super().__init__()
         self.l_n = l_n

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_9.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_5_structural_analysis/formula_5_9.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form5Dot9DesignSupportMomentReduction(Formula):
-    """Class representing formula 5.9 for the calculation of the design support moment reduction, [$$ΔM_{Ed}$$].
+    """Class representing formula 5.9 for the calculation of the design support moment reduction, [$ΔM_{Ed}$].
     See Figure 5.4 b.
     """
 
@@ -20,23 +20,23 @@ class Form5Dot9DesignSupportMomentReduction(Formula):
         f_ed_sup: KN,
         t: M,
     ) -> None:
-        r"""[$$ΔM_{Ed}$$] Design support moment reduction [$$kN$$].
+        r"""[$ΔM_{Ed}$] Design support moment reduction [$kN$].
 
         Note: Regardless of the method of analysis used, where a beam or slab is continuous over a
         support which may be considered to provide no restraint to rotation (e.g. over walls), the design
         support moment, calculated on the basis of a span equal to the centre-to-centre distance
-        between supports, may be reduced by an amount [$$ΔM_{Ed}$$].
+        between supports, may be reduced by an amount [$ΔM_{Ed}$].
 
         NEN-EN 1992-1-1+C2:2011 art.5.3.2.2(4) - Formula (5.9)
 
         Parameters
         ----------
         f_ed_sup : KN
-            [$$F_{Ed,sup}$$] Design support reaction [$$kN$$].
+            [$F_{Ed,sup}$] Design support reaction [$kN$].
         t : M
-            [$$t$$] breadth of the support (see Figure 5.4 b) [$$m$$].
+            [$t$] breadth of the support (see Figure 5.4 b) [$m$].
 
-            Note:  Where support bearings are used [$$t$$] should be taken as the bearing width.
+            Note:  Where support bearings are used [$t$] should be taken as the bearing width.
         """
         super().__init__()
         self.f_ed_sup = f_ed_sup

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_1.py
@@ -18,18 +18,18 @@ class Form6Dot1DesignShearStrength(Formula):
         v_ccd: KN,
         v_td: KN,
     ) -> None:
-        r"""[$$V_{Rd}$$] Design shear resistance of an element with shear reinforcement.
+        r"""[$V_{Rd}$] Design shear resistance of an element with shear reinforcement.
 
         NEN-EN 1992-1-1+C2:2011 art.6.2.1(2) - Formula (6.1)
 
         Parameters
         ----------
         v_rd_s : KN
-            [$$V_{Rd,s}$$] Design shear resistance of an element with shear reinforcement [$$kN$$].
+            [$V_{Rd,s}$] Design shear resistance of an element with shear reinforcement [$kN$].
         v_ccd : KN
-            [$$V_{ccd}$$] Design value of the shear force component in the compression area in case of a change in height [$$kN$$].
+            [$V_{ccd}$] Design value of the shear force component in the compression area in case of a change in height [$kN$].
         v_td : KN
-            [$$V_{td}$$] Design value of the shear force component of the tensile force in the reinforcement in case of a change in height [$$kN$$].
+            [$V_{td}$] Design value of the shear force component of the tensile force in the reinforcement in case of a change in height [$kN$].
         """
         super().__init__()
         self.v_rd_s = v_rd_s

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_47.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_47.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form6Dot47PunchingShearResistance(Formula):
-    r"""Class representing formula 6.47 for the calculation of punching shear resistance, $$v_{Rd,c}$$ of slabs and column bases
+    r"""Class representing formula 6.47 for the calculation of punching shear resistance, $v_{Rd,c}$ of slabs and column bases
     without shear reinforcement.
     """
 
@@ -25,31 +25,31 @@ class Form6Dot47PunchingShearResistance(Formula):
         sigma_cp: MPA,
         v_min: MPA,
     ) -> None:
-        r"""$$v_{Rd,c}$$ Calculation of punching shear resistance of slabs and column bases without shear reinforcement.
+        r"""$v_{Rd,c}$ Calculation of punching shear resistance of slabs and column bases without shear reinforcement.
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(1) - Formula (6.47).
 
-        The values of $$C_{Rd,c}$$, $$v_{min}$$, and $$k_1$$ for use in a country may be found in its national annex.
-        The recommended value for $$C_{Rd,c}$$ is $$0.18 / \gamma_c$$, for $$v_{min}$$ is given by Expression (6.3N),
-        and that for $$k_1$$ is $$0.1$$.
+        The values of $C_{Rd,c}$, $v_{min}$, and $k_1$ for use in a country may be found in its national annex.
+        The recommended value for $C_{Rd,c}$ is $0.18 / \gamma_c$, for $v_{min}$ is given by Expression (6.3N),
+        and that for $k_1$ is $0.1$.
 
         Parameters
         ----------
         c_rd_c : DIMENSIONLESS
-            $$C_{Rd,c}$$ Coefficient for punching shear resistance, recommended value $$0.18 / \gamma_c$$ [-].
+            $C_{Rd,c}$ Coefficient for punching shear resistance, recommended value $0.18 / \gamma_c$ [-].
         k : DIMENSIONLESS
-            $$k$$ Size effect factor, see equation SubForm6Dot47FactorK [-].
+            $k$ Size effect factor, see equation SubForm6Dot47FactorK [-].
         rho_l : DIMENSIONLESS
-            $$\rho_l$$ Longitudinal reinforcement ratio, see equation SubForm6Dot47FactorRhoL [-].
+            $\rho_l$ Longitudinal reinforcement ratio, see equation SubForm6Dot47FactorRhoL [-].
         f_ck : MPA
-            $$f_{ck}$$ Characteristic compressive strength of concrete [$$MPa$$].
+            $f_{ck}$ Characteristic compressive strength of concrete [$MPa$].
         k_1 : DIMENSIONLESS
-            $$k_1$$ Coefficient for concrete strength, recommended value 0.1 [-].
+            $k_1$ Coefficient for concrete strength, recommended value 0.1 [-].
         sigma_cp : MPA
-            $$\sigma_{cp}$$ Stress in the critical section as average of the two perpendicular directions, see
-             equation SubForm6Dot47FactorSigmaCp [$$MPa$$].
+            $\sigma_{cp}$ Stress in the critical section as average of the two perpendicular directions, see
+             equation SubForm6Dot47FactorSigmaCp [$MPa$].
         v_min : MPA
-            $$v_{min}$$ Minimum shear stress capacity concrete, recommended value with Expression (6.3N) [$$MPa$$].
+            $v_{min}$ Minimum shear stress capacity concrete, recommended value with Expression (6.3N) [$MPa$].
         """
         super().__init__()
         self.c_rd_c = c_rd_c

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_47_subs.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_47_subs.py
@@ -10,20 +10,20 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class SubForm6Dot47FactorK(Formula):
-    r"""Class representing the sub-formula which calculates the factor [$$k$$] for formula 6.47 ."""
+    r"""Class representing the sub-formula which calculates the factor [$k$] for formula 6.47 ."""
 
     label = "6.47 (factor k)"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, d: MM) -> None:
-        r"""[$$k$$] Calculation of factor k.
+        r"""[$k$] Calculation of factor k.
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(1) - Factor k for Formula (6.47)
 
         Parameters
         ----------
         d : MM
-            [$$d$$] Effective depth [$$mm$$].
+            [$d$] Effective depth [$mm$].
         """
         super().__init__()
         self.d = d
@@ -55,24 +55,24 @@ class SubForm6Dot47FactorK(Formula):
 
 
 class SubForm6Dot47FactorRhoL(Formula):
-    r"""Class representing the sub-formula which calculates the factor [$$\rho_l$$] for formula 6.47 ."""
+    r"""Class representing the sub-formula which calculates the factor [$\rho_l$] for formula 6.47 ."""
 
     label = "6.47 (factor rho_l)"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, rho_ly: DIMENSIONLESS, rho_lz: DIMENSIONLESS) -> None:
-        r"""[$$\rho_l$$] Calculation of factor [$$\rho_l$$].
+        r"""[$\rho_l$] Calculation of factor [$\rho_l$].
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(1) - Factor rho_l for Formula (6.47)
 
         Parameters
         ----------
         rho_ly : DIMENSIONLESS
-            [$$\rho_{ly}$$] Related to the bonded tension steel in y- drection. The value $$\rho_ly$$ should be calculated as mean values taking
-            into account a slab width equal to the column width plus 3d each side [$$-$$].
+            [$\rho_{ly}$] Related to the bonded tension steel in y- drection. The value $\rho_ly$ should be calculated as mean values taking
+            into account a slab width equal to the column width plus 3d each side [$-$].
         rho_lz : DIMENSIONLESS
-            [$$\rho_{lz}$$] Related to the bonded tension steel in z- drection. The value $$\rho_lz$$ should be calculated as mean values taking
-            into account a slab width equal to the column width plus 3d each side [$$-$$].
+            [$\rho_{lz}$] Related to the bonded tension steel in z- drection. The value $\rho_lz$ should be calculated as mean values taking
+            into account a slab width equal to the column width plus 3d each side [$-$].
         """
         super().__init__()
         self.rho_ly = rho_ly
@@ -106,23 +106,23 @@ class SubForm6Dot47FactorRhoL(Formula):
 
 
 class SubForm6Dot47FactorSigmaCp(Formula):
-    r"""Class representing the sub-formula which calculates the factor [$$\sigma_{cp}$$] for formula 6.47,."""
+    r"""Class representing the sub-formula which calculates the factor [$\sigma_{cp}$] for formula 6.47,."""
 
     label = "6.47 (factor sigma_cp)"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, sigma_cy: MPA, sigma_cz: MPA) -> None:
-        r"""[$$\sigma_{cp}$$] Calculation of factor [$$\sigma_{cp}$$].
+        r"""[$\sigma_{cp}$] Calculation of factor [$\sigma_{cp}$].
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(1) - Factor sigma_cp for Formula (6.47)
 
         Parameters
         ----------
         sigma_cy : MPA
-            [$$\sigma_{cy}$$] Normal concrete stress in the critical section in the y-direction [$$MPa$$], Positive if compression.
+            [$\sigma_{cy}$] Normal concrete stress in the critical section in the y-direction [$MPa$], Positive if compression.
             See equation SubForm6Dot47FactorSigmaCy.
         sigma_cz : MPA
-            [$$\sigma_{cz}$$] Normal concrete stress inm the critical section in the z-direction [$$MPa$$], Positive if compression.
+            [$\sigma_{cz}$] Normal concrete stress inm the critical section in the z-direction [$MPa$], Positive if compression.
             See equation SubForm6Dot47FactorSigmaCz.
         """
         super().__init__()
@@ -157,23 +157,23 @@ class SubForm6Dot47FactorSigmaCp(Formula):
 
 
 class SubForm6Dot47FactorSigmaCy(Formula):
-    r"""Class representing the sub-formula which calculates the factor [$$\sigma_{cy}$$] for formula 6.47."""
+    r"""Class representing the sub-formula which calculates the factor [$\sigma_{cy}$] for formula 6.47."""
 
     label = "6.47 (factor sigma_cy)"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, n_ed_y: N, a_cy: MM2) -> None:
-        r"""[$$\sigma_{cy}$$] Calculation of factor [$$\sigma_{cy}$$].
+        r"""[$\sigma_{cy}$] Calculation of factor [$\sigma_{cy}$].
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(1) - Factor sigma_cy for Formula (6.47)
 
         Parameters
         ----------
         n_ed_y : N
-            [$$N_{Ed,y}$$] Longitudinal forces across the full bay for internal columns and the logintudinal force across
-            the control section for edge columns. The force may be from a load or prestressing action [$$N$$].
+            [$N_{Ed,y}$] Longitudinal forces across the full bay for internal columns and the logintudinal force across
+            the control section for edge columns. The force may be from a load or prestressing action [$N$].
         a_cy : MM2
-            [$$A_{cy}$$] Cross-sectional area in y-direction [$$mm^2$$].
+            [$A_{cy}$] Cross-sectional area in y-direction [$mm^2$].
         """
         super().__init__()
         self.n_ed_y = n_ed_y
@@ -208,23 +208,23 @@ class SubForm6Dot47FactorSigmaCy(Formula):
 
 
 class SubForm6Dot47FactorSigmaCz(Formula):
-    r"""Class representing the sub-formula which calculates the factor [$$\sigma_{cz}$$] for formula 6.47."""
+    r"""Class representing the sub-formula which calculates the factor [$\sigma_{cz}$] for formula 6.47."""
 
     label = "6.47 (factor sigma_cz)"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, n_ed_z: N, a_cz: MM2) -> None:
-        r"""[$$\sigma_{cz}$$] Calculation of factor [$$\sigma_{cz}$$].
+        r"""[$\sigma_{cz}$] Calculation of factor [$\sigma_{cz}$].
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(1) - Factor sigma_cz for Formula (6.47)
 
         Parameters
         ----------
         n_ed_z : N
-            [$$N_{Ed,z}$$] Longitudinal forces across the full bay for internal columns and the logintudinal force across
-            the control section for edge columns. The force may be from a load or prestressing action [$$N$$].
+            [$N_{Ed,z}$] Longitudinal forces across the full bay for internal columns and the logintudinal force across
+            the control section for edge columns. The force may be from a load or prestressing action [$N$].
         a_cz : MM2
-            [$$A_{cz}$$] Cross-sectional area in z-direction [$$mm^2$$].
+            [$A_{cz}$] Cross-sectional area in z-direction [$mm^2$].
         """
         super().__init__()
         self.n_ed_z = n_ed_z

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_48.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_48.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form6Dot48NetAppliedPunchingForce(Formula):
-    r"""Class representing formula 6.48 for the calculation of net applied punching force [$$V_{Ed,red}$$] of slabs and column
+    r"""Class representing formula 6.48 for the calculation of net applied punching force [$V_{Ed,red}$] of slabs and column
     bases without shear reinforcement.
     """
 
@@ -20,16 +20,16 @@ class Form6Dot48NetAppliedPunchingForce(Formula):
         v_ed: N,
         delta_v_ed: N,
     ) -> None:
-        r"""[$$V_{Ed,red}$$] Calculation of net applied punching force of slabs and column bases without shear reinforcement.
+        r"""[$V_{Ed,red}$] Calculation of net applied punching force of slabs and column bases without shear reinforcement.
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(2) - Formula (6.48)
 
         Parameters
         ----------
         v_ed : N
-            [$$V_{Ed}$$] Applied shear force [$$N$$].
+            [$V_{Ed}$] Applied shear force [$N$].
         delta_v_ed : N
-            [$$\Delta V_{Ed}$$] Net upward force within the control perimeter considered [$$N$$].
+            [$\Delta V_{Ed}$] Net upward force within the control perimeter considered [$N$].
         """
         super().__init__()
         self.v_ed = v_ed

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_49.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_49.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form6Dot49AppliedPunchingShearStress(Formula):
-    r"""Class representing formula 6.49 for the calculation of applied punching shear stress [$$v_{Ed}$$] of slabs and column bases
+    r"""Class representing formula 6.49 for the calculation of applied punching shear stress [$v_{Ed}$] of slabs and column bases
     without shear reinforcement.
     """
 
@@ -21,18 +21,18 @@ class Form6Dot49AppliedPunchingShearStress(Formula):
         u: MM,
         d: MM,
     ) -> None:
-        r"""[$$v_{Ed}$$] Calculation of applied punching shear stress [$$v_{Ed}$$] of slabs and column bases without shear reinforcement.
+        r"""[$v_{Ed}$] Calculation of applied punching shear stress [$v_{Ed}$] of slabs and column bases without shear reinforcement.
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(2) - Formula (6.49)
 
         Parameters
         ----------
         v_ed_red : N
-            [$$V_{Ed,red}$$] Net applied punching force [$$N$$].
+            [$V_{Ed,red}$] Net applied punching force [$N$].
         u : MM
-            [$$u$$] Punching perimeter [$$mm$$].
+            [$u$] Punching perimeter [$mm$].
         d : MM
-            [$$d$$] Effective depth [$$mm$$].
+            [$d$] Effective depth [$mm$].
         """
         super().__init__()
         self.v_ed_red = v_ed_red

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_50.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_50.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form6Dot50PunchingStressResistance(Formula):
-    r"""Class representing formula 6.50 for the calculation of punching stress resistance [$$v_{Rd}$$] of slabs and
+    r"""Class representing formula 6.50 for the calculation of punching stress resistance [$v_{Rd}$] of slabs and
     column bases without shear reinforcement.
     """
 
@@ -25,30 +25,30 @@ class Form6Dot50PunchingStressResistance(Formula):
         a: MM,
         v_min: MPA,
     ) -> None:
-        r"""[$$v_{Rd}$$] Calculation of punching stress resistance of slabs and column bases without shear reinforcement.
+        r"""[$v_{Rd}$] Calculation of punching stress resistance of slabs and column bases without shear reinforcement.
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(2) - Formula (6.50)
 
-        The values of $$C_{Rd,c}$$, $$v_{min}$$, and $$k$$ for use in a country may be found in its national annex.
-        The recommended value for $$C_{Rd,c}$$ is $$0.18 / \gamma_c$$, for $$v_{min}$$ is given by Expression (6.3N),
-        and that for $$k$$ is $$1.0$$.
+        The values of $C_{Rd,c}$, $v_{min}$, and $k$ for use in a country may be found in its national annex.
+        The recommended value for $C_{Rd,c}$ is $0.18 / \gamma_c$, for $v_{min}$ is given by Expression (6.3N),
+        and that for $k$ is $1.0$.
 
         Parameters
         ----------
         c_rd_c : DIMENSIONLESS
-            $$C_{Rd,c}$$ Coefficient for punching shear resistance, recommended value $$0.18 / \gamma_c$$ [-].
+            $C_{Rd,c}$ Coefficient for punching shear resistance, recommended value $0.18 / \gamma_c$ [-].
         k : DIMENSIONLESS
-            $$k$$ Size effect factor, see equation SubForm6Dot47FactorK [-].
+            $k$ Size effect factor, see equation SubForm6Dot47FactorK [-].
         rho_l : DIMENSIONLESS
-            $$\rho_l$$ Longitudinal reinforcement ratio, see equation SubForm6Dot47FactorRhoL [-].
+            $\rho_l$ Longitudinal reinforcement ratio, see equation SubForm6Dot47FactorRhoL [-].
         f_ck : MPA
-            $$f_{ck}$$ Characteristic compressive strength of concrete [$$MPa$$].
+            $f_{ck}$ Characteristic compressive strength of concrete [$MPa$].
         d : MM
-            $$d$$ Effective depth [$$mm$$].
+            $d$ Effective depth [$mm$].
         a : MM
-            $$a$$ Distance from the periphery of the column to the control perimeter considered [$$mm$$].
+            $a$ Distance from the periphery of the column to the control perimeter considered [$mm$].
         v_min : MPA
-            $$v_{min}$$ Minimum shear stress capacity concrete, recommended value with Expression (6.3N) [$$MPa$$].
+            $v_{min}$ Minimum shear stress capacity concrete, recommended value with Expression (6.3N) [$MPa$].
         """
         super().__init__()
         self.c_rd_c = c_rd_c

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_51.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_51.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form6Dot51AppliedPunchingShearStressEccentricLoading(Formula):
-    r"""Class representing formula 6.51 for the calculation of punching shear stress for eccentric loading [$$v_{Ed}$$]
+    r"""Class representing formula 6.51 for the calculation of punching shear stress for eccentric loading [$v_{Ed}$]
     of slabs and column bases without shear reinforcement.
     """
 
@@ -24,24 +24,24 @@ class Form6Dot51AppliedPunchingShearStressEccentricLoading(Formula):
         m_ed: NMM,
         w: MM2,
     ) -> None:
-        r"""[$$v_{Ed}$$] Calculation of punching shear stress for eccentric loading of slabs and column bases without shear reinforcement.
+        r"""[$v_{Ed}$] Calculation of punching shear stress for eccentric loading of slabs and column bases without shear reinforcement.
 
         NEN-EN 1992-1-1+C2:2011 art.6.4.4(2) - Formula (6.51)
 
         Parameters
         ----------
         v_ed_red : N
-            [$$V_{Ed,red}$$] Net applied punching force [$$N$$].
+            [$V_{Ed,red}$] Net applied punching force [$N$].
         u : MM
-            [$$u$$] Perimeter of the critical section [$$mm$$].
+            [$u$] Perimeter of the critical section [$mm$].
         d : MM
-            [$$d$$] Mean effective depth of the slab [$$mm$$].
+            [$d$] Mean effective depth of the slab [$mm$].
         k : DIMENSIONLESS
-            [$$k$$] Coefficient dependent on the ratio between the column dimensions as defined in 6.4.3(3) or 6.4.3(4) [$$-$$].
+            [$k$] Coefficient dependent on the ratio between the column dimensions as defined in 6.4.3(3) or 6.4.3(4) [$-$].
         m_ed : NMM
-            [$$M_{Ed}$$] Design bending moment [$$Nmm$$].
+            [$M_{Ed}$] Design bending moment [$Nmm$].
         w : MM2
-            [$$W$$] Similar to [$$W_1$$] as defined in 6.4.3(3) and 6.4.3.(4) but for perimeter [$$u$$] [$$mm^2$$].
+            [$W$] Similar to [$W_1$] as defined in 6.4.3(3) and 6.4.3.(4) but for perimeter [$u$] [$mm^2$].
         """
         super().__init__()
         self.v_ed_red = v_ed_red

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_71.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_71.py
@@ -18,16 +18,16 @@ class Form6Dot71CriteriaBasedOnStressRangeLHS(Formula):
         gamma_f_fat: DIMENSIONLESS,
         delta_sigma_s_equ_n_star: MPA,
     ) -> None:
-        r"""[$$\Delta\sigma_{Ed}$$] Loading side of equation [$$MPa$$].
+        r"""[$\Delta\sigma_{Ed}$] Loading side of equation [$MPa$].
 
         NEN-EN 1993-1-1+C2:2011 art.6.8.5 - Formula (6.71)
 
         Parameters
         ----------
         gamma_f_fat : DIMENSIONLESS
-            [$$\gamma_{F,fat}$$] Partial factor for fatigue actions [$$-$$].
+            [$\gamma_{F,fat}$] Partial factor for fatigue actions [$-$].
         delta_sigma_s_equ_n_star : MPA
-            [$$\Delta\sigma_{s,equ}(N*)$$] Damage equivalent stress range for types of reinforcement and considering number of cycles N* [$$MPa$$].
+            [$\Delta\sigma_{s,equ}(N*)$] Damage equivalent stress range for types of reinforcement and considering number of cycles N* [$MPa$].
 
         Returns
         -------
@@ -68,16 +68,16 @@ class Form6Dot71CriteriaBasedOnStressRangeRHS(Formula):
         delta_sigma_rsk_n_star: MPA,
         gamma_s_fat: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\Delta\sigma_{Rd}$$] Resistance side of equation [$$MPa$$].
+        r"""[$\Delta\sigma_{Rd}$] Resistance side of equation [$MPa$].
 
         NEN-EN 1993-1-1+C2:2011 art.6.8.5 - Formula (6.71)
 
         Parameters
         ----------
         delta_sigma_rsk_n_star : MPA
-            [$$\Delta\sigma_{Rsk}(N*)$$] Stress range at N* cycles from the S-N curve in Figure 6.30 [$$MPa$$].
+            [$\Delta\sigma_{Rsk}(N*)$] Stress range at N* cycles from the S-N curve in Figure 6.30 [$MPa$].
         gamma_s_fat : DIMENSIONLESS
-            [$$\gamma_{S,fat}$$] Partial factor for reinforcing or prestressing steel under fatigue loading [$$-$$].
+            [$\gamma_{S,fat}$] Partial factor for reinforcing or prestressing steel under fatigue loading [$-$].
 
         Returns
         -------
@@ -118,20 +118,20 @@ class Form6Dot71CriteriaBasedOnStressRange:
         delta_sigma_rsk_n_star: MPA,
         gamma_s_fat: DIMENSIONLESS,
     ) -> None:
-        r"""[$$\text{CHECK}$$] Criteria met, based on damage accumulation.
+        r"""[$\text{CHECK}$] Criteria met, based on damage accumulation.
 
         NEN-EN 1993-1-1+C2:2011 art.6.8.5 - Formula (6.71)
 
         Parameters
         ----------
         gamma_f_fat : DIMENSIONLESS
-            [$$\gamma_{F,fat}$$] Partial factor for fatigue actions [$$-$$].
+            [$\gamma_{F,fat}$] Partial factor for fatigue actions [$-$].
         delta_sigma_s_equ_n_star : MPA
-            [$$\Delta\sigma_{s,equ}(N*)$$] Damage equivalent stress range for types of reinforcement and considering number of cycles N* [$$MPa$$].
+            [$\Delta\sigma_{s,equ}(N*)$] Damage equivalent stress range for types of reinforcement and considering number of cycles N* [$MPa$].
         delta_sigma_rsk_n_star : MPA
-            [$$\Delta\sigma_{Rsk}(N*)$$] Stress range at N* cycles from the S-N curve in Figure 6.30 [$$MPa$$].
+            [$\Delta\sigma_{Rsk}(N*)$] Stress range at N* cycles from the S-N curve in Figure 6.30 [$MPa$].
         gamma_s_fat : DIMENSIONLESS
-            [$$\gamma_{S,fat}$$] Partial factor for reinforcing or prestressing steel under fatigue loading [$$-$$].
+            [$\gamma_{S,fat}$] Partial factor for reinforcing or prestressing steel under fatigue loading [$-$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_76.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_6_ultimate_limit_state/formula_6_76.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form6Dot76DesignFatigueStrengthConcrete(Formula):
-    """Class representing formula 6.76 for the design fatigue strength of concrete, [$$f_{cd,fat}$$]."""
+    """Class representing formula 6.76 for the design fatigue strength of concrete, [$f_{cd,fat}$]."""
 
     label = "6.76"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -20,21 +20,21 @@ class Form6Dot76DesignFatigueStrengthConcrete(Formula):
         f_cd: MPA,
         f_ck: MPA,
     ) -> None:
-        r"""[$$f_{cd,fat}$$] Design fatigue strength of concrete in [$$MPa$$].
+        r"""[$f_{cd,fat}$] Design fatigue strength of concrete in [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art. 6.8.7(1) - Formula (6.76)
 
         Parameters
         ----------
         k_1 : DIMENSIONLESS
-            [$$k_{1}$$] k1 factor [$$-$$]
+            [$k_{1}$] k1 factor [$-$]
         beta_cc_t0 : DIMENSIONLESS
-            [$$β_{cc}(t_0)$$] Coefficient for concrete strength at first load application see (3.1.2 (6)) [$$-$$].
-            [$$t_0$$] The time of the start of the cyclic loading in concrete in days.
+            [$β_{cc}(t_0)$] Coefficient for concrete strength at first load application see (3.1.2 (6)) [$-$].
+            [$t_0$] The time of the start of the cyclic loading in concrete in days.
         f_cd : MPA
-            [$$f_{cd}$$] Design strength of concrete [$$MPa$$]
+            [$f_{cd}$] Design strength of concrete [$MPa$]
         f_ck : MPA
-            [$$f_{ck}$$] Characteristic strength of concrete [$$MPa$$]
+            [$f_{ck}$] Characteristic strength of concrete [$MPa$]
 
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_7_serviceability_limit_state/formula_7_3.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_7_serviceability_limit_state/formula_7_3.py
@@ -19,20 +19,20 @@ class Form7Dot3CoefficientKc(Formula):
         a_ct: MM2,
         f_ct_eff: MPA,
     ) -> None:
-        r"""[$$kc$$] Calculates kc for flanges of tubular cross-sections and T-sections [$$-$$].
+        r"""[$kc$] Calculates kc for flanges of tubular cross-sections and T-sections [$-$].
 
         NEN-EN 1992-1-1:2011 art.7.3.2(2) - Formula (7.3)
 
         Parameters
         ----------
         f_cr : KN
-            [$$F_{cr}$$] Absolute value of the tensile force within the flange immediately before cracking due to the cracking moment calculated with
-            [$$f_{ct,eff}$$] [$$kN$$].
+            [$F_{cr}$] Absolute value of the tensile force within the flange immediately before cracking due to the cracking moment calculated with
+            [$f_{ct,eff}$] [$kN$].
         a_ct : MM2
-            [$$A_{ct}$$] Area of the concrete within the tension zone. The tension zone is that part of the cross-section that,
-            according to the calculation, is under tension just before the first crack occurs [$$mm^2$$].
+            [$A_{ct}$] Area of the concrete within the tension zone. The tension zone is that part of the cross-section that,
+            according to the calculation, is under tension just before the first crack occurs [$mm^2$].
         f_ct_eff : MPA
-            [$$f_{ct,eff}$$] Average value of the tensile strength of the concrete at the time when the first cracks can be expected [$$MPa$$].
+            [$f_{ct,eff}$] Average value of the tensile strength of the concrete at the time when the first cracks can be expected [$MPa$].
         """
         super().__init__()
         self.f_cr = f_cr

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_1.py
@@ -23,23 +23,23 @@ class Form8Dot1RequiredMinimumMandrelDiameter(Formula):
         diameter: MM,
         f_cd: MPA,
     ) -> None:
-        r"""[$$\Ø_{m,min}$$] minimum mandrel diameter if it needs to be checked to avoid concrete failure [$$MM$$].
+        r"""[$\Ø_{m,min}$] minimum mandrel diameter if it needs to be checked to avoid concrete failure [$MM$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.3(3) - Formula (8.1)
 
         Parameters
         ----------
         f_bt: KN
-            [$$F_{bt}$$] Tensile force from ultimate loads in a bar or group of bars in contact at the start of a bend  [$$kN$$].
+            [$F_{bt}$] Tensile force from ultimate loads in a bar or group of bars in contact at the start of a bend  [$kN$].
         a_b: MM
-            [$$a_b$$] Half of the centre-to-centre distance between bars (or groups of bars) perpendicular
+            [$a_b$] Half of the centre-to-centre distance between bars (or groups of bars) perpendicular
             to the plane of the bend for a given bar (or group of bars in contact).
-            For a bar or group of bars adjacent to the face of the member, [$$a_b$$] should be taken as the cover plus [$$\Ø/2$$] [$$mm$$].
+            For a bar or group of bars adjacent to the face of the member, [$a_b$] should be taken as the cover plus [$\Ø/2$] [$mm$].
         diameter: MM
-            [$$\Ø$$] Diameter of reinforcing bar [$$mm$$].
+            [$\Ø$] Diameter of reinforcing bar [$mm$].
         f_cd: MPA
-            [$$f_{cd}$$] Design value of concrete compressive stress [$$MPa$$].
-            Note: The value of [$$f_{cd}$$] should not be taken greater than that for concrete class C55/67.
+            [$f_{cd}$] Design value of concrete compressive stress [$MPa$].
+            Note: The value of [$f_{cd}$] should not be taken greater than that for concrete class C55/67.
         """
         super().__init__()
         self.f_bt = f_bt

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_10.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_10.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form8Dot10DesignLapLength(Formula):
-    r"""Class representing formula 8.10 for the calculation of the design lap length [$$l_{0}$$] [$$mm$$]."""
+    r"""Class representing formula 8.10 for the calculation of the design lap length [$l_{0}$] [$mm$]."""
 
     label = "8.10"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -23,74 +23,74 @@ class Form8Dot10DesignLapLength(Formula):
         l_b_rqd: MM,
         l_0_min: MM,
     ) -> None:
-        r"""[$$l_{0}$$] Design lap length [$$mm$$].
+        r"""[$l_{0}$] Design lap length [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.7.3(1) - Formula (8.10)
 
         Parameters
         ----------
         alpha_1 : DIMENSIONLESS
-            [$$α_{1}$$] Coefficient for the effect of the form of the bars assuming adequate cover (see figure 8.1) [$$-$$].
+            [$α_{1}$] Coefficient for the effect of the form of the bars assuming adequate cover (see figure 8.1) [$-$].
 
-            [$$= 1.0$$] for bars in compression.
+            [$= 1.0$] for bars in compression.
 
-            [$$= 1.0$$] for straight bars in tension.
+            [$= 1.0$] for straight bars in tension.
 
-            [$$= 1.0$$] if [$$c_{d} <= 3 ⋅ Ø$$] for bars other than straight in tension (see figure 8.1 (b), (c) and (d)).
+            [$= 1.0$] if [$c_{d} <= 3 ⋅ Ø$] for bars other than straight in tension (see figure 8.1 (b), (c) and (d)).
 
-            [$$= 0.7$$] if [$$c_{d} > 3 ⋅ Ø$$] for bars other than straight in tension (see figure 8.1 (b), (c) and (d)).
+            [$= 0.7$] if [$c_{d} > 3 ⋅ Ø$] for bars other than straight in tension (see figure 8.1 (b), (c) and (d)).
 
-            Note: see figure 8.3 for values of [$$c_{d}$$].
+            Note: see figure 8.3 for values of [$c_{d}$].
         alpha_2 : DIMENSIONLESS
-            [$$α_{2}$$] Coefficient for the effect of minimum concrete cover (see figure 8.3) [$$-$$].
+            [$α_{2}$] Coefficient for the effect of minimum concrete cover (see figure 8.3) [$-$].
 
-            [$$= 1.0$$] for bars in compression.
+            [$= 1.0$] for bars in compression.
 
-            [$$= 1 - 0.15 ⋅ (c_{d} - Ø) / Ø <= 1$$] with a minimum of 0.7 for straight bars in tension.
+            [$= 1 - 0.15 ⋅ (c_{d} - Ø) / Ø <= 1$] with a minimum of 0.7 for straight bars in tension.
 
-            [$$= 1 - 0.15 ⋅ (c_{d} - 3 ⋅ Ø) / Ø <= 1$$] with a minimum of 0.7 for bars other than straight in tension
+            [$= 1 - 0.15 ⋅ (c_{d} - 3 ⋅ Ø) / Ø <= 1$] with a minimum of 0.7 for bars other than straight in tension
             (see figure 8.1 (b), (c) and (d)).
 
-            Note: see figure 8.3 for values of [$$c_{d}$$].
+            Note: see figure 8.3 for values of [$c_{d}$].
         alpha_3 : DIMENSIONLESS
-            [$$α_{3}$$] Coefficient for the effect of confinement by transverse reinforcement [$$-$$].
+            [$α_{3}$] Coefficient for the effect of confinement by transverse reinforcement [$-$].
 
-            [$$= 1.0$$] for bars in compression.
+            [$= 1.0$] for bars in compression.
 
-            [$$= 1 - K ⋅ λ <= 1$$] with a minimum of 0.7 for bars in tension.
+            [$= 1 - K ⋅ λ <= 1$] with a minimum of 0.7 for bars in tension.
 
-            Where: [$$λ = (ΣA_{st} - ΣA_{st,min}) / A_{s}$$].
+            Where: [$λ = (ΣA_{st} - ΣA_{st,min}) / A_{s}$].
 
-            Where: [$$ΣA_{st,min} = A_{s} ⋅ (σ_{sd}/f_{yd})$$]
+            Where: [$ΣA_{st,min} = A_{s} ⋅ (σ_{sd}/f_{yd})$]
 
-            With [$$A_{s}$$] = area of one lapped bar [$$mm²$$].
+            With [$A_{s}$] = area of one lapped bar [$mm²$].
 
-            Note: see figure 8.4 for values of [$$K, A_{s}$$] and [$$A_{st}$$].
+            Note: see figure 8.4 for values of [$K, A_{s}$] and [$A_{st}$].
         alpha_5 : DIMENSIONLESS
-            [$$α_{5}$$] Coefficient for the effect of the pressure transverse to the plane of splitting along the design
-            anchorage length [$$l_{bd}$$] (see 8.6) [$$-$$].
+            [$α_{5}$] Coefficient for the effect of the pressure transverse to the plane of splitting along the design
+            anchorage length [$l_{bd}$] (see 8.6) [$-$].
 
-            [$$= 1 - 0.04 ⋅ p <= 1$$] with a minimum of 0.7 for all types of anchorage in compression.
+            [$= 1 - 0.04 ⋅ p <= 1$] with a minimum of 0.7 for all types of anchorage in compression.
 
-            Where: p = transverse pressure at ultimate limit state along [$$l_{bd}$$] [$$MPa$$].
+            Where: p = transverse pressure at ultimate limit state along [$l_{bd}$] [$MPa$].
         alpha_6 : DIMENSIONLESS
-            [$$α_{6}$$] Coefficient for the effect of reinforcement ratio [$$-$$].
+            [$α_{6}$] Coefficient for the effect of reinforcement ratio [$-$].
 
-            [$$= (ρ_{1}/25)^{0.5} <= 1.5$$] with a minimum of 1.0.
+            [$= (ρ_{1}/25)^{0.5} <= 1.5$] with a minimum of 1.0.
 
-            Where: [$$ρ_{1}$$] = reinforcement percentage lapped within [$$0,65 ⋅ l_{0}$$] from the centre of the lap length
-            considered (see figure 8.8) [$$-$$].
+            Where: [$ρ_{1}$] = reinforcement percentage lapped within [$0,65 ⋅ l_{0}$] from the centre of the lap length
+            considered (see figure 8.8) [$-$].
 
             Use your own implementation of this formula or use the :class:`SubForm8Dot10Alpha6` class.
         l_b_rqd : MM
-            [$$l_{b,rqd}$$] Basic required anchorage length, for anchoring the force [$$A_{s} ⋅ σ_{sd}$$] in a straight bar assuming constant
-            bond stress (formula 8.3) [$$mm$$].
+            [$l_{b,rqd}$] Basic required anchorage length, for anchoring the force [$A_{s} ⋅ σ_{sd}$] in a straight bar assuming constant
+            bond stress (formula 8.3) [$mm$].
 
             Use your own implementation for this value or use the :class:`Form8Dot3RequiredAnchorageLength` class.
         l_0_min : MM
-            [$$l_{0,min}$$] Minimum design lap length [$$mm$$].
+            [$l_{0,min}$] Minimum design lap length [$mm$].
 
-            [$$= max(0.3 ⋅ α_{6} ⋅ l_{b,rqd}, 15 ⋅ Ø, 200)$$] (formula 8.11).
+            [$= max(0.3 ⋅ α_{6} ⋅ l_{b,rqd}, 15 ⋅ Ø, 200)$] (formula 8.11).
 
             Use your own implementation of this formula or use :class:`Form8Dot11MinimumDesignLapLength` class.
         """
@@ -141,21 +141,21 @@ class Form8Dot10DesignLapLength(Formula):
 
 
 class SubForm8Dot10Alpha6(Formula):
-    r"""Class representing the formula for the calculation of the coefficient [$$α_{6}$$]."""
+    r"""Class representing the formula for the calculation of the coefficient [$α_{6}$]."""
 
     label = "8.8"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, rho_1: DIMENSIONLESS) -> None:
-        r"""[$$α_{6}$$] Coefficient for the effect of reinforcement ratio [$$-$$].
+        r"""[$α_{6}$] Coefficient for the effect of reinforcement ratio [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.7.3(1) - Formula (8.8)
 
         Parameters
         ----------
         rho_1 : DIMENSIONLESS
-            [$$ρ_{1}$$] Reinforcement percentage lapped within [$$0,65 ⋅ l_{0}$$] from the centre of the lap length
-            considered (see figure 8.8) [$$-$$].
+            [$ρ_{1}$] Reinforcement percentage lapped within [$0,65 ⋅ l_{0}$] from the centre of the lap length
+            considered (see figure 8.8) [$-$].
         """
         super().__init__()
         self.rho_1 = rho_1

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_11.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_11.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form8Dot11MinimumDesignLapLength(Formula):
-    """Class representing formula 8.11 for the calculation of the minimum design lap length [$$l_{0,min}$$] [$$mm$$]."""
+    """Class representing formula 8.11 for the calculation of the minimum design lap length [$l_{0,min}$] [$mm$]."""
 
     label = "8.11"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -19,28 +19,28 @@ class Form8Dot11MinimumDesignLapLength(Formula):
         l_b_rqd: MM,
         diameter: MM,
     ) -> None:
-        r"""[$$l_{0,min}$$] Design minimum lap length [$$mm$$].
+        r"""[$l_{0,min}$] Design minimum lap length [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.7.3(1) - Formula (8.11)
 
         Parameters
         ----------
         alpha_6 : DIMENSIONLESS
-            [$$α_6$$] Coefficient for the effect of reinforcement ratio [$$-$$].
+            [$α_6$] Coefficient for the effect of reinforcement ratio [$-$].
 
-            [$$= (\rho_l/25)^{0.5} \leq 1.5$$] with a minimum of 1.0.
+            [$= (\rho_l/25)^{0.5} \leq 1.5$] with a minimum of 1.0.
 
-            Where: [$$\rho_l$$] = reinforcement percentage lapped within [$$0.65 \cdot l_0$$] from the centre of the lap length
-            considered (see figure 8.8) [$$-$$].
+            Where: [$\rho_l$] = reinforcement percentage lapped within [$0.65 \cdot l_0$] from the centre of the lap length
+            considered (see figure 8.8) [$-$].
 
             Use your own implementation for this value or use the :class:`SubForm8Dot10Alpha6` class.
         l_b_rqd: MM
-            [$$l_{b,rqd}$$] Basic required anchorage length, for anchoring the force [$$A_s \cdot \sigma_{sd}$$] in a straight bar assuming constant
-            bond stress (formula 8.3) [$$mm$$].
+            [$l_{b,rqd}$] Basic required anchorage length, for anchoring the force [$A_s \cdot \sigma_{sd}$] in a straight bar assuming constant
+            bond stress (formula 8.3) [$mm$].
 
             Use your own implementation for this value or use the :class:`Form8Dot3RequiredAnchorageLength` class.
         diameter : MM
-            [$$Ø$$] Diameter of the bar [$$mm$$].
+            [$Ø$] Diameter of the bar [$mm$].
         """
         super().__init__()
         self.alpha_6 = alpha_6

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_12.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_12.py
@@ -20,17 +20,17 @@ class Form8Dot12AdditionalShearReinforcement(Formula):
         a_s: MM2,
         n_1: DIMENSIONLESS,
     ) -> None:
-        r"""[$$A_{sh}$$] Minimum additional shear reinforcement in the anchorage zones where transverse compression is not present for straight
-        anchorage lengths, in the direction parallel to the tension face [$$mm^2$$].
+        r"""[$A_{sh}$] Minimum additional shear reinforcement in the anchorage zones where transverse compression is not present for straight
+        anchorage lengths, in the direction parallel to the tension face [$mm^2$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.8(6) - Formula (8.12)
 
         Parameters
         ----------
         a_s: MM2
-            [$$A_{s}$$] Cross sectional area of reinforcement [$$mm²$$].
+            [$A_{s}$] Cross sectional area of reinforcement [$mm²$].
         n_1: DIMENSIONLESS
-            [$$n_{1}$$] Number of layers with bars anchored at the same point in the member [$$-$$].
+            [$n_{1}$] Number of layers with bars anchored at the same point in the member [$-$].
         """
         super().__init__()
         self.a_s = a_s

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_13.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_13.py
@@ -20,17 +20,17 @@ class Form8Dot13AdditionalShearReinforcement(Formula):
         a_s: MM2,
         n_2: DIMENSIONLESS,
     ) -> None:
-        r"""[$$A_{sh}$$] Minimum additional shear reinforcement in the anchorage zones where transverse compression is not present for straight
-        anchorage lengths, in the direction perpendicular to the tension face [$$mm^2$$].
+        r"""[$A_{sh}$] Minimum additional shear reinforcement in the anchorage zones where transverse compression is not present for straight
+        anchorage lengths, in the direction perpendicular to the tension face [$mm^2$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.8(6) - Formula (8.12)
 
         Parameters
         ----------
         a_s: MM2
-            [$$A_{s}$$] Cross sectional area of reinforcement [$$mm^2$$].
+            [$A_{s}$] Cross sectional area of reinforcement [$mm^2$].
         n_2: DIMENSIONLESS
-            [$$n_{2}$$] Number of bars anchored in each layer [$$-$$].
+            [$n_{2}$] Number of bars anchored in each layer [$-$].
         """
         super().__init__()
         self.a_s = a_s

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_14.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_14.py
@@ -10,7 +10,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form8Dot14EquivalentDiameterBundledBars(Formula):
-    """Class representing formula 8.14 for the calculation of the equivalent diameter of bundled bars, [$$Ø_{n}$$]."""
+    """Class representing formula 8.14 for the calculation of the equivalent diameter of bundled bars, [$Ø_{n}$]."""
 
     label = "8.14"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -20,16 +20,16 @@ class Form8Dot14EquivalentDiameterBundledBars(Formula):
         diameter: MM,
         n_b: DIMENSIONLESS,
     ) -> None:
-        r"""[$$Ø_{n}$$] Equivalent diameter of bundled bars [$$mm$$].
+        r"""[$Ø_{n}$] Equivalent diameter of bundled bars [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.9.1(2) - Formula (8.14)
 
         Parameters
         ----------
         diameter : MM
-            [$$Ø$$] Diameter of the bars [$$mm$$]
+            [$Ø$] Diameter of the bars [$mm$]
         n_b : DIMENSIONLESS
-            [$$n_{b}$$] Number of bars in the bundle [$$-$$].
+            [$n_{b}$] Number of bars in the bundle [$-$].
 
             ≤ 4 for vertical bars in compression and for bars in a lapped joint.
 

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_15.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_15.py
@@ -21,24 +21,24 @@ class Form8Dot15PrestressTransferStress(Formula):
         eta_1: DIMENSIONLESS,
         f_ctd_t: MPA,
     ) -> None:
-        r"""[$$f_{bpt}$$] Constant bond stress at which prestress is assumed to be transferred to the concrete [$$MPa$$].
+        r"""[$f_{bpt}$] Constant bond stress at which prestress is assumed to be transferred to the concrete [$MPa$].
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(1) - Formula (8.15).
 
         Parameters
         ----------
         eta_p1 : DIMENSIONLESS
-            [$$\eta_{p1}$$] Coefficient that takes into account the type of tendon and the bond situation at release [$$-$$].
+            [$\eta_{p1}$] Coefficient that takes into account the type of tendon and the bond situation at release [$-$].
             = 2.7 for indented wires.
             = 3.2 for 3 and 7-wire strands
             Use your own implementation for this value or use :class:`SubForm8Dot15EtaP1` class.
         eta_1 : DIMENSIONLESS
-            [$$\eta_1$$] Coefficient related to the quality of the bond condition and the position of bar during concreting (see Figure 8.2) [$$-$$].
+            [$\eta_1$] Coefficient related to the quality of the bond condition and the position of bar during concreting (see Figure 8.2) [$-$].
             = 1 when 'good' conditions are obtained;
             = 0.7 other cases and for bars in structural elements built with slip-forms, unless it can be shown that 'good' bond conditions exist;
             Use your own implementation of this formula or use the :class:`SubForm8Dot2CoefficientQualityOfBond` class.
         f_ctd_t : MPA
-            [$$f_{ctd}(t)$$] Design tensile value of strength at time of release [$$MPa$$].
-            = [$$\alpha_{ct} \cdot 0.7 \cdot f_{ctm}(t) / \gamma_{c}$$] (see 3.1.2(9) and 3.1.6(2)P)
+            [$f_{ctd}(t)$] Design tensile value of strength at time of release [$MPa$].
+            = [$\alpha_{ct} \cdot 0.7 \cdot f_{ctm}(t) / \gamma_{c}$] (see 3.1.2(9) and 3.1.6(2)P)
             Use your own implementation for this value or use :class:`SubForm8Dot15TensileStrengthAtRelease` class.
         """
         super().__init__()
@@ -83,7 +83,7 @@ class SubForm8Dot15EtaP1(Formula):
         self,
         type_of_wire: str,
     ) -> None:
-        r"""[$$\eta_{p1}$$] Coefficient that takes into account the type of tendon and the bond situation at release [$$-$$].
+        r"""[$\eta_{p1}$] Coefficient that takes into account the type of tendon and the bond situation at release [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(1) - Formula (8.15)
 
@@ -135,23 +135,23 @@ class SubForm8Dot15TensileStrengthAtRelease(Formula):
         f_ctm_t: MPA,
         gamma_c: DIMENSIONLESS,
     ) -> None:
-        r"""[$$f_{ctd}(t)$$] Design tensile value of strength at time of release [$$MPa$$].
+        r"""[$f_{ctd}(t)$] Design tensile value of strength at time of release [$MPa$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(1) - Formula (8.15)
 
         Parameters
         ----------
         alpha_ct : DIMENSIONLESS
-            [$$\alpha_{ct}$$] coefficient taking account of long term effects on the tensile strength and of unfavourable effects, resulting from the
-            way the load is applied. [$$-$$].
+            [$\alpha_{ct}$] coefficient taking account of long term effects on the tensile strength and of unfavourable effects, resulting from the
+            way the load is applied. [$-$].
 
             Value may be found in national annex. Recommended value: 1.0
         f_ctm_t : MPA
-            [$$f_{ctm}(t)$$] Mean value of tensile strength at time of release (see formula 3.4) [$$MPa$$].
+            [$f_{ctm}(t)$] Mean value of tensile strength at time of release (see formula 3.4) [$MPa$].
 
             Use your own implementation for this value or use :class:`Form3Dot4DevelopmentTensileStrength` class.
         gamma_c : DIMENSIONLESS
-            [$$\gamma_{c}$$] Partial safety factor for concrete [$$-$$].
+            [$\gamma_{c}$] Partial safety factor for concrete [$-$].
         """
         super().__init__()
         self.alpha_ct = alpha_ct

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_16.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_16.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form8Dot16BasicTransmissionLength(Formula):
-    r"""Class representing formula 8.16 for the calculation of the basic transmission length [$$l_{pt}$$]."""
+    r"""Class representing formula 8.16 for the calculation of the basic transmission length [$l_{pt}$]."""
 
     label = "8.16"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -21,14 +21,14 @@ class Form8Dot16BasicTransmissionLength(Formula):
         sigma_pm0: MPA,
         f_bpt: MPA,
     ) -> None:
-        r"""[$$l_{pt}$$] Basic value of the transmission length [$$mm$$].
+        r"""[$l_{pt}$] Basic value of the transmission length [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(2) - Formula (8.16)
 
         Parameters
         ----------
         alpha_1 : DIMENSIONLESS
-            [$$α_{1}$$] Coefficient taking account of the type of release [$$-$$].
+            [$α_{1}$] Coefficient taking account of the type of release [$-$].
 
             = 1.0 for gradual release;
 
@@ -36,7 +36,7 @@ class Form8Dot16BasicTransmissionLength(Formula):
 
             Use your own implementation for this value or use :class:`SubForm8Dot16Alpha1` class.
         alpha_2 : DIMENSIONLESS
-            [$$α_{2}$$] Coefficient taking account of the type of prestressing steel [$$-$$].
+            [$α_{2}$] Coefficient taking account of the type of prestressing steel [$-$].
 
             = 0.25 for tendons with circular cross-section;
 
@@ -44,11 +44,11 @@ class Form8Dot16BasicTransmissionLength(Formula):
 
             Use your own implementation for this value or use :class:`SubForm8Dot16Alpha2` class.
         diameter : MM
-            [$$Ø$$] Nominal diameter of the tendon [$$mm$$].
+            [$Ø$] Nominal diameter of the tendon [$mm$].
         sigma_pm0 : MPA
-            [$$σ_{pm0}$$] Tendon stress at time of release [$$MPa$$].
+            [$σ_{pm0}$] Tendon stress at time of release [$MPa$].
         f_bpt : MPA
-            [$$f_{bpt}$$] Constant bond stress at which prestress is assumed to be transferred to the concrete [$$MPa$$]
+            [$f_{bpt}$] Constant bond stress at which prestress is assumed to be transferred to the concrete [$MPa$]
 
             Use your own implementation for this value or use :class:`Form8Dot15PrestressTransferStress` class.
         """
@@ -91,13 +91,13 @@ class Form8Dot16BasicTransmissionLength(Formula):
 
 
 class SubForm8Dot16Alpha1(Formula):
-    r"""Class representing sub-formula 8.16 for the calculation of the coefficient [$$α_{1}$$]."""
+    r"""Class representing sub-formula 8.16 for the calculation of the coefficient [$α_{1}$]."""
 
     label = "8.16"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, release_type: str) -> None:
-        r"""[$$α_{1}$$] Coefficient taking account of the type of release [$$-$$].
+        r"""[$α_{1}$] Coefficient taking account of the type of release [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(2) - Formula (8.16)
 
@@ -132,7 +132,7 @@ class SubForm8Dot16Alpha1(Formula):
 
 
 class SubForm8Dot16Alpha2(Formula):
-    r"""Class representing sub-formula 8.16 for the calculation of the coefficient [$$α_{2}$$]."""
+    r"""Class representing sub-formula 8.16 for the calculation of the coefficient [$α_{2}$]."""
 
     label = "8.16"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -141,7 +141,7 @@ class SubForm8Dot16Alpha2(Formula):
         self,
         type_of_wire: str,
     ) -> None:
-        r"""[$$α_{2}$$] Coefficient that takes into account the type of wires in the cross-section [$$-$$].
+        r"""[$α_{2}$] Coefficient that takes into account the type of wires in the cross-section [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(2) - Formula (8.16)
 

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_17.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_17.py
@@ -8,22 +8,22 @@ from blueprints.validations import raise_if_negative
 
 
 class Form8Dot17DesignValueTransmissionLength1(Formula):
-    r"""Class representing formula 8.17 for the calculation of design value 1 of the transmission length [$$l_{pt1}$$]. The less favourable of
-    [$$l_{pt1}$$] or [$$l_{pt2}$$] has to be chosen depending on the design situation.
+    r"""Class representing formula 8.17 for the calculation of design value 1 of the transmission length [$l_{pt1}$]. The less favourable of
+    [$l_{pt1}$] or [$l_{pt2}$] has to be chosen depending on the design situation.
     """
 
     label = "8.17"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, l_pt: MM) -> None:
-        r"""[$$l_{pt1}$$] design value 1 of the transmission length [$$mm$$].
+        r"""[$l_{pt1}$] design value 1 of the transmission length [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(3) - Formula (8.17)
 
         Parameters
         ----------
         l_pt : MM
-            [$$l_{pt}$$] Basic value of the transmission length [$$mm$$].
+            [$l_{pt}$] Basic value of the transmission length [$mm$].
             Use your own implementation for this value or use :class:`Form8Dot16BasicTransmissionLength` class.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_18.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_18.py
@@ -8,22 +8,22 @@ from blueprints.validations import raise_if_negative
 
 
 class Form8Dot18DesignValueTransmissionLength2(Formula):
-    r"""Class representing formula 8.18 for the calculation of design value 2 of the transmission length [$$l_{pt2}$$]. The less favourable of
-    [$$l_{pt1}$$] or [$$l_{pt2}$$] has to be chosen depending on the design situation.
+    r"""Class representing formula 8.18 for the calculation of design value 2 of the transmission length [$l_{pt2}$]. The less favourable of
+    [$l_{pt1}$] or [$l_{pt2}$] has to be chosen depending on the design situation.
     """
 
     label = "8.18"
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, l_pt: MM) -> None:
-        r"""[$$l_{pt2}$$] design value 2 of the transmission length [$$mm$$].
+        r"""[$l_{pt2}$] design value 2 of the transmission length [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(3) - Formula (8.18)
 
         Parameters
         ----------
         l_pt : MM
-            [$$l_{pt}$$] Basic value of the transmission length [$$mm$$].
+            [$l_{pt}$] Basic value of the transmission length [$mm$].
             Use your own implementation for this value or use :class:`Form8Dot16BasicTransmissionLength` class.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_19.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_19.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form8Dot19DispersionLength(Formula):
-    """Class representing formula 8.19 for the calculation of dispersion length [$$l_{disp}$$]."""
+    """Class representing formula 8.19 for the calculation of dispersion length [$l_{disp}$]."""
 
     label = "8.19"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -18,16 +18,16 @@ class Form8Dot19DispersionLength(Formula):
         l_pt: M,
         d: M,
     ) -> None:
-        r"""[$$l_{disp}$$] Dispersion length for prestressing tendons [$$m$$].
+        r"""[$l_{disp}$] Dispersion length for prestressing tendons [$m$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(4) - Formula (8.19)
 
         Parameters
         ----------
         l_pt : M
-            [$$l_{disp}$$] Length of prestressing tendon [$$m$$].
+            [$l_{disp}$] Length of prestressing tendon [$m$].
         d : M
-            [$$d$$] Diameter of the tendon [$$m$$].
+            [$d$] Diameter of the tendon [$m$].
         """
         super().__init__()
         self.l_pt = l_pt

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_2.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_2.py
@@ -19,26 +19,26 @@ class Form8Dot2UltimateBondStress(Formula):
         eta_2: DIMENSIONLESS,
         f_ctd: MPA,
     ) -> None:
-        r"""[$$f_{bd}$$] The design value of the ultimate bond stress for ribbed bars [$$-$$].
+        r"""[$f_{bd}$] The design value of the ultimate bond stress for ribbed bars [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.4.2(2) - Formula (8.2)
 
         Parameters
         ----------
         eta_1 : DIMENSIONLESS
-            [$$η_1$$] coefficient related to the quality of the bond condition and the position of the bar during concreting (see Figure 8.2) [$$-$$].
-            = [$$1$$] when ‘good’ conditions are obtained;
-            = [$$1$$] other cases and for bars in structural elements built with slip-forms, unless it can be shown that ‘good’ bond conditions
+            [$η_1$] coefficient related to the quality of the bond condition and the position of the bar during concreting (see Figure 8.2) [$-$].
+            = [$1$] when ‘good’ conditions are obtained;
+            = [$1$] other cases and for bars in structural elements built with slip-forms, unless it can be shown that ‘good’ bond conditions
             exist;
             Use your own implementation of this formula or use the SubForm8Dot2CoefficientQualityOfBond class.
         eta_2 : DIMENSIONLESS
-            [$$η_2$$] A factor related to the bar diameter [$$-$$].
-            = [$$1$$] for bars with a diameter ≤ [$$32 \text{mm}$$];
-            = [$$(132 - Ø) / 100$$] for bars with a diameter > [$$32 \text{mm}$$].
+            [$η_2$] A factor related to the bar diameter [$-$].
+            = [$1$] for bars with a diameter ≤ [$32 \text{mm}$];
+            = [$(132 - Ø) / 100$] for bars with a diameter > [$32 \text{mm}$].
             Use your own implementation of this value or use the SubForm8Dot2CoefficientBarDiameter class.
         f_ctd : MPA
-            [$$f_{ctd}$$] Design tensile strength of concrete according to art.3.1.6(2) [$$MPa$$].
-            Due to the increasing brittleness of higher strength concrete, [$$f_{ctk,0,05}$$] should be limited here to the value for C60/75, unless
+            [$f_{ctd}$] Design tensile strength of concrete according to art.3.1.6(2) [$MPa$].
+            Due to the increasing brittleness of higher strength concrete, [$f_{ctk,0,05}$] should be limited here to the value for C60/75, unless
             it can be verified that the average bond strength increases above this limit.
         """
         super().__init__()
@@ -74,7 +74,7 @@ class SubForm8Dot2CoefficientQualityOfBond(Formula):
     label = "8.2"
 
     def __init__(self, bond_quality: str) -> None:
-        r"""[$$η_1$$] Coefficient that depends on the type of cement [$$-$$].
+        r"""[$η_1$] Coefficient that depends on the type of cement [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.4.2(2) - η1
 
@@ -108,14 +108,14 @@ class SubForm8Dot2CoefficientBarDiameter(Formula):
     label = "8.2"
 
     def __init__(self, diameter: MM) -> None:
-        r"""[$$η_2$$] Coefficient that depends on the bar diameter [$$-$$].
+        r"""[$η_2$] Coefficient that depends on the bar diameter [$-$].
 
-        NEN-EN 1992-1-1+C2:2011 art.8.4.2(2) - [$$η_2$$]
+        NEN-EN 1992-1-1+C2:2011 art.8.4.2(2) - [$η_2$]
 
         Parameters
         ----------
         diameter : MM
-            [$$Ø$$] Diameter of the bar [$$mm$$].
+            [$Ø$] Diameter of the bar [$mm$].
         """
         super().__init__()
         self.diameter = diameter

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_20.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_20.py
@@ -8,20 +8,20 @@ from blueprints.validations import raise_if_negative
 
 
 class Form8Dot20BondStrengthAnchorageULS(Formula):
-    r"""Class representing formula 8.20 for the calculation of bond strength for anchorage in the ultimate limit state [$$f_{bpd}$$].
+    r"""Class representing formula 8.20 for the calculation of bond strength for anchorage in the ultimate limit state [$f_{bpd}$].
 
     NEN-EN 1992-1-1+C2:2011 art.8.10.2.2(3) - Formula (8.20)
 
     Parameters
     ----------
     eta_p2 : DIMENSIONLESS
-        [$$\eta_{p2}$$] Coefficient that takes into account the type of tendon and the bond situation at anchorage [$$-$$].
+        [$\eta_{p2}$] Coefficient that takes into account the type of tendon and the bond situation at anchorage [$-$].
 
         1.4 for indented wires or 1.2 for 7-wire strands.
     eta_1 : DIMENSIONLESS
-        [$$\eta_{1}$$] Coefficient for concrete, defined in 8.10.2.2 (1) [$$-$$].
+        [$\eta_{1}$] Coefficient for concrete, defined in 8.10.2.2 (1) [$-$].
     f_ctd : MPA
-        Design tensile strength of concrete [$$MPa$$].
+        Design tensile strength of concrete [$MPa$].
     """
 
     label = "8.20"

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_21.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_21.py
@@ -8,24 +8,24 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form8Dot21AnchorageLength(Formula):
-    r"""Class representing formula 8.21 for the calculation of anchorage length [$$l_{bpd}$$] [$$mm$$].
+    r"""Class representing formula 8.21 for the calculation of anchorage length [$l_{bpd}$] [$mm$].
 
     NEN-EN 1992-1-1+C2:2011 art.8.10.2.3(4) - Formula (8.21)
 
     Parameters
     ----------
     l_pt2 : MM
-        [$$l_{pt2}$$] is the upper design value of transmission length, see 8.10.2.2 (3) [$$mm$$].
+        [$l_{pt2}$] is the upper design value of transmission length, see 8.10.2.2 (3) [$mm$].
     alpha_2 : DIMENSIONLESS
-        [$$\alpha_{2}$$] as defined in 8.10.2.2 (2) [$$-$$].
+        [$\alpha_{2}$] as defined in 8.10.2.2 (2) [$-$].
     diameter : MM
-        [$$Ø$$] Diameter of the tendon [$$mm$$].
+        [$Ø$] Diameter of the tendon [$mm$].
     sigma_pd : MPA
-        [$$\sigma_{pd}$$] Is the tendon stress corresponding to the force described in art.8.10.2.3(1) [$$MPa$$].
+        [$\sigma_{pd}$] Is the tendon stress corresponding to the force described in art.8.10.2.3(1) [$MPa$].
     sigma_pminf : MPA
-        [$$\sigma_{pm\infty}$$] is the prestress after all losses [$$MPa$$].
+        [$\sigma_{pm\infty}$] is the prestress after all losses [$MPa$].
     f_bpd : MPA
-        [$$f_{bpd}$$] Bond strength for anchorage in the ultimate limit state [$$MPa$$].
+        [$f_{bpd}$] Bond strength for anchorage in the ultimate limit state [$MPa$].
     """
 
     label = "8.21"

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_3.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_3.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form8Dot3RequiredAnchorageLength(Formula):
-    r"""Class representing formula 8.3 for the calculation of the basic required anchorage length, assuming constant bond stress [$$f_{bd}$$]."""
+    r"""Class representing formula 8.3 for the calculation of the basic required anchorage length, assuming constant bond stress [$f_{bd}$]."""
 
     label = "8.3"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -19,19 +19,19 @@ class Form8Dot3RequiredAnchorageLength(Formula):
         sigma_sd: MPA,
         f_bd: MPA,
     ) -> None:
-        r"""[$$l_{b,rqd}$$] Basic required anchorage length, for anchoring the force [$$A_{s} \cdot \sigma_{sd}$$] in a straight bar assuming
-        constant bond stress [$$f_{bd}$$]. [mm].
+        r"""[$l_{b,rqd}$] Basic required anchorage length, for anchoring the force [$A_{s} \cdot \sigma_{sd}$] in a straight bar assuming
+        constant bond stress [$f_{bd}$]. [mm].
 
         NEN-EN 1992-1-1+C2:2011 art.8.4.3(2) - Formula (8.3)
 
         Parameters
         ----------
         diameter: MM
-            [$$Ø$$] Diameter of the bar [mm].
+            [$Ø$] Diameter of the bar [mm].
         sigma_sd: MPA
-            [$$\sigma_{sd}$$] design stress of the bar at the position from where the anchorage is measured from [MPa].
+            [$\sigma_{sd}$] design stress of the bar at the position from where the anchorage is measured from [MPa].
         f_bd: MPA
-            [$$f_{bd}$$] Design value ultimate bond stress [MPa].
+            [$f_{bd}$] Design value ultimate bond stress [MPa].
             Use your own implementation for this value or use the Form8Dot2UltimateBondStress class.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_4.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_4.py
@@ -11,7 +11,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form8Dot4DesignAnchorageLength(Formula):
-    r"""Class representing formula 8.4 for the calculation of the design anchorage length [$$l_{bd}$$] [$$mm$$]."""
+    r"""Class representing formula 8.4 for the calculation of the design anchorage length [$l_{bd}$] [$mm$]."""
 
     label = "8.4"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -27,61 +27,61 @@ class Form8Dot4DesignAnchorageLength(Formula):
         l_b_min: MM,
         min_product_alpha_2_3_5: RATIO | None = None,
     ) -> None:
-        r"""[$$l_{bd}$$] Design anchorage length [$$mm$$].
+        r"""[$l_{bd}$] Design anchorage length [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.4.4(1) - Formula (8.4)
 
         Parameters
         ----------
         alpha_1 : RATIO
-            [$$α_{1}$$] Coefficient for the effect of the form of the bars assuming adequate cover (see figure 8.1) [$$-$$].
-            [$$= 1.0$$] for bars in compression.
-            [$$= 1.0$$] for straight bars in tension.
-            [$$= 1.0 \text{ if } c_{d} \leq 3 ⋅ Ø$$] for bars other than straight in tension (see figure 8.1 (b), (c) and (d)).
-            [$$= 0.7 \text{ if } c_{d} > 3 ⋅ Ø$$] for bars other than straight in tension (see figure 8.1 (b), (c) and (d)).
-            Note: see figure 8.3 for values of [$$c_{d}$$].
+            [$α_{1}$] Coefficient for the effect of the form of the bars assuming adequate cover (see figure 8.1) [$-$].
+            [$= 1.0$] for bars in compression.
+            [$= 1.0$] for straight bars in tension.
+            [$= 1.0 \text{ if } c_{d} \leq 3 ⋅ Ø$] for bars other than straight in tension (see figure 8.1 (b), (c) and (d)).
+            [$= 0.7 \text{ if } c_{d} > 3 ⋅ Ø$] for bars other than straight in tension (see figure 8.1 (b), (c) and (d)).
+            Note: see figure 8.3 for values of [$c_{d}$].
         alpha_2 : RATIO
-            [$$α_{2}$$] Coefficient for the effect of minimum concrete cover (see figure 8.3) [$$-$$].
-            [$$= 1.0$$] for bars in compression.
-            [$$= 1 - 0.15 ⋅ (c_{d} - Ø) / Ø \leq 1$$] with a minimum of 0.7 for straight bars in tension.
-            [$$= 1 - 0.15 ⋅ (c_{d} - 3 ⋅ Ø) / Ø \leq 1$$] with a minimum of 0.7 for bars other than
+            [$α_{2}$] Coefficient for the effect of minimum concrete cover (see figure 8.3) [$-$].
+            [$= 1.0$] for bars in compression.
+            [$= 1 - 0.15 ⋅ (c_{d} - Ø) / Ø \leq 1$] with a minimum of 0.7 for straight bars in tension.
+            [$= 1 - 0.15 ⋅ (c_{d} - 3 ⋅ Ø) / Ø \leq 1$] with a minimum of 0.7 for bars other than
             straight in tension (see figure 8.1 (b), (c) and (d)).
-            Note: see figure 8.3 for values of [$$c_{d}$$].
+            Note: see figure 8.3 for values of [$c_{d}$].
         alpha_3 : RATIO
-            [$$α_{3}$$] Coefficient for the effect of confinement by transverse reinforcement [$$-$$].
-            [$$= 1.0$$] for bars in compression.
-            [$$= 1 - K ⋅ λ \leq 1$$] with a minimum of 0.7 for bars in tension.
-            Where: [$$λ = (\Sigma A_{st} - \Sigma A_{st,min}) / A_{s}$$].
-            Where: [$$\Sigma A_{st,min}$$] = cross-sectional area of the minimum transverse
-            reinforcement [$$= 0,25 ⋅ A_{s}$$] for beams and 0 for slabs.
-            Note: see figure 8.4 for values of [$$K, A_{s}$$] and [$$A_{st}$$].
+            [$α_{3}$] Coefficient for the effect of confinement by transverse reinforcement [$-$].
+            [$= 1.0$] for bars in compression.
+            [$= 1 - K ⋅ λ \leq 1$] with a minimum of 0.7 for bars in tension.
+            Where: [$λ = (\Sigma A_{st} - \Sigma A_{st,min}) / A_{s}$].
+            Where: [$\Sigma A_{st,min}$] = cross-sectional area of the minimum transverse
+            reinforcement [$= 0,25 ⋅ A_{s}$] for beams and 0 for slabs.
+            Note: see figure 8.4 for values of [$K, A_{s}$] and [$A_{st}$].
         alpha_4 : RATIO
-            [$$α_{4}$$] Coefficient for the influence of one or more welded transverse bars [$$Ø_{t} > 0,6 Ø$$] along the design anchorage
-            length [$$l_{bd}$$] (see 8.6) [$$-$$].
-            [$$= 0.7$$] for all types, position and size as specified in figure 8.6 (e) in both tension and compression.
+            [$α_{4}$] Coefficient for the influence of one or more welded transverse bars [$Ø_{t} > 0,6 Ø$] along the design anchorage
+            length [$l_{bd}$] (see 8.6) [$-$].
+            [$= 0.7$] for all types, position and size as specified in figure 8.6 (e) in both tension and compression.
         alpha_5 : RATIO
-            [$$α_{5}$$] Coefficient for the effect of the pressure transverse to the plane of splitting
-            along the design anchorage length [$$l_{bd}$$] (see 8.6) [$$-$$].
-            [$$= 1 - 0.04 ⋅ p \leq 1$$] with a minimum of 0.7 for all types of anchorage in compression.
-            Where: p = transverse pressure at ultimate limit state along [$$l_{bd}$$] [$$MPa$$].
+            [$α_{5}$] Coefficient for the effect of the pressure transverse to the plane of splitting
+            along the design anchorage length [$l_{bd}$] (see 8.6) [$-$].
+            [$= 1 - 0.04 ⋅ p \leq 1$] with a minimum of 0.7 for all types of anchorage in compression.
+            Where: p = transverse pressure at ultimate limit state along [$l_{bd}$] [$MPa$].
         l_b_rqd: MM
-            [$$l_{b,rqd}$$] Basic required anchorage length, for anchoring the force [$$A_{s}⋅σ_{sd}$$] in a straight bar assuming constant
-            bond stress (formula 8.3) [$$mm$$].
+            [$l_{b,rqd}$] Basic required anchorage length, for anchoring the force [$A_{s}⋅σ_{sd}$] in a straight bar assuming constant
+            bond stress (formula 8.3) [$mm$].
             Use your own implementation for this value or use the :class:`Form8Dot3RequiredAnchorageLength` class.
         l_b_min : MM
-            [$$l_{b,min}$$] Minimum anchorage length if no other limitation is applied [$$mm$$].
-            [$$= \max(0.3 ⋅ l_{b,rqd}, 10 ⋅ Ø, 100)$$] for tension anchorage (formula 8.6).
-            [$$= \max(0.6 ⋅ l_{b,rqd}, 10 ⋅ Ø, 100)$$] for compression anchorage (formula 8.7).
+            [$l_{b,min}$] Minimum anchorage length if no other limitation is applied [$mm$].
+            [$= \max(0.3 ⋅ l_{b,rqd}, 10 ⋅ Ø, 100)$] for tension anchorage (formula 8.6).
+            [$= \max(0.6 ⋅ l_{b,rqd}, 10 ⋅ Ø, 100)$] for compression anchorage (formula 8.7).
             Use your own implementation of this formula or use the :class:`Form8Dot6MinimumTensionAnchorage` class for tension or
             :class:`Form8Dot7MinimumCompressionAnchorage` for compression.
         min_product_alpha_2_3_5: RATIO | None
-            Minimum value of the product of factors [$$α_{2}$$], [$$α_{3}$$] and [$$α_{5}$$].
+            Minimum value of the product of factors [$α_{2}$], [$α_{3}$] and [$α_{5}$].
             When this argument is None, :class: `Form8Dot5ProductAlphas235` is used for this condition.
-            When this argument is given, the condition [$$\max(α_{2}⋅α_{3}⋅α_{5}) \geq$$] min_product_alpha_2_3_5 is used.
+            When this argument is given, the condition [$\max(α_{2}⋅α_{3}⋅α_{5}) \geq$] min_product_alpha_2_3_5 is used.
 
         Notes
         -----
-        NEN-EN 1992-1-1+C2:2011 art.8.4.4(1) - Formula (8.5) prescribes that [$$α_{2} ⋅ α_{3} ⋅ α_{5} \geq 0.7$$].
+        NEN-EN 1992-1-1+C2:2011 art.8.4.4(1) - Formula (8.5) prescribes that [$α_{2} ⋅ α_{3} ⋅ α_{5} \geq 0.7$].
         """
         super().__init__()
         self.alpha_1 = alpha_1

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_5.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_5.py
@@ -8,7 +8,7 @@ from blueprints.validations import raise_if_negative
 
 
 class Form8Dot5ProductAlphas235(Formula):
-    r"""Class representing formula 8.5 for the calculating the product of [$$\alpha_{2}$$], [$$\alpha_{3}$$] [$$\alpha_{5}$$] [$$-$$]."""
+    r"""Class representing formula 8.5 for the calculating the product of [$\alpha_{2}$], [$\alpha_{3}$] [$\alpha_{5}$] [$-$]."""
 
     label = "8.5"
     source_document = NEN_EN_1992_1_1_C2_2011
@@ -19,45 +19,45 @@ class Form8Dot5ProductAlphas235(Formula):
         alpha_3: RATIO,
         alpha_5: RATIO,
     ) -> None:
-        r"""Calculate the product of [$$\alpha_{2}$$], [$$\alpha_{3}$$] and [$$\alpha_{5}$$] [$$-$$].
+        r"""Calculate the product of [$\alpha_{2}$], [$\alpha_{3}$] and [$\alpha_{5}$] [$-$].
 
-        NEN-EN 1992-1-1+C2:2011 art.8.4.4(1) - Formula (8.5) prescribes that [$$(\alpha_{2} \cdot \alpha_{3} \cdot \alpha_{5}) \ge 0.7$$].
+        NEN-EN 1992-1-1+C2:2011 art.8.4.4(1) - Formula (8.5) prescribes that [$(\alpha_{2} \cdot \alpha_{3} \cdot \alpha_{5}) \ge 0.7$].
         Used by NEN-EN 1992-1-1+C2:2011 art.8.4.4(1) - Formula (8.4)
 
         Parameters
         ----------
         alpha_2 : RATIO
-            [$$\alpha_{2}$$] Coefficient for the effect of minimum concrete cover (see figure 8.3) [$$-$$].
+            [$\alpha_{2}$] Coefficient for the effect of minimum concrete cover (see figure 8.3) [$-$].
 
-            [$$= 1.0$$] for bars in compression.
+            [$= 1.0$] for bars in compression.
 
-            [$$= 1 - 0.15 \cdot (c_{d} - \varnothing) / \varnothing \le 1$$] with a minimum of [$$0.7$$] for straight bars in tension.
+            [$= 1 - 0.15 \cdot (c_{d} - \varnothing) / \varnothing \le 1$] with a minimum of [$0.7$] for straight bars in tension.
 
-            [$$= 1 - 0.15 \cdot (c_{d} - 3 \cdot \varnothing) / \varnothing \le 1$$] with a minimum of [$$0.7$$] for bars other than
+            [$= 1 - 0.15 \cdot (c_{d} - 3 \cdot \varnothing) / \varnothing \le 1$] with a minimum of [$0.7$] for bars other than
             straight in tension (see figure 8.1 (b), (c) and (d)).
 
-            Note: see figure 8.3 for values of [$$c_{d}$$].
+            Note: see figure 8.3 for values of [$c_{d}$].
         alpha_3 : RATIO
-            [$$\alpha_{3}$$] Coefficient for the effect of confinement by transverse reinforcement [$$-$$].
+            [$\alpha_{3}$] Coefficient for the effect of confinement by transverse reinforcement [$-$].
 
-            [$$= 1.0$$] for bars in compression.
+            [$= 1.0$] for bars in compression.
 
-            [$$= 1 - K \cdot \lambda \le 1$$] with a minimum of [$$0.7$$] for bars in tension.
+            [$= 1 - K \cdot \lambda \le 1$] with a minimum of [$0.7$] for bars in tension.
 
-            Where: [$$\lambda = (\Sigma A_{st} - \Sigma A_{st,min}) / A_{s}$$].
+            Where: [$\lambda = (\Sigma A_{st} - \Sigma A_{st,min}) / A_{s}$].
 
-            Where: [$$\Sigma A_{st,min}$$] = cross-sectional area of the minimum transverse
-            reinforcement [$$= 0.25 \cdot A_{s}$$] for beams and [$$0$$] for slabs.
+            Where: [$\Sigma A_{st,min}$] = cross-sectional area of the minimum transverse
+            reinforcement [$= 0.25 \cdot A_{s}$] for beams and [$0$] for slabs.
 
-            Note: see figure 8.4 for values of [$$K, A_{s}$$] and [$$A_{st}$$].
+            Note: see figure 8.4 for values of [$K, A_{s}$] and [$A_{st}$].
 
         alpha_5 : RATIO
-            [$$\alpha_{5}$$] Coefficient for the effect of the pressure transverse to the plane of splitting
-            along the design anchorage length [$$l_{bd}$$] (see 8.6) [$$-$$].
+            [$\alpha_{5}$] Coefficient for the effect of the pressure transverse to the plane of splitting
+            along the design anchorage length [$l_{bd}$] (see 8.6) [$-$].
 
-            [$$= 1 - 0.04 \cdot p \le 1$$] with a minimum of [$$0.7$$] for all types of anchorage in compression.
+            [$= 1 - 0.04 \cdot p \le 1$] with a minimum of [$0.7$] for all types of anchorage in compression.
 
-            Where: [$$p$$] = transverse pressure at ultimate limit state along [$$l_{bd}$$] [$$MPa$$].
+            Where: [$p$] = transverse pressure at ultimate limit state along [$l_{bd}$] [$MPa$].
         """
         super().__init__()
         self.alpha_2 = alpha_2

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_6.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_6.py
@@ -20,18 +20,18 @@ class Form8Dot6MinimumTensionAnchorage(Formula):
         l_b_rqd: MM,
         diameter: MM,
     ) -> None:
-        r"""[$$l_{b,min}$$] Minimum anchorage length if no other limitation is applied for anchorage in tension. [$$mm$$].
+        r"""[$l_{b,min}$] Minimum anchorage length if no other limitation is applied for anchorage in tension. [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.4.4(1) - Formula (8.6)
 
         Parameters
         ----------
         l_b_rqd: MM
-            [$$l_{b,rqd}$$] Basic required anchorage length, for anchoring the force [$$A_s \cdot \sigma_{sd}$$] in a straight bar assuming constant
-            bond stress (formula 8.3) [$$mm$$].
+            [$l_{b,rqd}$] Basic required anchorage length, for anchoring the force [$A_s \cdot \sigma_{sd}$] in a straight bar assuming constant
+            bond stress (formula 8.3) [$mm$].
             Use your own implementation for this value or use the Form8Dot3RequiredAnchorageLength class.
         diameter: MM
-            [$$Ø$$] Diameter of the bar [$$mm$$].
+            [$Ø$] Diameter of the bar [$mm$].
         """
         super().__init__()
         self.l_b_rqd = l_b_rqd

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_7.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_7.py
@@ -20,18 +20,18 @@ class Form8Dot7MinimumCompressionAnchorage(Formula):
         l_b_rqd: MM,
         diameter: MM,
     ) -> None:
-        r"""[$$l_{b,min}$$] Minimum anchorage length if no other limitation is applied for anchorage in compression. [$$mm$$].
+        r"""[$l_{b,min}$] Minimum anchorage length if no other limitation is applied for anchorage in compression. [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.4.4(1) - Formula (8.7)
 
         Parameters
         ----------
         l_b_rqd: MM
-            [$$l_{b,rqd}$$] Basic required anchorage length, for anchoring the force [$$A_s \cdot \sigma_{sd}$$] in a straight bar assuming constant
-            bond stress (formula 8.3) [$$mm$$].
+            [$l_{b,rqd}$] Basic required anchorage length, for anchoring the force [$A_s \cdot \sigma_{sd}$] in a straight bar assuming constant
+            bond stress (formula 8.3) [$mm$].
             Use your own implementation for this value or use the Form8Dot3RequiredAnchorageLength class.
         diameter: MM
-            [$$Ø$$] Diameter of the bar [$$mm$$].
+            [$Ø$] Diameter of the bar [$mm$].
         """
         super().__init__()
         self.l_b_rqd = l_b_rqd

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_8n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_8n.py
@@ -25,7 +25,7 @@ class Form8Dot8nAnchorageCapacityWeldedTransverseBar(Formula):
         sigma_td: MPA,
         f_wd: KN,
     ) -> None:
-        r"""[$$F_{btd}$$] Anchorage capacity of welded transverse bar, welded on the inside of the main bar [$$kN$$].
+        r"""[$F_{btd}$] Anchorage capacity of welded transverse bar, welded on the inside of the main bar [$kN$].
 
             Note: Value may be found in National Annex.
 
@@ -34,22 +34,22 @@ class Form8Dot8nAnchorageCapacityWeldedTransverseBar(Formula):
         Parameters
         ----------
         l_td: MM
-            [$$l_{td}$$] Design length of transverse bar [$$mm$$].
+            [$l_{td}$] Design length of transverse bar [$mm$].
 
-            [$$= 1.16 ⋅ ø_{t} ⋅ (f_{yd}/σ_{td})^{0.5} ≤ l_{t}$$]
+            [$= 1.16 ⋅ ø_{t} ⋅ (f_{yd}/σ_{td})^{0.5} ≤ l_{t}$]
 
             Use your own implementation of this formula or use the SubForm8Dot8nDesignLengthOfTransverseBar class.
         diameter_t: MM
-            [$$ø_{t}$$] Diameter of transverse bar [$$mm$$].
+            [$ø_{t}$] Diameter of transverse bar [$mm$].
         sigma_td: MPA
-            [$$σ_{td}$$] Concrete stress [$$MPa$$].
+            [$σ_{td}$] Concrete stress [$MPa$].
 
-            [$$=(f_{ctd}+σ_{cm})/y ≤ 3⋅f_{cd}$$]
+            [$=(f_{ctd}+σ_{cm})/y ≤ 3⋅f_{cd}$]
 
             Use your own implementation of this formula or use the SubForm8Dot8nConcreteStress class.
         f_wd: KN
-            [$$F_{wd}$$] Design shear strength of weld (specified as a factor times [$$A_{s}⋅f_{yd}$$]; say [$$0.5⋅A_{s}⋅f_{yd}$$] where
-            [$$A_{s}$$] is the cross-section of the anchored bar and fyd is its design yield strength)  [$$kN$$].
+            [$F_{wd}$] Design shear strength of weld (specified as a factor times [$A_{s}⋅f_{yd}$]; say [$0.5⋅A_{s}⋅f_{yd}$] where
+            [$A_{s}$] is the cross-section of the anchored bar and fyd is its design yield strength)  [$kN$].
         """
         super().__init__()
         self.l_td = l_td
@@ -97,24 +97,24 @@ class SubForm8Dot8nDesignLengthOfTransverseBar(Formula):
         sigma_td: MPA,
         l_t: MM,
     ) -> None:
-        r"""[$$l_{td}$$] Design length of transverse bar [$$mm$$].
+        r"""[$l_{td}$] Design length of transverse bar [$mm$].
 
-        NEN-EN 1992-1-1+C2:2011 art.8.6(2) - [$$l_{td}$$]
+        NEN-EN 1992-1-1+C2:2011 art.8.6(2) - [$l_{td}$]
 
         Parameters
         ----------
         diameter_t: MM
-            [$$ø_{t}$$] Diameter of transverse bar [$$mm$$].
+            [$ø_{t}$] Diameter of transverse bar [$mm$].
         f_yd: MPA
-            [$$f_{yd}$$] Design yield strength of bar [$$MPa$$].
+            [$f_{yd}$] Design yield strength of bar [$MPa$].
         sigma_td: MPA
-            [$$σ_{td}$$] Concrete stress [$$MPa$$].
+            [$σ_{td}$] Concrete stress [$MPa$].
 
-            [$$=(f_{ctd}+σ_{cm})/y ≤ 3⋅f_{cd}$$]
+            [$=(f_{ctd}+σ_{cm})/y ≤ 3⋅f_{cd}$]
 
             Use your own implementation of this formula or use the SubForm8Dot8nConcreteStress class.
         l_t: MM
-            [$$l_{t}$$] Length of transverse bar, but not more than the spacing of bars to be anchored [$$mm$$].
+            [$l_{t}$] Length of transverse bar, but not more than the spacing of bars to be anchored [$mm$].
         """
         super().__init__()
         self.diameter_t = diameter_t
@@ -165,24 +165,24 @@ class SubForm8Dot8nConcreteStress(Formula):
         y_function: DIMENSIONLESS,
         f_cd: MPA,
     ) -> None:
-        r"""[$$σ_{td}$$] Concrete stress [$$MPa$$].
+        r"""[$σ_{td}$] Concrete stress [$MPa$].
 
-        NEN-EN 1992-1-1+C2:2011 art.8.6(2) - [$$σ_{td}$$]
+        NEN-EN 1992-1-1+C2:2011 art.8.6(2) - [$σ_{td}$]
 
         Parameters
         ----------
         f_ctd: MPA
-            [$$f_{ctd}$$] Design tensile strength of concrete [$$MPa$$].
+            [$f_{ctd}$] Design tensile strength of concrete [$MPa$].
         sigma_cm: MPA
-            [$$σ_{cm}$$] Compression in the concrete perpendicular to both bars (mean value) [$$MPa$$].
+            [$σ_{cm}$] Compression in the concrete perpendicular to both bars (mean value) [$MPa$].
         y_function: DIMENSIONLESS
-            [$$y$$] A function [$$-$$]
+            [$y$] A function [$-$]
 
-            [$$= 0.015 + 0.14 ⋅ exp(-0.18⋅x)$$]
+            [$= 0.015 + 0.14 ⋅ exp(-0.18⋅x)$]
 
             Use your own implementation of this formula or use the SubForm8Dot8nFunctionY class.
         f_cd: MPA
-            [$$f_{cd}$$] Design value compressive strength of concrete [$$MPa$$].
+            [$f_{cd}$] Design value compressive strength of concrete [$MPa$].
         """
         super().__init__()
         self.f_ctd = f_ctd
@@ -229,16 +229,16 @@ class SubForm8Dot8nFunctionY(Formula):
         self,
         x_function: DIMENSIONLESS,
     ) -> None:
-        r"""[$$y$$] A function [$$-$$].
+        r"""[$y$] A function [$-$].
 
-        NEN-EN 1992-1-1+C2:2011 art.8.6(2) - [$$y$$]
+        NEN-EN 1992-1-1+C2:2011 art.8.6(2) - [$y$]
 
         Parameters
         ----------
         x_function: DIMENSIONLESS
-            [$$x$$] A function accounting for the geometry [$$-$$]
+            [$x$] A function accounting for the geometry [$-$]
 
-            [$$= 2⋅(c/ø_{t}) + 1$$]
+            [$= 2⋅(c/ø_{t}) + 1$]
 
             Use your own implementation of this formula or use the SubForm8Dot8nFunctionX class.
         """
@@ -275,16 +275,16 @@ class SubForm8Dot8nFunctionX(Formula):
         cover: MM,
         diameter_t: MM,
     ) -> None:
-        r"""[$$x$$] A function accounting for the geometry [$$-$$].
+        r"""[$x$] A function accounting for the geometry [$-$].
 
-        NEN-EN 1992-1-1+C2:2011 art.8.6(2) - [$$x$$]
+        NEN-EN 1992-1-1+C2:2011 art.8.6(2) - [$x$]
 
         Parameters
         ----------
         cover: MM
-            [$$c$$] Concrete cover perpendicular to both bars [$$mm$$].
+            [$c$] Concrete cover perpendicular to both bars [$mm$].
         diameter_t: MM
-            [$$ø_{t}$$] Diameter of transverse bar [$$mm$$].
+            [$ø_{t}$] Diameter of transverse bar [$mm$].
         """
         super().__init__()
         self.cover = cover

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_9.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_8_detailing_of_reinforcement_and_prestressing_tendons/formula_8_9.py
@@ -24,27 +24,27 @@ class Form8Dot9AnchorageCapacityWeldedTransverseBarSmallDiameter(Formula):
         a_s: MM2,
         f_cd: MPA,
     ) -> None:
-        r"""[$$F_{btd}$$] Anchorage capacity of a welded cross bar for nominal bar diameters smaller than 12 mm [$$kN$$].
+        r"""[$F_{btd}$] Anchorage capacity of a welded cross bar for nominal bar diameters smaller than 12 mm [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.8.6(5) - formula 8.9
 
         Parameters
         ----------
         f_wd : KN
-            [$$F_{wd}$$] Design shear strength of weld (specified as a factor times [$$A_{s} \cdot f_{yd}$$]; say [$$0.5 \cdot A_{s} \cdot f_{yd}$$]
-            where [$$A_{s}$$] is the cross-section of the anchored bar and [$$f_{yd}$$] is its design yield strength)  [$$kN$$].
+            [$F_{wd}$] Design shear strength of weld (specified as a factor times [$A_{s} \cdot f_{yd}$]; say [$0.5 \cdot A_{s} \cdot f_{yd}$]
+            where [$A_{s}$] is the cross-section of the anchored bar and [$f_{yd}$] is its design yield strength)  [$kN$].
         diameter_t : MM
-            [$$ø_{t}$$] Diameter of the transverse bar [$$mm$$].
+            [$ø_{t}$] Diameter of the transverse bar [$mm$].
 
-            Note: [$$ø_{t} \leq 12$$] [$$mm$$].
+            Note: [$ø_{t} \leq 12$] [$mm$].
         diameter_l : MM
-            [$$ø_{l}$$] Diameter of the bar to be anchored [$$mm$$].
+            [$ø_{l}$] Diameter of the bar to be anchored [$mm$].
 
-            Note: [$$ø_{l} \leq 12$$] [$$mm$$].
+            Note: [$ø_{l} \leq 12$] [$mm$].
         a_s : MM2
-            [$$A_{s}$$] Cross-section of the anchored bar [$$mm^{2}$$].
+            [$A_{s}$] Cross-section of the anchored bar [$mm^{2}$].
         f_cd : MPA
-            [$$f_{cd}$$] Design compressive strength of concrete [$$MPa$$].
+            [$f_{cd}$] Design compressive strength of concrete [$MPa$].
         """
         super().__init__()
         self.f_wd = f_wd

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_10.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_10.py
@@ -14,14 +14,14 @@ class Form9Dot10MaximumSpacingBentUpBars(Formula):
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, d: MM) -> None:
-        r"""[$$s_{max}$$] Maximum longitudinal spacing of bent up bars for slabs [$$mm$$].
+        r"""[$s_{max}$] Maximum longitudinal spacing of bent up bars for slabs [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.3.2(4) - Formula (9.10)
 
         Parameters
         ----------
         d: MM
-            [$$d$$] Effective height of the cross-section [$$mm$$].
+            [$d$] Effective height of the cross-section [$mm$].
         """
         super().__init__()
         self.d = d

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_12n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_12n.py
@@ -20,18 +20,18 @@ class Form9Dot12nMinimumLongitudinalReinforcementColumns(Formula):
         f_yd: MPA,
         a_c: MM2,
     ) -> None:
-        r"""[$$A_{s,min}$$] Minimum longitudinal reinforcement for columns [$$mm^2$$].
+        r"""[$A_{s,min}$] Minimum longitudinal reinforcement for columns [$mm^2$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.5.2(2) - Formula (9.12N)
 
         Parameters
         ----------
         n_ed: KN
-            [$$N_{Ed}$$] Design value of axial force [$$kN$$].
+            [$N_{Ed}$] Design value of axial force [$kN$].
         f_yd: MPA
-            [$$f_{yd}$$] Design yield strength reinforcement steel [$$MPa$$].
+            [$f_{yd}$] Design yield strength reinforcement steel [$MPa$].
         a_c: MM2
-            [$$A_c$$] Concrete cross-sectional area [$$mm^2$$].
+            [$A_c$] Concrete cross-sectional area [$mm^2$].
         """
         super().__init__()
         self.n_ed = n_ed

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_13.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_13.py
@@ -19,18 +19,18 @@ class Form9Dot13TensileForceToBeAnchored(Formula):
         z_e: MM,
         z_i: MM,
     ) -> None:
-        r"""[$$F_s$$] Tensile force to be anchored [$$kN$$].
+        r"""[$F_s$] Tensile force to be anchored [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.8.2.2(2) - Formula (9.13)
 
         Parameters
         ----------
         r: MM
-            [$$R$$] The resultant of ground pressure within x from figure 9.13 [$$mm$$].
+            [$R$] The resultant of ground pressure within x from figure 9.13 [$mm$].
         z_e: MM
-            [$$z_e$$] The external lever arm, see figure 9.13, i.e. distance between the reinforcement and the horizontal force $$F_c$$ [$$mm$$].
+            [$z_e$] The external lever arm, see figure 9.13, i.e. distance between the reinforcement and the horizontal force $F_c$ [$mm$].
         z_i: MM
-            [$$z_i$$] Internal lever arm, see figure 9.13, i.e. distance between $$R$$ and the vertical force $$N_{Ed}$$ [$$mm$$].
+            [$z_i$] Internal lever arm, see figure 9.13, i.e. distance between $R$ and the vertical force $N_{Ed}$ [$mm$].
         """
         super().__init__()
         self.r = r

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_14.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_14.py
@@ -19,18 +19,18 @@ class Form9Dot14SplittingForceColumnOnRock(Formula):
         h: MM,
         n_ed: KN,
     ) -> None:
-        r"""[$$F_s$$] Splitting force on a column footing on rock [$$kN$$].
+        r"""[$F_s$] Splitting force on a column footing on rock [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.8.4(2) - Formula (9.14)
 
         Parameters
         ----------
         c: MM
-            [$$c$$] Width over which [$$N_{Ed}$$] is applied [$$mm$$].
+            [$c$] Width over which [$N_{Ed}$] is applied [$mm$].
         h: MM
-            [$$h$$] Lesser of [$$b$$] and [$$H$$] from figure 9.14 [$$mm$$].
+            [$h$] Lesser of [$b$] and [$H$] from figure 9.14 [$mm$].
         n_ed: KN
-            [$$N_{Ed}$$] Design value of the applied axial force [$$kN$$].
+            [$N_{Ed}$] Design value of the applied axial force [$kN$].
         """
         super().__init__()
         self.c = c

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_16.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_16.py
@@ -20,20 +20,20 @@ class Form9Dot16MinimumForceOnInternalBeamLine(Formula):
         l_2: M,
         q_4: KN,
     ) -> None:
-        r"""[$$F_{tie}$$] Minimum force on an internal beam line [$$kN$$].
+        r"""[$F_{tie}$] Minimum force on an internal beam line [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.10.2.3(4) - Formula (9.16)
 
         Parameters
         ----------
         q_3: KN_M
-            [$$q_3$$] May be found in national annex, recommended value is 20 [$$kN/m$$].
+            [$q_3$] May be found in national annex, recommended value is 20 [$kN/m$].
         l_1: M
-            [$$l_1$$] span length of floor slabs on either side of the beam, see figure 9.15 [$$m$$].
+            [$l_1$] span length of floor slabs on either side of the beam, see figure 9.15 [$m$].
         l_2: M
-            [$$l_2$$] span length of floor slabs on either side of the beam, see figure 9.15 [$$m$$].
+            [$l_2$] span length of floor slabs on either side of the beam, see figure 9.15 [$m$].
         q_4: KN
-            [$$Q_4$$] May be found in national annex, recommended value is 70 [$$kN$$].
+            [$Q_4$] May be found in national annex, recommended value is 70 [$kN$].
         """
         super().__init__()
         self.q_3 = q_3

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_1n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_1n.py
@@ -20,26 +20,26 @@ class Form9Dot1nMinimumTensileReinforcementBeam(Formula):
         b_t: MM,
         d: MM,
     ) -> None:
-        r"""[$$A_{s,min}$$] Calculates minimum required tensile reinforcement area in longitudinal direction for beams [$$\text{mm}^2$$].
+        r"""[$A_{s,min}$] Calculates minimum required tensile reinforcement area in longitudinal direction for beams [$\text{mm}^2$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.2.1.1(1) - Formula (9.1N)
 
         Notes
         -----
-        [$${A_{s,min}}$$] is no less than [$${0.0013 \cdot b_t \cdot d}$$]
+        [${A_{s,min}}$] is no less than [${0.0013 \cdot b_t \cdot d}$]
 
         Parameters
         ----------
         f_ctm: MPA
-            [$${f_{ctm}}$$] Mean axial tensile stress concrete [$$\text{MPa}$$].
+            [${f_{ctm}}$] Mean axial tensile stress concrete [$\text{MPa}$].
             Should be determined with respect to the relevant strength class according to Table 3.1
         f_yk: MPA
-            [$${f_{yk}}$$] Characteristic yield strength reinforcement steel [$$\text{MPa}$$].
+            [${f_{yk}}$] Characteristic yield strength reinforcement steel [$\text{MPa}$].
         b_t: MM
-            [$${b_t}$$] Mean width of the concrete tension zone, for T-beams with a flange under compression only the width of the web is
-            considered for calculating [$${b_t}$$] [$$\text{mm}$$].
+            [${b_t}$] Mean width of the concrete tension zone, for T-beams with a flange under compression only the width of the web is
+            considered for calculating [${b_t}$] [$\text{mm}$].
         d: MM
-            [$${d}$$] Effective height of the cross-section [$$\text{mm}$$].
+            [${d}$] Effective height of the cross-section [$\text{mm}$].
         """
         super().__init__()
         self.f_ctm = f_ctm

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_2.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_2.py
@@ -21,19 +21,19 @@ class Form9Dot2ShiftInMomentDiagram(Formula):
         theta: DEG,
         alpha: DEG,
     ) -> None:
-        r"""[$$a_l$$] Shift in the moment diagram of an element with shear reinforcement [$$mm$$].
+        r"""[$a_l$] Shift in the moment diagram of an element with shear reinforcement [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.2.1.3(2) - Formula (9.2)
 
         Parameters
         ----------
         z: MM
-            [$$z$$] The internal lever arm for an element with constant height, corresponding to the bending moment in the considered element. In the
-            shear force calculation of reinforced concrete without axial force, the approximate value [$$z = 0.9d$$] may generally be used [$$mm$$].
+            [$z$] The internal lever arm for an element with constant height, corresponding to the bending moment in the considered element. In the
+            shear force calculation of reinforced concrete without axial force, the approximate value [$z = 0.9d$] may generally be used [$mm$].
         alpha: DEG
-            [$$\alpha$$] The angle between the shear reinforcement and the longitudinal axis of the beam (see 9.2.2(1)) [$$deg$$].
+            [$\alpha$] The angle between the shear reinforcement and the longitudinal axis of the beam (see 9.2.2(1)) [$deg$].
         theta: DEG
-            [$$\theta$$] The angle between the shear compression strut and the axis of the beam 6.2.3 [$$C1$$] [$$deg$$].
+            [$\theta$] The angle between the shear compression strut and the axis of the beam 6.2.3 [$C1$] [$deg$].
         """
         super().__init__()
         self.z = z

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_3.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_3.py
@@ -20,22 +20,22 @@ class Form9Dot3ShiftInMomentDiagram(Formula):
         z: MM,
         n_ed: KN,
     ) -> None:
-        r"""[$$F_{Ed}$$] Force to be anchored according to the shift rule [$$kN$$].
+        r"""[$F_{Ed}$] Force to be anchored according to the shift rule [$kN$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.2.1.4(2) - Formula (9.3)
 
         Parameters
         ----------
         v_ed: KN
-            [$$V_{Ed}$$] Design value shear force [$$kN$$].
+            [$V_{Ed}$] Design value shear force [$kN$].
         a_l: MM
-            [$$a_l$$] Shift in the moment diagram of an element with shear reinforcement based on art. 9.2.1.3 (2) [$$mm$$].
+            [$a_l$] Shift in the moment diagram of an element with shear reinforcement based on art. 9.2.1.3 (2) [$mm$].
             Use your own implementation of this value or use the Form9Dot2ShiftInMomentDiagram class.
         z: MM
-            [$$z$$] The internal lever arm for an element with constant height, corresponding to the bending moment in the considered element. In the
-            shear force calculation of reinforced concrete without axial force, the approximate value [$$z = 0.9d$$] may generally be used [$$mm$$].
+            [$z$] The internal lever arm for an element with constant height, corresponding to the bending moment in the considered element. In the
+            shear force calculation of reinforced concrete without axial force, the approximate value [$z = 0.9d$] may generally be used [$mm$].
         n_ed: KN
-            [$$N_{Ed}$$] Design value of axial force [$$kN$$].
+            [$N_{Ed}$] Design value of axial force [$kN$].
         """
         super().__init__()
         self.v_ed = v_ed

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_4.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_4.py
@@ -22,20 +22,20 @@ class Form9Dot4ShearReinforcementRatio(Formula):
         b_w: MM,
         alpha: DEG,
     ) -> None:
-        r"""[$$\rho_w$$] Shear reinforcement ratio [$$-$$].
+        r"""[$\rho_w$] Shear reinforcement ratio [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.2.2(5) - Formula (9.4)
 
         Parameters
         ----------
         a_sw: MM2
-            [$$A_{sw}$$] Area of shear reinforcement within length s [$$mm^2$$].
+            [$A_{sw}$] Area of shear reinforcement within length s [$mm^2$].
         s: MM
-            [$$s$$] The spacing between shear reinforcement along the longitudinal axis of the element [$$mm$$].
+            [$s$] The spacing between shear reinforcement along the longitudinal axis of the element [$mm$].
         b_w: MM
-            [$$b_w$$] The width of the web of the element [$$mm$$].
+            [$b_w$] The width of the web of the element [$mm$].
         alpha: DEG
-            [$$\alpha$$] The angle between the shear reinforcement and the longitudinal axis of the beam (see 9.2.2(1)) [$$deg$$].
+            [$\alpha$] The angle between the shear reinforcement and the longitudinal axis of the beam (see 9.2.2(1)) [$deg$].
         """
         super().__init__()
         self.a_sw = a_sw

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_5n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_5n.py
@@ -20,16 +20,16 @@ class Form9Dot5nMinimumShearReinforcementRatio(Formula):
         f_ck: MPA,
         f_yk: MPA,
     ) -> None:
-        r"""[$$\rho_{w,min}$$] Minimum shear reinforcement ratio for beams [$$-$$].
+        r"""[$\rho_{w,min}$] Minimum shear reinforcement ratio for beams [$-$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.2.2(5) - Formula (9.5N)
 
         Parameters
         ----------
         f_ck: MPA
-            [$$f_{ck}$$] Characteristic concrete compressive cylinder strength at 28 days [$$MPa$$].
+            [$f_{ck}$] Characteristic concrete compressive cylinder strength at 28 days [$MPa$].
         f_yk: MPA
-            [$$f_{yk}$$] Characteristic yield strength reinforcement steel [$$MPa$$].
+            [$f_{yk}$] Characteristic yield strength reinforcement steel [$MPa$].
         """
         super().__init__()
         self.f_ck = f_ck

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_6n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_6n.py
@@ -20,16 +20,16 @@ class Form9Dot6nMaximumDistanceShearReinforcement(Formula):
         d: MM,
         alpha: DEG,
     ) -> None:
-        r"""[$$s_{l,max}$$] Maximum distance between shear reinforcement in longitudinal direction [$$mm$$].
+        r"""[$s_{l,max}$] Maximum distance between shear reinforcement in longitudinal direction [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.2.2(6) - Formula (9.6N)
 
         Parameters
         ----------
         d: MM
-            [$$d$$] Effective height of the cross-section [$$mm$$].
+            [$d$] Effective height of the cross-section [$mm$].
         alpha: DEG
-            [$$\alpha$$] The angle between the shear reinforcement and the longitudinal axis of the beam (see 9.2.2(1)) [$$deg$$].
+            [$\alpha$] The angle between the shear reinforcement and the longitudinal axis of the beam (see 9.2.2(1)) [$deg$].
         """
         super().__init__()
         self.d = d

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_7n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_7n.py
@@ -20,16 +20,16 @@ class Form9Dot7nMaximumDistanceBentUpBars(Formula):
         d: MM,
         alpha: DEG,
     ) -> None:
-        r"""[$$s_{b,max}$$] Maximum distance between bent-up bars in longitudinal direction [$$mm$$].
+        r"""[$s_{b,max}$] Maximum distance between bent-up bars in longitudinal direction [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.2.2(7) - Formula (9.7N)
 
         Parameters
         ----------
         d: MM
-            [$$d$$] Effective height of the cross-section [$$mm$$].
+            [$d$] Effective height of the cross-section [$mm$].
         alpha: DEG
-            [$$\alpha$$] The angle between the shear reinforcement and the longitudinal axis of the beam (see 9.2.2(1)) [$$deg$$].
+            [$\alpha$] The angle between the shear reinforcement and the longitudinal axis of the beam (see 9.2.2(1)) [$deg$].
         """
         super().__init__()
         self.d = d

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_8n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_8n.py
@@ -16,14 +16,14 @@ class Form9Dot8nMaximumTransverseDistanceLegsSeriesShearLinks(Formula):
     source_document = NEN_EN_1992_1_1_C2_2011
 
     def __init__(self, d: MM) -> None:
-        r"""[$$s_{t,max}$$] Maximum distance in transverse direction between legs in a series of shear links [mm].
+        r"""[$s_{t,max}$] Maximum distance in transverse direction between legs in a series of shear links [mm].
 
         NEN-EN 1992-1-1+C2:2011 art.9.2.2(8) - Formula (9.8N)
 
         Parameters
         ----------
         d: MM
-            [$$d$$] Effective height of the cross-section [mm].
+            [$d$] Effective height of the cross-section [mm].
         """
         super().__init__()
         self.d = d

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_9.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_c2_2011/chapter_9_detailling_and_specific_rules/formula_9_9.py
@@ -22,16 +22,16 @@ class Form9Dot9MaximumSpacingSeriesOfLinks(Formula):
         d: MM,
         alpha: DEG,
     ) -> None:
-        r"""[$$s_{max}$$] Maximum distance between successive series of links in longitudinal direction for slabs [$$mm$$].
+        r"""[$s_{max}$] Maximum distance between successive series of links in longitudinal direction for slabs [$mm$].
 
         NEN-EN 1992-1-1+C2:2011 art.9.3.2(4) - Formula (9.9)
 
         Parameters
         ----------
         d: MM
-            [$$d$$] Effective height of the cross-section [$$mm$$].
+            [$d$] Effective height of the cross-section [$mm$].
         alpha: DEG
-            [$$\alpha$$] The angle between the shear reinforcement and the longitudinal axis of the slab (see 9.2.2(1)) [$$deg$$].
+            [$\alpha$] The angle between the shear reinforcement and the longitudinal axis of the slab (see 9.2.2(1)) [$deg$].
         """
         super().__init__()
         self.d = d

--- a/blueprints/codes/eurocode/nen_en_1993_1_1_c2_a1_2016/chapter_2_basic_of_design/formula_2_2.py
+++ b/blueprints/codes/eurocode/nen_en_1993_1_1_c2_a1_2016/chapter_2_basic_of_design/formula_2_2.py
@@ -8,22 +8,22 @@ from blueprints.validations import raise_if_negative
 
 
 class Form2Dot2CharacteristicValueResistance(Formula):
-    """Class representing formula 2.2 for the calculation of the characteristic value of the resistance [$$R_k$$]."""
+    """Class representing formula 2.2 for the calculation of the characteristic value of the resistance [$R_k$]."""
 
     label = "2.2"
     source_document = NEN_EN_1993_1_1_C2_A1_2016
 
     def __init__(self, r_d: DIMENSIONLESS, gamma_mi: DIMENSIONLESS) -> None:
-        r"""[$$R_k$$] Characteristic value of the resistance [$$kN$$].
+        r"""[$R_k$] Characteristic value of the resistance [$kN$].
 
         NEN-EN 1993-1-1+C2+A1:2016 art.2.5(2) - Formula (2.2)
 
         Parameters
         ----------
         r_d : DIMENSIONLESS
-            [$$R_d$$] Design value of the resistance according to Annex D of EN 1990 [$$kN$$].
+            [$R_d$] Design value of the resistance according to Annex D of EN 1990 [$kN$].
         gamma_mi : DIMENSIONLESS
-            [$$\gamma_{Mi}$$] Recommended partial factors for the resistance [$$-$$].
+            [$\gamma_{Mi}$] Recommended partial factors for the resistance [$-$].
         """
         super().__init__()
         self.r_d = r_d

--- a/blueprints/codes/eurocode/nen_en_1993_1_1_c2_a1_2016/chapter_6_ultimate_limit_state/formula_6_2.py
+++ b/blueprints/codes/eurocode/nen_en_1993_1_1_c2_a1_2016/chapter_6_ultimate_limit_state/formula_6_2.py
@@ -9,31 +9,31 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form6Dot2UtilizationRatio(Formula):
-    """Class representing form 6.2 for the calculation of the utilization ratio [$$UC$$]."""
+    """Class representing form 6.2 for the calculation of the utilization ratio [$UC$]."""
 
     label = "6.2"
     source_document = NEN_EN_1993_1_1_C2_A1_2016
 
     def __init__(self, n_ed: KN, n_rd: KN, m_y_ed: KNM, m_y_rd: KNM, m_z_ed: KNM, m_z_rd: KNM) -> None:
         r"""
-        [$$UC$$] The calculation of the utilization ratio [$$-$$].
+        [$UC$] The calculation of the utilization ratio [$-$].
 
         NEN-EN 1993-1-1+C2+A1:2016 art.6.2.1(7) - Formula (6.2)
 
         Parameters
         ----------
         n_ed : kN
-            [$$N_{Ed}$$] Contains the design axial force [$$kN$$].
+            [$N_{Ed}$] Contains the design axial force [$kN$].
         n_rd : kN
-            [$$N_{Rd}$$] Contains the design axial resistance [$$kN$$].
+            [$N_{Rd}$] Contains the design axial resistance [$kN$].
         m_y_ed : kNm
-            [$$M_{y,Ed}$$] Contains the design moment about the y-axis [$$kNm$$].
+            [$M_{y,Ed}$] Contains the design moment about the y-axis [$kNm$].
         m_y_rd : kNm
-            [$$M_{y,Rd}$$] Contains the design moment resistance about the y-axis [$$kNm$$].
+            [$M_{y,Rd}$] Contains the design moment resistance about the y-axis [$kNm$].
         m_z_ed : kNm
-            [$$M_{z,Ed}$$] Contains the design moment about the z-axis [$$kNm$$].
+            [$M_{z,Ed}$] Contains the design moment about the z-axis [$kNm$].
         m_z_rd : kNm
-            [$$M_{z,Rd}$$] Contains the design moment resistance about the z-axis [$$kNm$$].
+            [$M_{z,Rd}$] Contains the design moment resistance about the z-axis [$kNm$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1993_1_1_c2_a1_2016/chapter_6_ultimate_limit_state/formula_6_5.py
+++ b/blueprints/codes/eurocode/nen_en_1993_1_1_c2_a1_2016/chapter_6_ultimate_limit_state/formula_6_5.py
@@ -19,16 +19,16 @@ class Form6Dot5UnityCheckTensileStrength(Formula):
         n_ed: KN,
         n_t_rd: KN,
     ) -> None:
-        r"""[$$N_{Ed}/N_{t,Rd}$$] Unity check for tensile strength of an element in tension.
+        r"""[$N_{Ed}/N_{t,Rd}$] Unity check for tensile strength of an element in tension.
 
         NEN-EN 1993-1-1+C2+A1:2016 art.6.2.3(1) - Formula (6.5)
 
         Parameters
         ----------
         n_ed : KN
-            [$$N_{Ed}$$] Design value of the normal tensile force [kN].
+            [$N_{Ed}$] Design value of the normal tensile force [kN].
         n_t_rd : KN
-            [$$N_{t,Rd}$$] Design value of the resistance against tensile force [kN].
+            [$N_{t,Rd}$] Design value of the resistance against tensile force [kN].
         """
         super().__init__()
         self.n_ed = n_ed

--- a/blueprints/codes/eurocode/nen_en_1993_1_9_c2_2012/annex_a_determination_of_fatigue_load_parameters_and_verification_formats/formula_a_1.py
+++ b/blueprints/codes/eurocode/nen_en_1993_1_9_c2_2012/annex_a_determination_of_fatigue_load_parameters_and_verification_formats/formula_a_1.py
@@ -8,24 +8,24 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_list
 
 
 class FormADot1DamageDuringDesignLife(Formula):
-    """Class representing formula A.1 for the calculation of the damage during the design life [$$D_d$$]."""
+    """Class representing formula A.1 for the calculation of the damage during the design life [$D_d$]."""
 
     label = "A.1"
     source_document = NEN_EN_1993_1_9_C2_2012
 
     def __init__(self, n_e: list[DIMENSIONLESS], n_r: list[DIMENSIONLESS]) -> None:
-        r"""[$$D_d$$] The calculation of the damage during the design life [$$-$$].
+        r"""[$D_d$] The calculation of the damage during the design life [$-$].
 
         NEN-EN 1993-1-9+C2:2012 art.A.5 - Formula (A.1)
 
         Parameters
         ----------
         n_e : list[DIMENSIONLESS]
-            [$$n_E$$] Contains number of cycles associated with the stress range [$$\gamma_{Ff} \cdot \Delta\sigma_i$$]
-            for each band i in the factored spectrum [$$-$$].
+            [$n_E$] Contains number of cycles associated with the stress range [$\gamma_{Ff} \cdot \Delta\sigma_i$]
+            for each band i in the factored spectrum [$-$].
         n_r : list[DIMENSIONLESS]
-            [$$N_R$$] Contains the endurance (in cycles) obtained from the factored [$$\Delta\sigma_C / \gamma_{Mf} - n_r$$] curve for
-            each stress range of [$$\gamma_{Ff} \cdot \Delta_i$$] [$$-$$].
+            [$N_R$] Contains the endurance (in cycles) obtained from the factored [$\Delta\sigma_C / \gamma_{Mf} - n_r$] curve for
+            each stress range of [$\gamma_{Ff} \cdot \Delta_i$] [$-$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1993_1_9_c2_2012/annex_a_determination_of_fatigue_load_parameters_and_verification_formats/formula_a_2.py
+++ b/blueprints/codes/eurocode/nen_en_1993_1_9_c2_2012/annex_a_determination_of_fatigue_load_parameters_and_verification_formats/formula_a_2.py
@@ -17,14 +17,14 @@ class FormADot2CriteriaBasedOnDamageAccumulation(Formula):
         self,
         d_d: DIMENSIONLESS,
     ) -> None:
-        r"""[$$CHECK$$] Criteria met, based on damage accumulation.
+        r"""[$CHECK$] Criteria met, based on damage accumulation.
 
         NEN-EN 1993-1-9+C2:2012 art.A.5 - Formula (A.1)
 
         Parameters
         ----------
         d_d : DIMENSIONLESS
-            [$$D_d$$] The damage during the design life [$$-$$].
+            [$D_d$] The damage during the design life [$-$].
 
         Returns
         -------

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_10.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_10.py
@@ -18,16 +18,16 @@ class Form5Dot10ReductionFactorShearArea(Formula):
         v_ed: KN,
         v_pl_rd: KN,
     ) -> None:
-        r"""[$$\rho$$] Calculate the reduction factor for shear area of the cross-section [$$-$$].
+        r"""[$\rho$] Calculate the reduction factor for shear area of the cross-section [$-$].
 
         NEN-EN 1993-5:2008(E) art.5.2.2(9) - Formula (5.10)
 
         Parameters
         ----------
         v_ed : KN
-            [$$V_{Ed}$$] Design shear force in [$$kN$$].
+            [$V_{Ed}$] Design shear force in [$kN$].
         v_pl_rd : KN
-            [$$V_{pl,Rd}$$] Plastic shear resistance in [$$kN$$].
+            [$V_{pl,Rd}$] Plastic shear resistance in [$kN$].
         """
         super().__init__()
         self.v_ed: KN = v_ed

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_12.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_12.py
@@ -10,7 +10,7 @@ from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_nega
 
 
 class Form5Dot12ElasticCriticalLoad(Formula):
-    r"""Class representing formula 5.12 for the calculation of the elastic critical load, [$$N_{cr}$$]."""
+    r"""Class representing formula 5.12 for the calculation of the elastic critical load, [$N_{cr}$]."""
 
     label = "5.12"
     source_document = NEN_EN_1993_5_2008
@@ -22,21 +22,21 @@ class Form5Dot12ElasticCriticalLoad(Formula):
         beta_d: DIMENSIONLESS,
         l: MM,  # noqa: E741
     ) -> None:
-        r"""[$$N_{cr}$$] Elastic critical load [$$N$$].
+        r"""[$N_{cr}$] Elastic critical load [$N$].
 
         NEN-EN 1993-5:2008 art.5.2.3 - Formula (5.12)
 
         Parameters
         ----------
         e : MPA
-            [$$E$$] Modulus of elasticity [$$MPa$$].
+            [$E$] Modulus of elasticity [$MPa$].
         i : MM4
-            [$$I$$] Moment of inertia [$$mm^4$$].
+            [$I$] Moment of inertia [$mm^4$].
         beta_d : DIMENSIONLESS
-            [$$\beta_D$$] Reduction factor, see 6.4 [$$-$$].
+            [$\beta_D$] Reduction factor, see 6.4 [$-$].
         l : MM
-            [$$l$$] the buckling length, determined according to Figure 5-2 for a free or partially fixed earth
-            support or according to Figure 5-3 for a fixed earth support. [$$mm$$].
+            [$l$] the buckling length, determined according to Figure 5-2 for a free or partially fixed earth
+            support or according to Figure 5-3 for a fixed earth support. [$mm$].
         """
         super().__init__()
         self.e = e

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_13.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_13.py
@@ -34,21 +34,21 @@ class Form5Dot13SimplifiedBucklingCheck(Formula):
         Parameters
         ----------
         n_ed : KN
-            [$$kN$$] Design axial force [$$kN$$].
+            [$kN$] Design axial force [$kN$].
         m_ed : KNM
-            [$$kNm$$] Design bending moment [$$kNm$$].
+            [$kNm$] Design bending moment [$kNm$].
         a : MM2
-            [$$mm^2$$] Cross-sectional area [$$mm^2$$].
+            [$mm^2$] Cross-sectional area [$mm^2$].
         f_y : MPA
-            [$$MPa$$] Yield strength of the material [$$MPa$$].
+            [$MPa$] Yield strength of the material [$MPa$].
         gamma_m0 : DIMENSIONLESS
-            [$$\gamma_{M0}$$] Partial factor according to 5.1.1 (4) [$$-$$].
+            [$\gamma_{M0}$] Partial factor according to 5.1.1 (4) [$-$].
         gamma_m1 : DIMENSIONLESS
-            [$$\gamma_{M1}$$] Partial factor according to 5.1.1 (4) [$$-$$].
+            [$\gamma_{M1}$] Partial factor according to 5.1.1 (4) [$-$].
         chi : DIMENSIONLESS
-            [$$\chi$$] Buckling coefficient from 6.3.1.2 of EN 1993-1-1 [$$-$$].
+            [$\chi$] Buckling coefficient from 6.3.1.2 of EN 1993-1-1 [$-$].
         m_c_rd : KNM
-            [$$kNm$$] Design moment resistance of the cross-section [$$kNm$$]. See 5.2.2 (2).
+            [$kNm$] Design moment resistance of the cross-section [$kNm$]. See 5.2.2 (2).
             This can also be calculated using Form5Dot2DesignMomentResistanceClass1Or2 or Form5Dot3DesignMomentResistanceClass3.
         """
         super().__init__()

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_2.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_2.py
@@ -21,20 +21,20 @@ class Form5Dot2DesignMomentResistanceClass1Or2(Formula):
         f_y: MPA,
         gamma_m_0: DIMENSIONLESS,
     ) -> None:
-        r"""[$$M_{c,Rd}$$] Calculate design moment resistance of the cross-section (class 1 or 2) in [$$kNm/m$$].
+        r"""[$M_{c,Rd}$] Calculate design moment resistance of the cross-section (class 1 or 2) in [$kNm/m$].
 
         NEN-EN 1993-5:2008(E) art.5.2.2(2) - Formula (5.2)
 
         Parameters
         ----------
         beta_b : DIMENSIONLESS
-            [$$\beta_{b}$$] Reduction factor for the bending resistance of the cross-section in [$$-$$].
+            [$\beta_{b}$] Reduction factor for the bending resistance of the cross-section in [$-$].
         w_pl : MM3
-            [$$W_{pl}$$] Plastic section modulus in [$$mm^3/m$$].
+            [$W_{pl}$] Plastic section modulus in [$mm^3/m$].
         f_y : MPA
-            [$$f_{y}$$] Yield strength in [$$MPa$$].
+            [$f_{y}$] Yield strength in [$MPa$].
         gamma_m_0 : DIMENSIONLESS
-            [$$\gamma_{M0}$$] Partial factor for material properties in [$$-$$].
+            [$\gamma_{M0}$] Partial factor for material properties in [$-$].
         """
         super().__init__()
         self.beta_b = beta_b

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_3.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_3.py
@@ -21,20 +21,20 @@ class Form5Dot3DesignMomentResistanceClass3(Formula):
         f_y: MPA,
         gamma_m_0: DIMENSIONLESS,
     ) -> None:
-        r"""[$$M_{c,Rd}$$] Calculate design moment resistance of the cross-section (class 3) in [$$kNm/m$$].
+        r"""[$M_{c,Rd}$] Calculate design moment resistance of the cross-section (class 3) in [$kNm/m$].
 
         NEN-EN 1993-5:2008(E) art.5.2.2(2) - Formula (5.3)
 
         Parameters
         ----------
         beta_b : DIMENSIONLESS
-            [$$\beta_{b}$$] Reduction factor for the bending resistance of the cross-section in [$$-$$].
+            [$\beta_{b}$] Reduction factor for the bending resistance of the cross-section in [$-$].
         w_el : MM3
-            [$$W_{el}$$] Elastic section modulus in [$$mm^3/m$$].
+            [$W_{el}$] Elastic section modulus in [$mm^3/m$].
         f_y : MPA
-            [$$f_{y}$$] Yield strength in [$$MPa$$].
+            [$f_{y}$] Yield strength in [$MPa$].
         gamma_m_0 : DIMENSIONLESS
-            [$$\gamma_{M0}$$] Partial factor for material properties in [$$-$$].
+            [$\gamma_{M0}$] Partial factor for material properties in [$-$].
         """
         super().__init__()
         self.beta_b = beta_b

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_5.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_5.py
@@ -22,18 +22,18 @@ class Form5Dot5PlasticShearResistance(Formula):
         f_y: MPA,
         gamma_m_0: DIMENSIONLESS,
     ) -> None:
-        r"""([$$V_{pl,Rd}$$]) Calculate design plastic shear resistance for each web in [$$kN$$].
+        r"""([$V_{pl,Rd}$]) Calculate design plastic shear resistance for each web in [$kN$].
 
         NEN-EN 1993-5:2008(E) art.5.2.2(4) - Formula (5.5)
 
         Parameters
         ----------
         a_v : MM2
-            ([$$A_{v}$$]) Projected shear area for each web, acting in the same direction as VEd in [$$mm^2$$].
+            ([$A_{v}$]) Projected shear area for each web, acting in the same direction as VEd in [$mm^2$].
         f_y : MPA
-            ([$$f_{y}$$]) Yield strength in [$$MPa$$].
+            ([$f_{y}$]) Yield strength in [$MPa$].
         gamma_m_0 : DIMENSIONLESS
-            ([$$\gamma_{M0}$$]) Partial factor for material properties in [$$-$$].
+            ([$\gamma_{M0}$]) Partial factor for material properties in [$-$].
         """
         super().__init__()
         self.a_v: float = a_v

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_6.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_6.py
@@ -19,18 +19,18 @@ class Form5Dot6ProjectedShearArea(Formula):
         t_f: MM,
         t_w: MM,
     ) -> None:
-        r"""[$$A_{v}$$] Calculate the projected shear area for each web of a U-profile or Z-profile in [$$mm^2$$].
+        r"""[$A_{v}$] Calculate the projected shear area for each web of a U-profile or Z-profile in [$mm^2$].
 
         NEN-EN 1993-5:2008(E) art.5.2.2(5) - Formula (5.6)
 
         Parameters
         ----------
         h : MM
-            [$$h$$] Overall height in [$$mm$$].
+            [$h$] Overall height in [$mm$].
         t_f : MM
-            [$$t_{f}$$] Flange thickness in [$$mm$$].
+            [$t_{f}$] Flange thickness in [$mm$].
         t_w : MM
-            [$$t_{w}$$] Web thickness in [$$mm$$].
+            [$t_{w}$] Web thickness in [$mm$].
         """
         super().__init__()
         self.h: MM = h

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_7.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_7.py
@@ -22,23 +22,23 @@ class Form5Dot7ShearBucklingResistance(Formula):
         f_bv: MPA,
         gamma_m_0: DIMENSIONLESS,
     ) -> None:
-        r"""[$$V_{b,Rd}$$] Calculate the shear buckling resistance [$$kN$$].
+        r"""[$V_{b,Rd}$] Calculate the shear buckling resistance [$kN$].
 
         NEN-EN 1993-5:2008(E) art.5.2.2(7) - Formula (5.7)
 
         Parameters
         ----------
         h : MM
-            [$$h$$] Height of the web in [$$mm$$].
+            [$h$] Height of the web in [$mm$].
         t_f : MM
-            [$$t_{f}$$] Thickness of the flange in [$$mm$$].
+            [$t_{f}$] Thickness of the flange in [$mm$].
         t_w : MM
-            [$$t_{w}$$] Thickness of the web in [$$mm$$].
+            [$t_{w}$] Thickness of the web in [$mm$].
         f_bv : MPA
-            [$$f_{bv}$$] Shear buckling strength according to Table 6-1 of EN 1993-1-3 for a web without stiffening
-            at the support and for a relative web slenderness [$$MPa$$].
+            [$f_{bv}$] Shear buckling strength according to Table 6-1 of EN 1993-1-3 for a web without stiffening
+            at the support and for a relative web slenderness [$MPa$].
         gamma_m_0 : DIMENSIONLESS
-            [$$\gamma_{M0}$$] Partial factor for material properties [$$-$$].
+            [$\gamma_{M0}$] Partial factor for material properties [$-$].
         """
         super().__init__()
         self.h: float = h

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_8.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_8.py
@@ -22,20 +22,20 @@ class Form5Dot8RelativeWebSlenderness(Formula):
         f_y: MPA,  # Yield strength
         e: MPA,  # Young's modulus
     ) -> None:
-        r"""[$$\overline{\lambda}$$] Calculate the relative slenderness of the web [$$-$$].
+        r"""[$\overline{\lambda}$] Calculate the relative slenderness of the web [$-$].
 
         NEN-EN 1993-5:2008(E) art.5.2.2(7) - Formula (5.8)
 
         Parameters
         ----------
         c : MM
-            [$$c$$] Length of the web in [$$mm$$].
+            [$c$] Length of the web in [$mm$].
         t_w : MM
-            [$$t_{w}$$] Thickness of the web in [$$mm$$].
+            [$t_{w}$] Thickness of the web in [$mm$].
         f_y : MPA
-            [$$f_{y}$$] Yield strength in [$$MPa$$].
+            [$f_{y}$] Yield strength in [$MPa$].
         e : MPA
-            [$$E$$] Young's modulus in [$$MPa$$].
+            [$E$] Young's modulus in [$MPa$].
         """
         super().__init__()
         self.c: MM = c

--- a/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_9.py
+++ b/blueprints/codes/eurocode/nen_en_1993_5_2008/chapter_5_ultimate_limit_states/formula_5_9.py
@@ -28,7 +28,7 @@ class Form5Dot9ReducedBendingMomentResistance(Formula):
         gamma_m_0: DIMENSIONLESS,
         mc_rd: KNM,
     ) -> None:
-        r"""[$$M_{V,Rd}$$] Calculate reduced design bending moment resistance of the cross-section allowing for the shear force in [$$kNm$$].
+        r"""[$M_{V,Rd}$] Calculate reduced design bending moment resistance of the cross-section allowing for the shear force in [$kNm$].
 
         This calculation is specifically for sheet pile cross-sections, particularly U-profiles and Z-profiles.
 
@@ -37,32 +37,32 @@ class Form5Dot9ReducedBendingMomentResistance(Formula):
         Parameters
         ----------
         beta_b : DIMENSIONLESS
-            [$$β_{b}$$] Reduction factor for the bending resistance of the cross-section, which takes account of
-            possible lack of shear force transmission in the interlocks [$$-$$].
+            [$β_{b}$] Reduction factor for the bending resistance of the cross-section, which takes account of
+            possible lack of shear force transmission in the interlocks [$-$].
             Defined in NEN-EN 1993-5:2008(E) art. 5.2.2(2) or CUR166, part 2, par. 3.3.2.
         w_pl : MM3
-            [$$W_{pl}$$] Plastic section modulus in [$$mm^3$$].
+            [$W_{pl}$] Plastic section modulus in [$mm^3$].
         rho : DIMENSIONLESS
-            [$$ρ$$] Reduction factor for shear resistance of the cross-section, according NEN-EN 1993-5:2008(E) art. 5.2.2(9) formula 5.10 [$$-$$].
+            [$ρ$] Reduction factor for shear resistance of the cross-section, according NEN-EN 1993-5:2008(E) art. 5.2.2(9) formula 5.10 [$-$].
         a_v : MM2
-            [$$A_{V}$$] Projected shear area for each web, acting in the same direction as VEd in [$$mm^2$$].
+            [$A_{V}$] Projected shear area for each web, acting in the same direction as VEd in [$mm^2$].
         t_w : MM
-            [$$t_{w}$$] Thickness of the web in [$$mm$$].
+            [$t_{w}$] Thickness of the web in [$mm$].
         alpha : DEG
-            [$$α$$] the inclination of the web according to NEN-EN 1993-5:2008(E) Figure 5-1 in [$$degrees$$].
+            [$α$] the inclination of the web according to NEN-EN 1993-5:2008(E) Figure 5-1 in [$degrees$].
         f_y : MPA
-            [$$f_{y}$$] Yield strength in [$$MPa$$].
+            [$f_{y}$] Yield strength in [$MPa$].
         gamma_m_0 : DIMENSIONLESS
-            [$$γ_{M0}$$] Partial factor for material properties in [$$-$$].
+            [$γ_{M0}$] Partial factor for material properties in [$-$].
         mc_rd : KNM
-            [$$M_{c,Rd}$$] Design moment resistance of the cross-section in [$$kNm$$].
+            [$M_{c,Rd}$] Design moment resistance of the cross-section in [$kNm$].
 
             The `mc_rd` parameter represents the design moment resistance of the cross-section.
             In the context of the formula for reduced bending moment resistance, it serves as an upper bound.
             The formula calculates the reduced design bending moment resistance (`m_v_rd`) and then returns the minimum of `m_v_rd` and `mc_rd`.
             This means that the result of the formula will never exceed `mc_rd`, making `mc_rd` an upper bound for this formula.
 
-            [$$M_{v,Rd} \leq M_{c,Rd}$$]
+            [$M_{v,Rd} \leq M_{c,Rd}$]
         """
         super().__init__()
         self.beta_b: DIMENSIONLESS = beta_b

--- a/blueprints/materials/concrete.py
+++ b/blueprints/materials/concrete.py
@@ -78,26 +78,26 @@ class ConcreteMaterial:
     cement_class: CementClass
         Cement class needed for calculation of Creep and shrinkage strain (Annex B from NEN-EN 1992-1-1). Classes are S, N and R. (default= N)
     density: KG_M3
-        Unit mass of concrete [$$kg/m^3$$] (default= 2500.0 for regular reinforced concrete)
+        Unit mass of concrete [$kg/m^3$] (default= 2500.0 for regular reinforced concrete)
     diagram_type: DiagramType
         Type of stress-strain diagram (Figures 3.2, 3.3 and 3.4 from NEN-EN 1992-1-1) (default= Bi-Linear)
     aggregate_type: ConcreteAggregateType
         Type of aggregate in the concrete material (NEN-EN 1992-1-1) (default= Quartzite)
     aggregate_size: MM
-        Largest nominal maximum aggregate size [$$mm$$] (NEN-EN 1992-1-1) (default= 16.0)
+        Largest nominal maximum aggregate size [$mm$] (NEN-EN 1992-1-1) (default= 16.0)
     use_plain_concrete_diagram: bool
         Use a Stress-strain diagram for plain or lightly reinforced concrete (NEN-EN 1992-1-1) (default= False)
     material_factor: DIMENSIONLESS
-        Partial safety factor [$$\gamma_c$$] for concrete according to NEN-EN 1992-1-1 art.2.4.2.4 [$$-$$] (default= 1.5)
+        Partial safety factor [$\gamma_c$] for concrete according to NEN-EN 1992-1-1 art.2.4.2.4 [$-$] (default= 1.5)
     thermal_coefficient: PER_DEGREE
-        Thermal coefficient of the material [$$1/°C$$] (default= 1e-5)
+        Thermal coefficient of the material [$1/°C$] (default= 1e-5)
     cement_type: CementType
         Type of cement in the concrete material (NEN-EN 1992-1-1) (default= CEM III)
     custom_name: str
         Use a custom name for the concrete material (default= concrete class name)
     custom_e_c: MPA
-        Use a custom modulus of elasticity of concrete [$$MPa$$]
-        If no custom value is given, the value [$$E_{cm}$$] from table 3.1 of NEN-EN 1992-1-1 is used.
+        Use a custom modulus of elasticity of concrete [$MPa$]
+        If no custom value is given, the value [$E_{cm}$] from table 3.1 of NEN-EN 1992-1-1 is used.
 
     """
 
@@ -129,9 +129,9 @@ class ConcreteMaterial:
 
     @property
     def e_c(self) -> MPA:
-        r"""[$$E_c$$] Modulus of elasticity of concrete [$$MPa$$].
+        r"""[$E_c$] Modulus of elasticity of concrete [$MPa$].
 
-        If no custom value is given, the value [$$E_{cm}$$] from table 3.1 of NEN-EN 1992-1-1 is used.
+        If no custom value is given, the value [$E_{cm}$] from table 3.1 of NEN-EN 1992-1-1 is used.
 
         Returns
         -------
@@ -144,7 +144,7 @@ class ConcreteMaterial:
 
     @property
     def f_ck(self) -> MPA:
-        r"""[$$f_{ck}$$] Characteristic compressive cylinder strength of concrete at 28 days [$$MPa$$].
+        r"""[$f_{ck}$] Characteristic compressive cylinder strength of concrete at 28 days [$MPa$].
 
         Returns
         -------
@@ -158,7 +158,7 @@ class ConcreteMaterial:
 
     @property
     def f_ck_cube(self) -> MPA:
-        r"""[$$f_{ck,cube}$$] Characteristic compressive cubic strength of concrete at 28 days [$$MPa$$].
+        r"""[$f_{ck,cube}$] Characteristic compressive cubic strength of concrete at 28 days [$MPa$].
 
         Returns
         -------
@@ -172,7 +172,7 @@ class ConcreteMaterial:
 
     @property
     def f_cd(self) -> MPA:
-        r"""[$$f_{cd}$$] Design value of concrete compressive strength (NEN-EN 1992-1-1 art.3.1.6 (1)) [$$MPa$$].
+        r"""[$f_{cd}$] Design value of concrete compressive strength (NEN-EN 1992-1-1 art.3.1.6 (1)) [$MPa$].
 
         Returns
         -------
@@ -183,7 +183,7 @@ class ConcreteMaterial:
 
     @property
     def f_cm(self) -> MPA:
-        r"""[$$f_{cm}$$] Mean value of concrete cylinder compressive strength [$$MPa$$].
+        r"""[$f_{cm}$] Mean value of concrete cylinder compressive strength [$MPa$].
 
         Returns
         -------
@@ -194,7 +194,7 @@ class ConcreteMaterial:
 
     @property
     def f_cm_cube(self) -> MPA:
-        r"""[$$f_{cm,cube}$$] Mean value of concrete cubic compressive strength [$$MPa$$].
+        r"""[$f_{cm,cube}$] Mean value of concrete cubic compressive strength [$MPa$].
 
         Returns
         -------
@@ -205,7 +205,7 @@ class ConcreteMaterial:
 
     @property
     def f_ctm(self) -> MPA:
-        r"""[$$f_{ctm}$$] Mean value of axial tensile strength of concrete [$$MPa$$].
+        r"""[$f_{ctm}$] Mean value of axial tensile strength of concrete [$MPa$].
 
         Returns
         -------
@@ -218,7 +218,7 @@ class ConcreteMaterial:
 
     @property
     def sigma_cr(self) -> MPA:
-        r"""[$$\sigma_{cr}$$] Crack tensile stress (long term) equal to [$$0.6 \cdot f_{ctm}$$] [$$MPa$$].
+        r"""[$\sigma_{cr}$] Crack tensile stress (long term) equal to [$0.6 \cdot f_{ctm}$] [$MPa$].
 
         Returns
         -------
@@ -229,7 +229,7 @@ class ConcreteMaterial:
 
     @property
     def strain_cr(self) -> MPA:
-        r"""[$$\epsilon_{cr}$$] Strain at crack tensile stress (long term) equal to [$$\sigma_{cr} / E_{cm}$$] [$$MPa$$].
+        r"""[$\epsilon_{cr}$] Strain at crack tensile stress (long term) equal to [$\sigma_{cr} / E_{cm}$] [$MPa$].
 
         Returns
         -------
@@ -240,7 +240,7 @@ class ConcreteMaterial:
 
     @property
     def f_ctk_0_05(self) -> MPA:
-        r"""[$$f_{ctk,0.05}$$] Mean value of axial tensile strength of concrete, 5% fractile [$$MPa$$].
+        r"""[$f_{ctk,0.05}$] Mean value of axial tensile strength of concrete, 5% fractile [$MPa$].
 
         Returns
         -------
@@ -251,7 +251,7 @@ class ConcreteMaterial:
 
     @property
     def f_ctd(self) -> MPA:
-        r"""[$$f_{ctd}$$] Design value of tensile strength of concrete [$$MPa$$].
+        r"""[$f_{ctd}$] Design value of tensile strength of concrete [$MPa$].
 
         Returns
         -------
@@ -262,7 +262,7 @@ class ConcreteMaterial:
 
     @property
     def f_ctk_0_95(self) -> MPA:
-        r"""[$$f_{ctk,0.95}$$] Mean value of axial tensile strength of concrete, 95% fractile [$$MPa$$].
+        r"""[$f_{ctk,0.95}$] Mean value of axial tensile strength of concrete, 95% fractile [$MPa$].
 
         Returns
         -------
@@ -273,7 +273,7 @@ class ConcreteMaterial:
 
     @property
     def e_cm(self) -> MPA:
-        r"""[$$E_{cm}$$] Secant modulus of elasticity of concrete [$$MPa$$].
+        r"""[$E_{cm}$] Secant modulus of elasticity of concrete [$MPa$].
 
         Returns
         -------
@@ -284,7 +284,7 @@ class ConcreteMaterial:
 
     @property
     def custom_e_c_present(self) -> bool:
-        r"""Checks if the value of [$$E_c$$] equal is to the value of [$$E_{cm}$$] from table 3.1 of NEN-EN 1992-1-1.
+        r"""Checks if the value of [$E_c$] equal is to the value of [$E_{cm}$] from table 3.1 of NEN-EN 1992-1-1.
 
         Returns
         -------
@@ -295,7 +295,7 @@ class ConcreteMaterial:
 
     @property
     def eps_c1(self) -> PER_MILLE:
-        r"""[$$\epsilon_{c1}$$] Compressive strain in the concrete at the peak stress [$$f_c$$] [$$‰$$ (per mille)]. Value with a maximum of 2.8 ‰.
+        r"""[$\epsilon_{c1}$] Compressive strain in the concrete at the peak stress [$f_c$] [$‰$ (per mille)]. Value with a maximum of 2.8 ‰.
         Check Figure 3.2 of NEN-EN 1992-1-1.
 
         Returns
@@ -307,7 +307,7 @@ class ConcreteMaterial:
 
     @property
     def eps_cu1(self) -> PER_MILLE:
-        r"""[$$\epsilon_{cu1}$$] Nominal ultimate compressive strain in the concrete [$$‰$$ (per mille)]. Check Figure 3.2 of NEN-EN 1992-1-1.
+        r"""[$\epsilon_{cu1}$] Nominal ultimate compressive strain in the concrete [$‰$ (per mille)]. Check Figure 3.2 of NEN-EN 1992-1-1.
 
         Returns
         -------
@@ -320,7 +320,7 @@ class ConcreteMaterial:
 
     @property
     def eps_c2(self) -> PER_MILLE:
-        r"""[$$\epsilon_{c2}$$] Compressive strain at reaching the maximum strength according to Table 3.1 [$$‰$$ (per mille)].
+        r"""[$\epsilon_{c2}$] Compressive strain at reaching the maximum strength according to Table 3.1 [$‰$ (per mille)].
         Check Figure 3.3 of NEN-EN 1992-1-1.
 
         Returns
@@ -334,7 +334,7 @@ class ConcreteMaterial:
 
     @property
     def eps_cu2(self) -> PER_MILLE:
-        r"""[$$\epsilon_{cu2}$$] Nominal ultimate compressive strain in the concrete according to Table 3.1 [$$‰$$ (per mille)].
+        r"""[$\epsilon_{cu2}$] Nominal ultimate compressive strain in the concrete according to Table 3.1 [$‰$ (per mille)].
         Check Figure 3.3 of NEN-EN 1992-1-1.
 
         Returns
@@ -348,7 +348,7 @@ class ConcreteMaterial:
 
     @property
     def n_factor(self) -> DIMENSIONLESS:
-        r"""[$$n$$] factor from table 3.1 of NEN-EN 1992-1-1 [$$-$$].
+        r"""[$n$] factor from table 3.1 of NEN-EN 1992-1-1 [$-$].
 
         Returns
         -------
@@ -361,7 +361,7 @@ class ConcreteMaterial:
 
     @property
     def eps_c3(self) -> PER_MILLE:
-        r"""[$$\epsilon_{c3}$$] Compressive strain at reaching the maximum strength according to Bi-linear stress-strain relation [$$‰$$ (per mille)].
+        r"""[$\epsilon_{c3}$] Compressive strain at reaching the maximum strength according to Bi-linear stress-strain relation [$‰$ (per mille)].
 
         Check Figure 3.4 of NEN-EN 1992-1-1.
 
@@ -376,7 +376,7 @@ class ConcreteMaterial:
 
     @property
     def eps_cu3(self) -> PER_MILLE:
-        r"""[$$\epsilon_{cu3}$$] Nominal ultimate compressive strain in concrete according to Bi-linear stress-strain relation [$$‰$$ (per mille)].
+        r"""[$\epsilon_{cu3}$] Nominal ultimate compressive strain in concrete according to Bi-linear stress-strain relation [$‰$ (per mille)].
 
         Check Figure 3.4 of NEN-EN 1992-1-1.
 
@@ -390,12 +390,12 @@ class ConcreteMaterial:
         return 3.5
 
     def rho_min(self, f_yd: MPA) -> PERCENTAGE:
-        r"""[$$\rho_{min}$$] Minimum reinforcement ratio (CB2, 7de druk 2011, pag.55) [$$%$$].
+        r"""[$\rho_{min}$] Minimum reinforcement ratio (CB2, 7de druk 2011, pag.55) [$%$].
 
         Parameters
         ----------
         f_yd: MPA
-            Design yield strength of reinforcement [$$MPa$$]
+            Design yield strength of reinforcement [$MPa$]
 
         Returns
         -------

--- a/blueprints/materials/reinforcement_steel.py
+++ b/blueprints/materials/reinforcement_steel.py
@@ -73,7 +73,7 @@ class ReinforcementSteelMaterial:
     steel_quality: ReinforcementSteelQuality,
         Steel quality of the ReinforcementSteelMaterial object (default: B500B).
     density: KG_M3
-        Unit weight of steel [kg/m³] (default= 7850.0) [$$kg/m^3$$]
+        Unit weight of steel [kg/m³] (default= 7850.0) [$kg/m^3$]
     reinforcement_type: ReinforcementType
         Product form / Reinforcement type (default=ReinforcementType.BARS)
     bar_surface: ReinforcementBarSurface
@@ -85,7 +85,7 @@ class ReinforcementSteelMaterial:
     custom_name: str
         User-defined name of the material (default= name of steel quality; example: 'B500B')
     custom_e_s: MPA
-        User-defined Young's modulus of the material, if not provided the default value is used (default=200000) [$$MPa$$]
+        User-defined Young's modulus of the material, if not provided the default value is used (default=200000) [$MPa$]
 
     """
 
@@ -113,7 +113,7 @@ class ReinforcementSteelMaterial:
 
     @property
     def e_s(self) -> MPA:
-        r"""Reinforcement steel Young's modulus [$$MPa$$].
+        r"""Reinforcement steel Young's modulus [$MPa$].
 
         Returns
         -------
@@ -126,7 +126,7 @@ class ReinforcementSteelMaterial:
 
     @property
     def f_yk(self) -> MPA:
-        r"""[$$f_{yk}$$] Characteristic yield strength of reinforcement [$$MPa$$].
+        r"""[$f_{yk}$] Characteristic yield strength of reinforcement [$MPa$].
 
         Returns
         -------
@@ -148,7 +148,7 @@ class ReinforcementSteelMaterial:
 
     @property
     def f_tk(self) -> MPA:
-        r"""[$$f_{tk}$$] Characteristic tensile strength of reinforcement [$$MPa$$].
+        r"""[$f_{tk}$] Characteristic tensile strength of reinforcement [$MPa$].
 
         Returns
         -------
@@ -159,7 +159,7 @@ class ReinforcementSteelMaterial:
 
     @property
     def ductility_factor_k(self) -> DIMENSIONLESS:
-        r"""Ductility factor k [$$-$$] -> ([$$f_{tk}$$] / [$$f_{yk}$$]) tabel C.1 Annex C from NEN-EN 1992-1-1.
+        r"""Ductility factor k [$-$] -> ([$f_{tk}$] / [$f_{yk}$]) tabel C.1 Annex C from NEN-EN 1992-1-1.
 
         * 1.05 for steel class A
         * 1.08 for steel class B
@@ -182,7 +182,7 @@ class ReinforcementSteelMaterial:
 
     @property
     def eps_uk(self) -> PER_MILLE:
-        r"""[$$\varepsilon_{uk}$$] Characteristic strain of reinforcement at max. load [$$‰$$ (per mille)] (tabel C.1 Annex C from NEN-EN 1992-1-1).
+        r"""[$\varepsilon_{uk}$] Characteristic strain of reinforcement at max. load [$‰$ (per mille)] (tabel C.1 Annex C from NEN-EN 1992-1-1).
 
         * 250 ‰ for steel class A
         * 500 ‰ for steel class B

--- a/docs/_overrides/assets/javascripts/katex.js
+++ b/docs/_overrides/assets/javascripts/katex.js
@@ -2,10 +2,10 @@
 document$.subscribe(({ body }) => { 
     renderMathInElement(body, {
       delimiters: [
-        { left: "$$",  right: "$$",  display: false },
+        { left: "$$",  right: "$$",  display: true },
         { left: "$",   right: "$",   display: false },
         { left: "\\(", right: "\\)", display: false },
-        { left: "\\[", right: "\\]", display: false}
+        { left: "\\[", right: "\\]", display: true }
       ],
     })
   })

--- a/docs/_overrides/assets/stylesheets/extra.css
+++ b/docs/_overrides/assets/stylesheets/extra.css
@@ -66,7 +66,7 @@
 .highlight .sd {
     color: var(--md-code-hl-string-color);
 }
-/* specific style for kc (boolean) class to match string color */
+/* specific style for kc (boolean) class to match special color */
 .highlight .kc {
     color: var(--md-code-hl-special-color);
 }

--- a/docs/_overrides/assets/stylesheets/extra.css
+++ b/docs/_overrides/assets/stylesheets/extra.css
@@ -61,3 +61,13 @@
     --md-code-hl-bg-color: #1e1e1e;
     --md-code-hl-string-color: #ce9178;
 }
+
+/* specific style for sd (docstring) class to match string color */
+.highlight .sd {
+    color: var(--md-code-hl-string-color);
+}
+/* specific style for kc (boolean) class to match string color */
+.highlight .kc {
+    color: var(--md-code-hl-special-color);
+}
+

--- a/docs/_overrides/assets/stylesheets/extra.css
+++ b/docs/_overrides/assets/stylesheets/extra.css
@@ -52,3 +52,12 @@
     max-width: fit-content;       /* Expand to content width */
     word-break: break-word;       /* Enable word breaks */
 }
+
+/* alternative code highlighting equal to vscode default */
+
+:root > * {
+    --md-code-hl-comment-color: #6a9955;
+    --md-code-hl-name-color: #4ec9b0;
+    --md-code-hl-bg-color: #1e1e1e;
+    --md-code-hl-string-color: #ce9178;
+}

--- a/docs/_scripts/generate_index.py
+++ b/docs/_scripts/generate_index.py
@@ -1,0 +1,26 @@
+"""Generate the index page using the README.md file and fixing the cross links."""
+
+import re
+from pathlib import Path
+
+import mkdocs_gen_files
+
+root = Path(__file__).parents[2]
+readme_file = root / "README.md"
+
+with open(readme_file, encoding="utf-8") as fd:
+    readme_content = fd.read()
+    readme_content = readme_content.replace("docs/", "")
+    # replace the relative links to the overview page by removing the .md extension
+    readme_content = re.sub(r"/\w+\.md", lambda match: match.group(0)[:-3], readme_content)
+    # replace blueprints/code references by links to the API reference
+    readme_content = readme_content.replace('"blueprints/codes', '"API reference/codes')
+    # add 'https://github.com/Blueprints-org/blueprints' prefix to file in [link](file) if file is not a URL
+    readme_content = re.sub(r"\[([^\]]+)\]\((?!http)([^)]+)\)", r"[\1](https://github.com/Blueprints-org/blueprints/blob/main/\2)", readme_content)
+    # remove the read the docs chapter, we're already in the docs
+    readme_content = re.sub(r"## Read the docs!\n\n.*\n## Quick", "## Quick", readme_content, flags=re.DOTALL)
+
+with mkdocs_gen_files.open("index.md", "w") as fd:
+    # hide navigation in the index page
+    fd.writelines(["---\n", "hide:\n", "  - navigation\n", "---\n"])
+    fd.write(readme_content)

--- a/docs/_scripts/generate_reference_pages.py
+++ b/docs/_scripts/generate_reference_pages.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import mkdocs_gen_files
+from natsort import natsorted
 
 nav = mkdocs_gen_files.Nav()
 mod_symbol = '<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code>'
@@ -10,7 +11,7 @@ mod_symbol = '<code class="doc-symbol doc-symbol-nav doc-symbol-module"></code>'
 root = Path(__file__).parents[2]
 src = root / "blueprints"
 
-for path in sorted(src.rglob("*.py")):
+for path in natsorted(src.rglob("*.py")):
     module_path = path.relative_to(src).with_suffix("")
     doc_path = path.relative_to(src).with_suffix(".md")
     full_doc_path = Path("API reference", doc_path)

--- a/docs/examples/nominal_concrete_cover.md
+++ b/docs/examples/nominal_concrete_cover.md
@@ -41,7 +41,7 @@ Then just print the results:
 
 The output will be:
 
-```python
+```text
 Structural class: S5
 
 C,min,dur: 20.0 mm

--- a/docs/examples/nominal_concrete_cover.md
+++ b/docs/examples/nominal_concrete_cover.md
@@ -1,3 +1,7 @@
+---
+hide:
+  - toc
+---
 # Nominal Concrete Cover
 
 Calculating the nominal concrete cover is an important step in the design of reinforced concrete structures.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,0 @@
----
-hide:
-  - navigation
----
---8<-- "README.md::9"
-![](assets/images/blueprints_banner.png)
---8<-- "README.md:16:137"
---8<-- "README.md:150"

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -6,3 +6,5 @@ mkdocs-nav-weight ~= 0.2.0
 mkdocs-git-revision-date-localized-plugin ~= 1.2.6
 mkdocstrings[python] ~= 0.27.0
 mkdocs-gen-files ~= 0.5.0
+mkdocs-awesome-nav ~= v3.0.0
+natsorted ~= 8.4.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ plugins:
   - gen-files:
       scripts:
         - docs/_scripts/generate_reference_pages.py
+        - docs/_scripts/generate_index.py
   - mkdocstrings:
       handlers:
         python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ plugins:
             unwrap_annotated: true
             docstring_section_style: list
             show_if_no_docstring: false
+  - awesome-nav
 
 markdown_extensions: 
   - pymdownx.highlight:


### PR DESCRIPTION
## Description

Several improvements of the documentation:
- change block syntax latex to inline syntax for better rendering
- apply natural sorting for modules in the API reference
- improved syntax highlighting colors
- fixed banner in readme
- dynamic readme adjustment to improve cross-links in documentation

Fixes #493 

For the review:
i would suggest not to dive to deep in the changes for double dollar to single dollar, it is just a replacement of $$ to $. 

The files that are more interesting are just about the docs.

