### PR TITLE
Restructure exposure classes after Eurocode rename

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v0.11.13
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format

--- a/blueprints/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/table_4_1.py
+++ b/blueprints/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/table_4_1.py
@@ -2,13 +2,11 @@
 according to Table 4.1 from EN 1992-1-1:2004: Chapter 4 - Durability and cover to reinforcement.
 """
 
-from collections.abc import Sequence
 from functools import total_ordering
-from typing import Self, TypeVar
 
 from blueprints.codes.eurocode.exposure_classes import (
-    ExposureClassesBase,
     Exposure,
+    ExposureClassesBase,
 )
 
 
@@ -53,17 +51,6 @@ class Carbonation(Exposure):
             case Carbonation.NA:
                 return "Not applicable"
 
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XC"
-
 
 @total_ordering
 class Chloride(Exposure):
@@ -103,17 +90,6 @@ class Chloride(Exposure):
             case Chloride.NA:
                 return "Not applicable"
 
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XD"
-
 
 @total_ordering
 class ChlorideSeawater(Exposure):
@@ -152,17 +128,6 @@ class ChlorideSeawater(Exposure):
                 return "Tidal, splash and spray zones"
             case ChlorideSeawater.NA:
                 return "Not applicable"
-
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XS"
 
 
 @total_ordering
@@ -206,17 +171,6 @@ class FreezeThaw(Exposure):
             case FreezeThaw.NA:
                 return "Not applicable"
 
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XF"
-
 
 @total_ordering
 class Chemical(Exposure):
@@ -256,79 +210,37 @@ class Chemical(Exposure):
             case Chemical.NA:
                 return "Not applicable"
 
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XA"
-
-
-# Define a generic type for the class
-T = TypeVar("T", bound="Table4Dot1ExposureClasses")
-
 
 class Table4Dot1ExposureClasses(ExposureClassesBase):
-    """Implementation of table 4.1 from EN 1992-1-1:2004.
+    """Class representing table 4.1 from EN 1992-1-1:2004."""
 
-    Exposure classes related to environmental conditions in accordance with EN 206-1
-    """
+    def __init__(
+        self,
+        carbonation: Carbonation = Carbonation.NA,
+        chloride: Chloride = Chloride.NA,
+        chloride_seawater: ChlorideSeawater = ChlorideSeawater.NA,
+        freeze_thaw: FreezeThaw = FreezeThaw.NA,
+        chemical: Chemical = Chemical.NA,
+    ) -> None:
+        """Implementation of table 4.1 from EN 1992-1-1:2004 par. 4.2.
 
-    carbonation: Carbonation
-    chloride: Chloride
-    chloride_seawater: ChlorideSeawater
-    freeze: FreezeThaw
-    chemical: Chemical
-
-    @classmethod
-    def from_exposure_list(cls, exposure_classes: Sequence[str]) -> Self:
-        """Create an instance from a sequence of exposure classes.
-
-        Examples
-        --------
-        >>> exposure_classes = ["XC1", "XD1", "XS1"]
-        >>> Table4Dot1ExposureClasses().from_exposure_list(exposure_classes)
-        Table4Dot1ExposureClasses(
-            carbonation=<Carbonation.XC1: 'XC1'>,
-            chloride=<Chloride.XD1: 'XD1'>,
-            chloride_seawater=<ChlorideSeawater.XS1: 'XS1'>,
-            freeze=<FreezeThaw.NA: 'Not applicable'>,
-            chemical=<Chemical.NA: 'Not applicable'>
-        )
+        Exposure classes related to environmental conditions in accordance with EN 206-1
 
         Parameters
         ----------
-        exposure_classes : Sequence[str]
-            list of exposure classes, order is not important. If an exposure class is not provided, it is set to "Not applicable"
-            You can use capital letters or lowercase letters, the method is case-insensitive.
-            For example, "XC1" and "xc1" are both valid.
-
-        Returns
-        -------
-        Self
-            instance created from the list
+        carbonation : Carbonation
+            The carbonation exposure class. Defaults to Carbonation.NA.
+        chloride : Chloride
+            The chloride exposure class. Defaults to Chloride.NA.
+        chloride_seawater : ChlorideSeawater
+            The chloride seawater exposure class. Defaults to ChlorideSeawater.NA.
+        freeze_thaw : FreezeThaw
+            The freeze/thaw exposure class. Defaults to FreezeThaw.NA.
+        chemical : Chemical
+            The chemical exposure class. Defaults to Chemical.NA.
         """
-        exposures: dict[str, Carbonation | Chloride | ChlorideSeawater | Chemical | FreezeThaw] = {}
-        classifications = {
-            classification.notation(): classification for classification in (Carbonation, Chloride, ChlorideSeawater, FreezeThaw, Chemical)
-        }
-
-        for exposure_str in exposure_classes:
-            classification = classifications.get(exposure_str[:2].upper())
-            if classification is None:
-                raise ValueError(f"Invalid exposure class: '{exposure_str}'")
-            classification_name = classification.snake_case().removesuffix("_thaw")
-            if classification_name in exposures:
-                raise ValueError(f"Duplication Error: There are multiple instances of '{classification.__name__}' class.")
-            exposures[classification_name] = classification[exposure_str.upper()]
-
-        for classification in classifications.values():
-            classification_name = classification.snake_case().removesuffix("_thaw")
-            if classification_name not in exposures:
-                exposures.setdefault(classification_name, classification.NA)
-
-        return cls(**exposures)  # type: ignore[arg-type]
+        self.carbonation = carbonation
+        self.chloride = chloride
+        self.chloride_seawater = chloride_seawater
+        self.freeze_thaw = freeze_thaw
+        self.chemical = chemical

--- a/blueprints/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/table_4_1.py
+++ b/blueprints/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/table_4_1.py
@@ -7,17 +7,13 @@ from functools import total_ordering
 from typing import Self, TypeVar
 
 from blueprints.codes.eurocode.exposure_classes import (
-    CarbonationBase,
-    ChemicalBase,
-    ChlorideBase,
-    ChlorideSeawaterBase,
     ExposureClassesBase,
-    FreezeThawBase,
+    Exposure,
 )
 
 
 @total_ordering
-class Carbonation(CarbonationBase):
+class Carbonation(Exposure):
     """Enum Class which indicates the classification of corrosion induced by carbonation."""
 
     NA = "Not applicable"
@@ -70,7 +66,7 @@ class Carbonation(CarbonationBase):
 
 
 @total_ordering
-class Chloride(ChlorideBase):
+class Chloride(Exposure):
     """Enum Class which indicates the classification of corrosion induced by chlorides other than by sea water."""
 
     NA = "Not applicable"
@@ -120,7 +116,7 @@ class Chloride(ChlorideBase):
 
 
 @total_ordering
-class ChlorideSeawater(ChlorideSeawaterBase):
+class ChlorideSeawater(Exposure):
     """Enum Class which indicates the classification of corrosion induced by chlorides from sea water."""
 
     NA = "Not applicable"
@@ -170,7 +166,7 @@ class ChlorideSeawater(ChlorideSeawaterBase):
 
 
 @total_ordering
-class FreezeThaw(FreezeThawBase):
+class FreezeThaw(Exposure):
     """Enum Class which indicates the classification of freeze/thaw attack with or without de-icing agents."""
 
     NA = "Not applicable"
@@ -223,7 +219,7 @@ class FreezeThaw(FreezeThawBase):
 
 
 @total_ordering
-class Chemical(ChemicalBase):
+class Chemical(Exposure):
     """Enum Class which indicates the classification of chemical attack."""
 
     NA = "Not applicable"

--- a/blueprints/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/table_4_4n.py
+++ b/blueprints/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/table_4_4n.py
@@ -1,7 +1,7 @@
 """Table 4.4N from EN 1992-1-1:2004: Chapter 4 - Durability and cover to reinforcement."""
 
 from blueprints.codes.eurocode.en_1992_1_1_2004 import EN_1992_1_1_2004
-from blueprints.codes.eurocode.exposure_classes import ExposureClassesBase
+from blueprints.codes.eurocode.en_1992_1_1_2004.chapter_4_durability_and_cover.table_4_1 import Table4Dot1ExposureClasses
 from blueprints.codes.eurocode.structural_class import ConcreteStructuralClassBase
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula
@@ -19,7 +19,7 @@ class Table4Dot4nMinimumCoverDurabilityReinforcementSteel(Formula):
 
     def __init__(
         self,
-        exposure_classes: ExposureClassesBase,
+        exposure_classes: Table4Dot1ExposureClasses,
         structural_class: ConcreteStructuralClassBase,
     ) -> None:
         r"""[$c_{min,dur}$] Calculates the minimum concrete cover with regard to durability [$mm$] for reinforcement steel.
@@ -28,7 +28,7 @@ class Table4Dot4nMinimumCoverDurabilityReinforcementSteel(Formula):
 
         Parameters
         ----------
-        exposure_classes: ExposureClassesBase
+        exposure_classes: Table4Dot1ExposureClasses
             The exposure classes of the concrete. Use the [$Table4Dot1ExposureClasses$] class. [$-$]
         structural_class: ConcreteStructuralClassBase
             The structural class of the concrete. Use the [$Table4Dot3ConcreteStructuralClass$] class. [$-$]
@@ -39,7 +39,7 @@ class Table4Dot4nMinimumCoverDurabilityReinforcementSteel(Formula):
 
     @staticmethod
     def _evaluate(
-        exposure_classes: ExposureClassesBase,
+        exposure_classes: Table4Dot1ExposureClasses,
         structural_class: ConcreteStructuralClassBase,
     ) -> MM:
         """For more detailed documentation see the class docstring."""

--- a/blueprints/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/table_4_5n.py
+++ b/blueprints/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/table_4_5n.py
@@ -1,7 +1,7 @@
 """Table 4.5N from EN 1992-1-1:2004: Chapter 4 - Durability and cover to reinforcement."""
 
 from blueprints.codes.eurocode.en_1992_1_1_2004 import EN_1992_1_1_2004
-from blueprints.codes.eurocode.exposure_classes import ExposureClassesBase
+from blueprints.codes.eurocode.en_1992_1_1_2004.chapter_4_durability_and_cover.table_4_1 import Table4Dot1ExposureClasses
 from blueprints.codes.eurocode.structural_class import ConcreteStructuralClassBase
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula
@@ -19,7 +19,7 @@ class Table4Dot5nMinimumCoverDurabilityPrestressingSteel(Formula):
 
     def __init__(
         self,
-        exposure_classes: ExposureClassesBase,
+        exposure_classes: Table4Dot1ExposureClasses,
         structural_class: ConcreteStructuralClassBase,
     ) -> None:
         r"""[$c_{min,dur}$] Calculates the minimum concrete cover with regard to durability [$mm$] for prestressing steel.
@@ -28,7 +28,7 @@ class Table4Dot5nMinimumCoverDurabilityPrestressingSteel(Formula):
 
         Parameters
         ----------
-        exposure_classes: ExposureClassesBase
+        exposure_classes: Table4Dot1ExposureClasses
             The exposure classes of the concrete. Use the [$Table4Dot1ExposureClasses$] class. [$-$]
         structural_class: ConcreteStructuralClassBase
             The structural class of the concrete. Use the [$Table4Dot3ConcreteStructuralClass$] class. [$-$]
@@ -39,7 +39,7 @@ class Table4Dot5nMinimumCoverDurabilityPrestressingSteel(Formula):
 
     @staticmethod
     def _evaluate(
-        exposure_classes: ExposureClassesBase,
+        exposure_classes: Table4Dot1ExposureClasses,
         structural_class: ConcreteStructuralClassBase,
     ) -> MM:
         """For more detailed documentation see the class docstring."""

--- a/blueprints/codes/eurocode/exposure_classes.py
+++ b/blueprints/codes/eurocode/exposure_classes.py
@@ -4,11 +4,11 @@ according to Table 4.1 from NEN-EN 1992-1-1: Chapter 4 - Durability and cover to
 
 import re
 from abc import abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from functools import total_ordering
-from typing import Self
+from typing import ClassVar, Self
 
 from blueprints.utils.abc_enum_meta import ABCEnumMeta
 
@@ -116,6 +116,24 @@ class Exposure(Enum, metaclass=ABCEnumMeta):
         """
         return re.sub(r"(?<!^)(?=[A-Z])", "_", cls.__name__).lower()
 
+    @classmethod
+    def notation(cls) -> str:
+        """Returns the notation of the exposure class.
+
+        Returns
+        -------
+        str
+            notation of the exposure class, e.g. "XC", "XD", etc.
+        """
+        options = cls.options()
+        # Look for this pattern in the options: Uppercase letters followed by at least one digit
+        # If the pattern is found, return the Uppercase letters part
+        for option in options:
+            match = re.match(r"([A-Z]+)(\d+)", option)
+            if match:
+                return match.group(1)
+        raise ValueError(f"No valid notation found for {cls.__name__}. Available options: {options}")
+
 
 @dataclass(frozen=True)
 class ExposureClassesBase:
@@ -124,18 +142,20 @@ class ExposureClassesBase:
     Exposure classes related to environmental conditions in accordance with EN 206-1
     """
 
+    _not_applicable_key: ClassVar[str] = "Not applicable"
+
     @property
     def no_risk(self) -> bool:
-        """Check if all exposure classes are 'Not applicable'.
+        """Check if all exposure classes are 'Not applicable' (specified by _not_applicable_key).
 
         This represents X0 class designation according to table 4.1 from EN 1992-1-1:2004.
 
         Returns
         -------
         bool
-            True if all exposure classes are 'Not applicable'
+            True if all exposure classes are euqal to _not_applicable_key ("Not applicable")
         """
-        return all(exposure_class.value == "Not applicable" for exposure_class in self.__dict__.values())
+        return all(exposure_class.value == self.__class__._not_applicable_key for exposure_class in self.__dict__.values())  # noqa: SLF001
 
     def __str__(self) -> str:
         """String representation of the ExposureClasses object.
@@ -156,3 +176,51 @@ class ExposureClassesBase:
             Iterator for the ExposureClasses object
         """
         return iter(self.__dict__.values())
+
+    @classmethod
+    def from_exposure_list(cls, exposure_classes: Sequence[str]) -> Self:
+        """Create an instance from a sequence of exposure classes.
+
+        Examples
+        --------
+        >>> exposure_classes = ["XC1", "XD1", "XS1"]
+        >>> ConcreteExposureClasses().from_exposure_list(exposure_classes)
+        ConcreteExposureClasses(
+            carbonation=<Carbonation.XC1: 'XC1'>,
+            chloride=<Chloride.XD1: 'XD1'>,
+            chloride_seawater=<ChlorideSeawater.XS1: 'XS1'>,
+            freeze=<FreezeThaw.NA: 'Not applicable'>,
+            chemical=<Chemical.NA: 'Not applicable'>
+        )
+
+        Parameters
+        ----------
+        exposure_classes : Sequence[str]
+            sequence of exposure classes, order is not important.
+            If an exposure class is not provided, but is defined in the __init__, it is set to "Not applicable"
+            You can use capital letters or lowercase letters, the method is case-insensitive.
+            For example, "XC1" and "xc1" are both valid.
+
+        Returns
+        -------
+        Self
+            instance created from the list
+        """
+        exposures: dict[str, Exposure] = {}
+        classifications: dict[str, type[Exposure]] = {arg.notation(): arg for kw, arg in cls.__init__.__annotations__.items() if kw != "return"}
+
+        for exposure_str in exposure_classes:
+            classification = classifications.get(exposure_str[:2].upper())
+            if classification is None:
+                raise ValueError(f"Invalid exposure class: '{exposure_str}'")
+            classification_name = classification.snake_case()
+            if classification_name in exposures:
+                raise ValueError(f"Duplication Error: There are multiple instances of '{classification.__name__}' class.")
+            exposures[classification_name] = classification[exposure_str.upper()]
+
+        for classification in classifications.values():
+            classification_name = classification.snake_case()
+            if classification_name not in exposures:
+                exposures.setdefault(classification_name, classification(cls._not_applicable_key))
+
+        return cls(**exposures)  # type: ignore[arg-type]

--- a/blueprints/codes/eurocode/exposure_classes.py
+++ b/blueprints/codes/eurocode/exposure_classes.py
@@ -143,6 +143,7 @@ class ExposureClassesBase:
     """
 
     _not_applicable_key: ClassVar[str] = "Not applicable"
+    """Key for the 'Not applicable' exposure class. Can be overridden in subclasses if needed."""
 
     @property
     def no_risk(self) -> bool:
@@ -153,7 +154,7 @@ class ExposureClassesBase:
         Returns
         -------
         bool
-            True if all exposure classes are euqal to _not_applicable_key ("Not applicable")
+            True if all exposure classes are euqal to _not_applicable_key ("Not applicable" by default)
         """
         return all(exposure_class.value == self.__class__._not_applicable_key for exposure_class in self.__dict__.values())  # noqa: SLF001
 
@@ -165,14 +166,14 @@ class ExposureClassesBase:
         str
             String representation of the ExposureClasses object
         """
-        return "X0" if self.no_risk else ", ".join(enum.value for enum in self.__dict__.values() if enum.value != "Not applicable")
+        return "X0" if self.no_risk else ", ".join(enum.value for enum in self.__dict__.values() if enum.value != self.__class__._not_applicable_key)  # noqa: SLF001
 
     def __iter__(self) -> Iterator[Exposure]:
         """Iterator for the ExposureClasses object.
 
         Returns
         -------
-        Iterable[Exposure]
+        Iterator[Exposure]
             Iterator for the ExposureClasses object
         """
         return iter(self.__dict__.values())
@@ -189,7 +190,7 @@ class ExposureClassesBase:
             carbonation=<Carbonation.XC1: 'XC1'>,
             chloride=<Chloride.XD1: 'XD1'>,
             chloride_seawater=<ChlorideSeawater.XS1: 'XS1'>,
-            freeze=<FreezeThaw.NA: 'Not applicable'>,
+            freeze_thaw=<FreezeThaw.NA: 'Not applicable'>,
             chemical=<Chemical.NA: 'Not applicable'>
         )
 
@@ -197,7 +198,7 @@ class ExposureClassesBase:
         ----------
         exposure_classes : Sequence[str]
             sequence of exposure classes, order is not important.
-            If an exposure class is not provided, but is defined in the __init__, it is set to "Not applicable"
+            If an exposure class is not provided, but is defined in the __init__, it is set to the value of _not_applicable_key ("Not applicable").
             You can use capital letters or lowercase letters, the method is case-insensitive.
             For example, "XC1" and "xc1" are both valid.
 
@@ -223,4 +224,4 @@ class ExposureClassesBase:
             if classification_name not in exposures:
                 exposures.setdefault(classification_name, classification(cls._not_applicable_key))
 
-        return cls(**exposures)  # type: ignore[arg-type]
+        return cls(**exposures)

--- a/blueprints/codes/eurocode/exposure_classes.py
+++ b/blueprints/codes/eurocode/exposure_classes.py
@@ -132,7 +132,11 @@ class Exposure(Enum, metaclass=ABCEnumMeta):
             match = re.match(r"([A-Z]+)(\d+)", option)
             if match:
                 return match.group(1)
-        raise ValueError(f"No valid notation found for {cls.__name__}. Available options: {options}")
+        raise ValueError(
+            f"No valid notation found for {cls.__name__}.\n"
+            "Either adhere to the pattern of Uppercase letters followed by at least one digit for Enum values, "
+            "or implement the notation method in the subclass."
+        )
 
 
 @dataclass(frozen=True)

--- a/blueprints/codes/eurocode/exposure_classes.py
+++ b/blueprints/codes/eurocode/exposure_classes.py
@@ -117,43 +117,12 @@ class Exposure(Enum, metaclass=ABCEnumMeta):
         return re.sub(r"(?<!^)(?=[A-Z])", "_", cls.__name__).lower()
 
 
-@total_ordering
-class CarbonationBase(Exposure):
-    """Enum Class which indicates the classification of corrosion induced by carbonation."""
-
-
-@total_ordering
-class ChlorideBase(Exposure):
-    """Enum Class which indicates the classification of corrosion induced by chlorides other than by sea water."""
-
-
-@total_ordering
-class ChlorideSeawaterBase(Exposure):
-    """Enum Class which indicates the classification of corrosion induced by chlorides from sea water."""
-
-
-@total_ordering
-class FreezeThawBase(Exposure):
-    """Enum Class which indicates the classification of freeze/thaw attack with or without de-icing agents."""
-
-
-@total_ordering
-class ChemicalBase(Exposure):
-    """Enum Class which indicates the classification of chemical attack."""
-
-
 @dataclass(frozen=True)
 class ExposureClassesBase:
     """Parent class which serves as a container for the Exposure classes.
 
     Exposure classes related to environmental conditions in accordance with EN 206-1
     """
-
-    carbonation: CarbonationBase
-    chloride: ChlorideBase
-    chloride_seawater: ChlorideSeawaterBase
-    freeze: FreezeThawBase
-    chemical: ChemicalBase
 
     @property
     def no_risk(self) -> bool:

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_1.py
@@ -2,17 +2,11 @@
 according to Table 4.1 from NEN-EN 1992-1-1:2005+A1:2015+NB:2016+A1:2020: Chapter 4 - Durability and cover to reinforcement.
 """
 
-from collections.abc import Sequence
 from functools import total_ordering
-from typing import Self, TypeVar
 
 from blueprints.codes.eurocode.exposure_classes import (
     Exposure,
-    Exposure,
-    Exposure,
-    Exposure,
     ExposureClassesBase,
-    Exposure,
 )
 
 
@@ -272,67 +266,36 @@ class Chemical(Exposure):
         return "XA"
 
 
-# Define a generic type for the class
-T = TypeVar("T", bound="Table4Dot1ExposureClasses")
-
-
 class Table4Dot1ExposureClasses(ExposureClassesBase):
-    """Implementation of table 4.1 from NEN-EN 1992-1-1:2005+A1:2015+NB:2016+A1:2020.
+    """Class representing table 4.1 from NEN-EN 1992-1-1:2005+A1:2015+NB:2016+A1:2020."""
 
-    Exposure classes related to environmental conditions in accordance with EN 206-1
-    """
+    def __init__(
+        self,
+        carbonation: Carbonation = Carbonation.NA,
+        chloride: Chloride = Chloride.NA,
+        chloride_seawater: ChlorideSeawater = ChlorideSeawater.NA,
+        freeze_thaw: FreezeThaw = FreezeThaw.NA,
+        chemical: Chemical = Chemical.NA,
+    ) -> None:
+        """Implementation of table 4.1 from NEN-EN 1992-1-1:2005+A1:2015+NB:2016+A1:2020 par. 4.2.
 
-    carbonation: Carbonation
-    chloride: Chloride
-    chloride_seawater: ChlorideSeawater
-    freeze: FreezeThaw
-    chemical: Chemical
-
-    @classmethod
-    def from_exposure_list(cls, exposure_classes: Sequence[str]) -> Self:
-        """Create an instance from a sequence of exposure classes.
-
-        Examples
-        --------
-        >>> exposure_classes = ["XC1", "XD1", "XS1"]
-        >>> Table4Dot1ExposureClasses().from_exposure_list(exposure_classes)
-        Table4Dot1ExposureClasses(
-            carbonation=<Carbonation.XC1: 'XC1'>,
-            chloride=<Chloride.XD1: 'XD1'>,
-            chloride_seawater=<ChlorideSeawater.XS1: 'XS1'>,
-            freeze=<FreezeThaw.NA: 'Not applicable'>,
-            chemical=<Chemical.NA: 'Not applicable'>
-        )
+        Exposure classes related to environmental conditions in accordance with EN 206-1
 
         Parameters
         ----------
-        exposure_classes : Sequence[str]
-            list of exposure classes, order is not important. If an exposure class is not provided, it is set to "Not applicable"
-            You can use capital letters or lowercase letters, the method is case-insensitive.
-            For example, "XC1" and "xc1" are both valid.
-
-        Returns
-        -------
-        Self
-            instance created from the list
+        carbonation : Carbonation
+            The carbonation exposure class. Defaults to Carbonation.NA.
+        chloride : Chloride
+            The chloride exposure class. Defaults to Chloride.NA.
+        chloride_seawater : ChlorideSeawater
+            The chloride seawater exposure class. Defaults to ChlorideSeawater.NA.
+        freeze_thaw : FreezeThaw
+            The freeze/thaw exposure class. Defaults to FreezeThaw.NA.
+        chemical : Chemical
+            The chemical exposure class. Defaults to Chemical.NA.
         """
-        exposures: dict[str, Carbonation | Chloride | ChlorideSeawater | Chemical | FreezeThaw] = {}
-        classifications = {
-            classification.notation(): classification for classification in (Carbonation, Chloride, ChlorideSeawater, FreezeThaw, Chemical)
-        }
-
-        for exposure_str in exposure_classes:
-            classification = classifications.get(exposure_str[:2].upper())
-            if classification is None:
-                raise ValueError(f"Invalid exposure class: '{exposure_str}'")
-            classification_name = classification.snake_case().removesuffix("_thaw")
-            if classification_name in exposures:
-                raise ValueError(f"Duplication Error: There are multiple instances of '{classification.__name__}' class.")
-            exposures[classification_name] = classification[exposure_str.upper()]
-
-        for classification in classifications.values():
-            classification_name = classification.snake_case().removesuffix("_thaw")
-            if classification_name not in exposures:
-                exposures.setdefault(classification_name, classification.NA)
-
-        return cls(**exposures)  # type: ignore[arg-type]
+        self.carbonation = carbonation
+        self.chloride = chloride
+        self.chloride_seawater = chloride_seawater
+        self.freeze_thaw = freeze_thaw
+        self.chemical = chemical

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_1.py
@@ -51,17 +51,6 @@ class Carbonation(Exposure):
             case Carbonation.NA:
                 return "Not applicable"
 
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XC"
-
 
 @total_ordering
 class Chloride(Exposure):
@@ -101,17 +90,6 @@ class Chloride(Exposure):
             case Chloride.NA:
                 return "Not applicable"
 
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XD"
-
 
 @total_ordering
 class ChlorideSeawater(Exposure):
@@ -150,17 +128,6 @@ class ChlorideSeawater(Exposure):
                 return "Tidal, splash and spray zones"
             case ChlorideSeawater.NA:
                 return "Not applicable"
-
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XS"
 
 
 @total_ordering
@@ -204,17 +171,6 @@ class FreezeThaw(Exposure):
             case FreezeThaw.NA:
                 return "Not applicable"
 
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XF"
-
 
 @total_ordering
 class Chemical(Exposure):
@@ -253,17 +209,6 @@ class Chemical(Exposure):
                 return "Highly aggressive chemical environment according to EN 206-1, Table 2"
             case Chemical.NA:
                 return "Not applicable"
-
-    @staticmethod
-    def notation() -> str:
-        """Static method which returns the notation of this exposure class.
-
-        Returns
-        -------
-        str
-            notation of this exposure class
-        """
-        return "XA"
 
 
 class Table4Dot1ExposureClasses(ExposureClassesBase):

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_1.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_1.py
@@ -7,17 +7,17 @@ from functools import total_ordering
 from typing import Self, TypeVar
 
 from blueprints.codes.eurocode.exposure_classes import (
-    CarbonationBase,
-    ChemicalBase,
-    ChlorideBase,
-    ChlorideSeawaterBase,
+    Exposure,
+    Exposure,
+    Exposure,
+    Exposure,
     ExposureClassesBase,
-    FreezeThawBase,
+    Exposure,
 )
 
 
 @total_ordering
-class Carbonation(CarbonationBase):
+class Carbonation(Exposure):
     """Enum Class which indicates the classification of corrosion induced by carbonation."""
 
     NA = "Not applicable"
@@ -70,7 +70,7 @@ class Carbonation(CarbonationBase):
 
 
 @total_ordering
-class Chloride(ChlorideBase):
+class Chloride(Exposure):
     """Enum Class which indicates the classification of corrosion induced by chlorides other than by sea water."""
 
     NA = "Not applicable"
@@ -120,7 +120,7 @@ class Chloride(ChlorideBase):
 
 
 @total_ordering
-class ChlorideSeawater(ChlorideSeawaterBase):
+class ChlorideSeawater(Exposure):
     """Enum Class which indicates the classification of corrosion induced by chlorides from sea water."""
 
     NA = "Not applicable"
@@ -170,7 +170,7 @@ class ChlorideSeawater(ChlorideSeawaterBase):
 
 
 @total_ordering
-class FreezeThaw(FreezeThawBase):
+class FreezeThaw(Exposure):
     """Enum Class which indicates the classification of freeze/thaw attack with or without de-icing agents."""
 
     NA = "Not applicable"
@@ -223,7 +223,7 @@ class FreezeThaw(FreezeThawBase):
 
 
 @total_ordering
-class Chemical(ChemicalBase):
+class Chemical(Exposure):
     """Enum Class which indicates the classification of chemical attack."""
 
     NA = "Not applicable"

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_4n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_4n.py
@@ -1,7 +1,7 @@
 """Table 4.4N from NEN-EN 1992-1-1:2005+A1:2015+NB:2016+A1:2020: Chapter 4 - Durability and cover to reinforcement."""
 
-from blueprints.codes.eurocode.exposure_classes import ExposureClassesBase
 from blueprints.codes.eurocode.nen_en_1992_1_1_a1_2020 import NEN_EN_1992_1_1_A1_2020
+from blueprints.codes.eurocode.nen_en_1992_1_1_a1_2020.chapter_4_durability_and_cover.table_4_1 import Table4Dot1ExposureClasses
 from blueprints.codes.eurocode.structural_class import ConcreteStructuralClassBase
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula
@@ -19,7 +19,7 @@ class Table4Dot4nMinimumCoverDurabilityReinforcementSteel(Formula):
 
     def __init__(
         self,
-        exposure_classes: ExposureClassesBase,
+        exposure_classes: Table4Dot1ExposureClasses,
         structural_class: ConcreteStructuralClassBase,
     ) -> None:
         r"""[$c_{min,dur}$] Calculates the minimum concrete cover with regard to durability [$mm$] for reinforcement steel.
@@ -28,7 +28,7 @@ class Table4Dot4nMinimumCoverDurabilityReinforcementSteel(Formula):
 
         Parameters
         ----------
-        exposure_classes: ExposureClassesBase
+        exposure_classes: Table4Dot1ExposureClasses
             The exposure classes of the concrete. Use the [$Table4Dot1ExposureClasses$] class. [$-$]
         structural_class: ConcreteStructuralClassBase
             The structural class of the concrete. Use the [$Table4Dot3ConcreteStructuralClass$] class. [$-$]
@@ -39,7 +39,7 @@ class Table4Dot4nMinimumCoverDurabilityReinforcementSteel(Formula):
 
     @staticmethod
     def _evaluate(
-        exposure_classes: ExposureClassesBase,
+        exposure_classes: Table4Dot1ExposureClasses,
         structural_class: ConcreteStructuralClassBase,
     ) -> MM:
         """For more detailed documentation see the class docstring."""

--- a/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_5n.py
+++ b/blueprints/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/table_4_5n.py
@@ -1,7 +1,7 @@
 """Table 4.5N from NEN-EN 1992-1-1:2005+A1:2015+NB:2016+A1:2020: Chapter 4 - Durability and cover to reinforcement."""
 
-from blueprints.codes.eurocode.exposure_classes import ExposureClassesBase
 from blueprints.codes.eurocode.nen_en_1992_1_1_a1_2020 import NEN_EN_1992_1_1_A1_2020
+from blueprints.codes.eurocode.nen_en_1992_1_1_a1_2020.chapter_4_durability_and_cover.table_4_1 import Table4Dot1ExposureClasses
 from blueprints.codes.eurocode.structural_class import ConcreteStructuralClassBase
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula
@@ -19,7 +19,7 @@ class Table4Dot5nMinimumCoverDurabilityPrestressingSteel(Formula):
 
     def __init__(
         self,
-        exposure_classes: ExposureClassesBase,
+        exposure_classes: Table4Dot1ExposureClasses,
         structural_class: ConcreteStructuralClassBase,
     ) -> None:
         r"""[$c_{min,dur}$] Calculates the minimum concrete cover with regard to durability [$mm$] for prestressing steel.
@@ -28,7 +28,7 @@ class Table4Dot5nMinimumCoverDurabilityPrestressingSteel(Formula):
 
         Parameters
         ----------
-        exposure_classes: ExposureClassesBase
+        exposure_classes: Table4Dot1ExposureClasses
             The exposure classes of the concrete. Use the [$Table4Dot1ExposureClasses$] class. [$-$]
         structural_class: ConcreteStructuralClassBase
             The structural class of the concrete. Use the [$Table4Dot3ConcreteStructuralClass$] class. [$-$]
@@ -39,7 +39,7 @@ class Table4Dot5nMinimumCoverDurabilityPrestressingSteel(Formula):
 
     @staticmethod
     def _evaluate(
-        exposure_classes: ExposureClassesBase,
+        exposure_classes: Table4Dot1ExposureClasses,
         structural_class: ConcreteStructuralClassBase,
     ) -> MM:
         """For more detailed documentation see the class docstring."""

--- a/tests/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/test_table_4_1.py
+++ b/tests/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/test_table_4_1.py
@@ -136,7 +136,7 @@ class TestTable4Dot1ExposureClasses:
         assert exposure_classes.carbonation == Carbonation.XC1
         assert exposure_classes.chloride == Chloride.XD1
         assert exposure_classes.chloride_seawater == ChlorideSeawater.XS1
-        assert exposure_classes.freeze == FreezeThaw.XF1
+        assert exposure_classes.freeze_thaw == FreezeThaw.XF1
         assert exposure_classes.chemical == Chemical.XA1
 
         # test with wrong exposure class

--- a/tests/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/test_table_4_3.py
+++ b/tests/codes/eurocode/en_1992_1_1_2004/chapter_4_durability_and_cover/test_table_4_3.py
@@ -21,19 +21,13 @@ from blueprints.codes.eurocode.en_1992_1_1_2004.chapter_4_durability_and_cover.t
 )
 from blueprints.type_alias import YEARS
 
-DUMMY_EXPOSURE_CLASSES_NA = Table4Dot1ExposureClasses(
-    carbonation=Carbonation.NA,
-    chloride=Chloride.NA,
-    chloride_seawater=ChlorideSeawater.NA,
-    freeze=FreezeThaw.NA,
-    chemical=Chemical.NA,
-)
+DUMMY_EXPOSURE_CLASSES_NA = Table4Dot1ExposureClasses()
 
 DUMMY_EXPOSURE_CLASSES = Table4Dot1ExposureClasses(
     carbonation=Carbonation.XC2,
     chloride=Chloride.XD1,
     chloride_seawater=ChlorideSeawater.XS1,
-    freeze=FreezeThaw.NA,
+    freeze_thaw=FreezeThaw.NA,
     chemical=Chemical.XA2,
 )
 

--- a/tests/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/test_table_4_1.py
+++ b/tests/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/test_table_4_1.py
@@ -72,8 +72,8 @@ class TestChlorideSeawater:
         assert ChlorideSeawater.NA.description_of_the_environment() == "Not applicable"
 
 
-class TestFreeze:
-    """Testing Freeze class."""
+class TestFreezeThaw:
+    """Testing FreezeThaw class."""
 
     def test_options(self) -> None:
         """Check if the options method returns all the possible options within an exposure class."""
@@ -136,7 +136,7 @@ class TestTable4Dot1ExposureClasses:
         assert exposure_classes.carbonation == Carbonation.XC1
         assert exposure_classes.chloride == Chloride.XD1
         assert exposure_classes.chloride_seawater == ChlorideSeawater.XS1
-        assert exposure_classes.freeze == FreezeThaw.XF1
+        assert exposure_classes.freeze_thaw == FreezeThaw.XF1
         assert exposure_classes.chemical == Chemical.XA1
 
         # test with wrong exposure class

--- a/tests/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/test_table_4_3.py
+++ b/tests/codes/eurocode/nen_en_1992_1_1_a1_2020/chapter_4_durability_and_cover/test_table_4_3.py
@@ -21,19 +21,13 @@ from blueprints.codes.eurocode.nen_en_1992_1_1_a1_2020.chapter_4_durability_and_
 )
 from blueprints.type_alias import YEARS
 
-DUMMY_EXPOSURE_CLASSES_NA = Table4Dot1ExposureClasses(
-    carbonation=Carbonation.NA,
-    chloride=Chloride.NA,
-    chloride_seawater=ChlorideSeawater.NA,
-    freeze=FreezeThaw.NA,
-    chemical=Chemical.NA,
-)
+DUMMY_EXPOSURE_CLASSES_NA = Table4Dot1ExposureClasses()
 
 DUMMY_EXPOSURE_CLASSES = Table4Dot1ExposureClasses(
     carbonation=Carbonation.XC2,
     chloride=Chloride.XD1,
     chloride_seawater=ChlorideSeawater.XS1,
-    freeze=FreezeThaw.NA,
+    freeze_thaw=FreezeThaw.NA,
     chemical=Chemical.XA2,
 )
 

--- a/tests/codes/eurocode/test_exposure_classes.py
+++ b/tests/codes/eurocode/test_exposure_classes.py
@@ -137,6 +137,11 @@ class DummyExposureClasses(ExposureClassesBase):
 class TestExposure:
     """Testing Exposure parent class."""
 
+    def test_initiate_abc_class(self) -> None:
+        """Check if initiating the Exposure class raises a TypeError."""
+        with pytest.raises(TypeError):
+            _ = Exposure()  # type: ignore[abstract, call-arg]
+
     def test_equal_to_operator(self) -> None:
         """Check if the == operator is working correctly."""
         assert DummyExposureSubclass.DUMMY1 == DummyExposureSubclass.DUMMY1
@@ -202,12 +207,7 @@ class TestExposure:
 
 
 class TestCarbonation:
-    """Testing CarbonationBase class."""
-
-    def test_initiate_subclasses(self) -> None:
-        """Check if initiating the CarbonationBase class raises a TypeError."""
-        with pytest.raises(TypeError):
-            _ = Exposure()  # type: ignore[abstract, call-arg]
+    """Testing Carbonation class."""
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -223,12 +223,7 @@ class TestCarbonation:
 
 
 class TestChloride:
-    """Testing ChlorideBase class."""
-
-    def test_initiate_subclasses(self) -> None:
-        """Check if initiating the ChlorideBase class raises a TypeError."""
-        with pytest.raises(TypeError):
-            _ = Exposure()  # type: ignore[abstract, call-arg]
+    """Testing Chloride class."""
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -244,12 +239,7 @@ class TestChloride:
 
 
 class TestChlorideSeawater:
-    """Testing ChlorideSeawaterBase class."""
-
-    def test_initiate_subclasses(self) -> None:
-        """Check if initiating the ChlorideSeawaterBase class raises a TypeError."""
-        with pytest.raises(TypeError):
-            _ = Exposure()  # type: ignore[abstract, call-arg]
+    """Testing ChlorideSeawater class."""
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -265,12 +255,7 @@ class TestChlorideSeawater:
 
 
 class TestFreezeThaw:
-    """Testing FreezeThawBase class."""
-
-    def test_initiate_subclasses(self) -> None:
-        """Check if initiating the FreezeThawBase class raises a TypeError."""
-        with pytest.raises(TypeError):
-            _ = Exposure()  # type: ignore[abstract, call-arg]
+    """Testing FreezeThaw class."""
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -286,12 +271,7 @@ class TestFreezeThaw:
 
 
 class TestChemical:
-    """Testing ChemicalBase class."""
-
-    def test_initiate_subclasses(self) -> None:
-        """Check if initiating the ChemicalBase class raises a TypeError."""
-        with pytest.raises(TypeError):
-            _ = Exposure()  # type: ignore[abstract, call-arg]
+    """Testing Chemical class."""
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""

--- a/tests/codes/eurocode/test_exposure_classes.py
+++ b/tests/codes/eurocode/test_exposure_classes.py
@@ -205,6 +205,29 @@ class TestExposure:
         assert DummyExposureSubclass.DUMMY2.notation() == "DUMMY"
         assert DummyExposureSubclass.DUMMY3.notation() == "DUMMY"
 
+    def test_notation_raises_error(self) -> None:
+        """Check if the notation method raises an error when called on the base class."""
+
+        class BadNotation(Exposure):
+            """Dummy Exposure subclass with bad notation."""
+
+            NA = "Not applicable"
+            DUMMY1 = "dummy1"
+            DUMMY2 = "DUMMY"
+            DUMMY3 = "Dummy3"
+
+            @staticmethod
+            def exposure_class_description() -> str:
+                """Dummy implementation of abstract method."""
+                return ""
+
+            def description_of_the_environment(self) -> str:
+                """Dummy implementation of abstract method."""
+                return ""
+
+        with pytest.raises(ValueError):
+            _ = BadNotation.notation()
+
 
 class TestCarbonation:
     """Testing Carbonation class."""

--- a/tests/codes/eurocode/test_exposure_classes.py
+++ b/tests/codes/eurocode/test_exposure_classes.py
@@ -3,13 +3,8 @@
 import pytest
 
 from blueprints.codes.eurocode.exposure_classes import (
-    CarbonationBase,
-    ChemicalBase,
-    ChlorideBase,
-    ChlorideSeawaterBase,
-    Exposure,
     ExposureClassesBase,
-    FreezeThawBase,
+    Exposure,
 )
 
 
@@ -30,7 +25,7 @@ class DummyExposureSubclass(Exposure):
         return "Dummy environment"
 
 
-class DummyCarbonation(CarbonationBase):
+class DummyCarbonation(Exposure):
     """Dummy Carbonation subclass for testing purposes."""
 
     NA = "Not applicable"
@@ -46,7 +41,7 @@ class DummyCarbonation(CarbonationBase):
         return "Dummy environment"
 
 
-class DummyChloride(ChlorideBase):
+class DummyChloride(Exposure):
     """Dummy Chloride subclass for testing purposes."""
 
     NA = "Not applicable"
@@ -62,7 +57,7 @@ class DummyChloride(ChlorideBase):
         return "Dummy environment"
 
 
-class DummyChlorideSeawater(ChlorideSeawaterBase):
+class DummyChlorideSeawater(Exposure):
     """Dummy ChlorideSeawater subclass for testing purposes."""
 
     NA = "Not applicable"
@@ -78,7 +73,7 @@ class DummyChlorideSeawater(ChlorideSeawaterBase):
         return "Dummy environment"
 
 
-class DummyFreezeThaw(FreezeThawBase):
+class DummyFreezeThaw(Exposure):
     """Dummy FreezeThaw subclass for testing purposes."""
 
     NA = "Not applicable"
@@ -94,7 +89,7 @@ class DummyFreezeThaw(FreezeThawBase):
         return "Dummy environment"
 
 
-class DummyChemical(ChemicalBase):
+class DummyChemical(Exposure):
     """Dummy Chemical subclass for testing purposes."""
 
     NA = "Not applicable"
@@ -172,7 +167,7 @@ class TestCarbonation:
     def test_initiate_subclasses(self) -> None:
         """Check if initiating the CarbonationBase class raises a TypeError."""
         with pytest.raises(TypeError):
-            _ = CarbonationBase()  # type: ignore[abstract, call-arg]
+            _ = Exposure()  # type: ignore[abstract, call-arg]
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -189,7 +184,7 @@ class TestChloride:
     def test_initiate_subclasses(self) -> None:
         """Check if initiating the ChlorideBase class raises a TypeError."""
         with pytest.raises(TypeError):
-            _ = ChlorideBase()  # type: ignore[abstract, call-arg]
+            _ = Exposure()  # type: ignore[abstract, call-arg]
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -206,7 +201,7 @@ class TestChlorideSeawater:
     def test_initiate_subclasses(self) -> None:
         """Check if initiating the ChlorideSeawaterBase class raises a TypeError."""
         with pytest.raises(TypeError):
-            _ = ChlorideSeawaterBase()  # type: ignore[abstract, call-arg]
+            _ = Exposure()  # type: ignore[abstract, call-arg]
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -223,7 +218,7 @@ class TestFreezeThaw:
     def test_initiate_subclasses(self) -> None:
         """Check if initiating the FreezeThawBase class raises a TypeError."""
         with pytest.raises(TypeError):
-            _ = FreezeThawBase()  # type: ignore[abstract, call-arg]
+            _ = Exposure()  # type: ignore[abstract, call-arg]
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -240,7 +235,7 @@ class TestChemical:
     def test_initiate_subclasses(self) -> None:
         """Check if initiating the ChemicalBase class raises a TypeError."""
         with pytest.raises(TypeError):
-            _ = ChemicalBase()  # type: ignore[abstract, call-arg]
+            _ = Exposure()  # type: ignore[abstract, call-arg]
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""

--- a/tests/codes/eurocode/test_exposure_classes.py
+++ b/tests/codes/eurocode/test_exposure_classes.py
@@ -1,19 +1,24 @@
+# mypy: disable-error-code="operator"
 """Tests for the Exposure classes."""
+
+from functools import total_ordering
 
 import pytest
 
 from blueprints.codes.eurocode.exposure_classes import (
-    ExposureClassesBase,
     Exposure,
+    ExposureClassesBase,
 )
 
 
+@total_ordering
 class DummyExposureSubclass(Exposure):
     """Dummy Exposure subclass for testing purposes."""
 
-    DUMMY1 = "Dummy1"
-    DUMMY2 = "Dummy2"
-    DUMMY3 = "Dummy3"
+    NA = "Not applicable"
+    DUMMY1 = "DUMMY1"
+    DUMMY2 = "DUMMY2"
+    DUMMY3 = "DUMMY3"
 
     @staticmethod
     def exposure_class_description() -> str:
@@ -25,6 +30,7 @@ class DummyExposureSubclass(Exposure):
         return "Dummy environment"
 
 
+@total_ordering
 class DummyCarbonation(Exposure):
     """Dummy Carbonation subclass for testing purposes."""
 
@@ -41,6 +47,7 @@ class DummyCarbonation(Exposure):
         return "Dummy environment"
 
 
+@total_ordering
 class DummyChloride(Exposure):
     """Dummy Chloride subclass for testing purposes."""
 
@@ -57,6 +64,7 @@ class DummyChloride(Exposure):
         return "Dummy environment"
 
 
+@total_ordering
 class DummyChlorideSeawater(Exposure):
     """Dummy ChlorideSeawater subclass for testing purposes."""
 
@@ -73,6 +81,7 @@ class DummyChlorideSeawater(Exposure):
         return "Dummy environment"
 
 
+@total_ordering
 class DummyFreezeThaw(Exposure):
     """Dummy FreezeThaw subclass for testing purposes."""
 
@@ -89,6 +98,7 @@ class DummyFreezeThaw(Exposure):
         return "Dummy environment"
 
 
+@total_ordering
 class DummyChemical(Exposure):
     """Dummy Chemical subclass for testing purposes."""
 
@@ -103,6 +113,25 @@ class DummyChemical(Exposure):
     def description_of_the_environment(self) -> str:
         """Return the description of the environment."""
         return "Dummy environment"
+
+
+class DummyExposureClasses(ExposureClassesBase):
+    """Dummy ExposureClassesBase subclass for testing purposes."""
+
+    def __init__(
+        self,
+        dummy_carbonation: DummyCarbonation,
+        dummy_chloride: DummyChloride,
+        dummy_chloride_seawater: DummyChlorideSeawater,
+        dummy_freeze_thaw: DummyFreezeThaw,
+        dummy_chemical: DummyChemical,
+    ) -> None:
+        """Initialize the DummyExposureClassesBase with dummy exposure classes."""
+        self.dummy_carbonation = dummy_carbonation
+        self.dummy_chloride = dummy_chloride
+        self.dummy_chloride_seawater = dummy_chloride_seawater
+        self.dummy_freeze_thaw = dummy_freeze_thaw
+        self.dummy_chemical = dummy_chemical
 
 
 class TestExposure:
@@ -124,12 +153,14 @@ class TestExposure:
         """Check if the > operator is working correctly."""
         assert DummyExposureSubclass.DUMMY3 > DummyExposureSubclass.DUMMY2
         assert DummyExposureSubclass.DUMMY2 > DummyExposureSubclass.DUMMY1
+        assert DummyExposureSubclass.DUMMY1 > DummyExposureSubclass.NA
 
     def test_greather_than_equal_to_operator(self) -> None:
         """Check if the >= operator is working correctly."""
         # Testing greater than
         assert DummyExposureSubclass.DUMMY3 >= DummyExposureSubclass.DUMMY2
         assert DummyExposureSubclass.DUMMY2 >= DummyExposureSubclass.DUMMY1
+        assert DummyExposureSubclass.DUMMY1 >= DummyExposureSubclass.NA
         # Testing equal to
         assert DummyExposureSubclass.DUMMY3 >= DummyExposureSubclass.DUMMY3
         assert DummyExposureSubclass.DUMMY1 >= DummyExposureSubclass.DUMMY1
@@ -138,19 +169,21 @@ class TestExposure:
         """Check if the < operator is working correctly."""
         assert DummyExposureSubclass.DUMMY1 < DummyExposureSubclass.DUMMY2
         assert DummyExposureSubclass.DUMMY2 < DummyExposureSubclass.DUMMY3
+        assert DummyExposureSubclass.NA < DummyExposureSubclass.DUMMY1
 
     def test_lesser_than_equal_to_operator(self) -> None:
         """Check if the <= operator is working correctly."""
         # Testing lesser than
         assert DummyExposureSubclass.DUMMY1 <= DummyExposureSubclass.DUMMY2
         assert DummyExposureSubclass.DUMMY2 <= DummyExposureSubclass.DUMMY3
+        assert DummyExposureSubclass.NA <= DummyExposureSubclass.DUMMY1
         # Testing equal to
         assert DummyExposureSubclass.DUMMY1 <= DummyExposureSubclass.DUMMY1
         assert DummyExposureSubclass.DUMMY3 <= DummyExposureSubclass.DUMMY3
 
     def test_options(self) -> None:
         """Check if the options method returns all the possible options within an exposure class."""
-        assert DummyExposureSubclass.options() == ["Dummy1", "Dummy2", "Dummy3"]
+        assert DummyExposureSubclass.options() == ["Not applicable", "DUMMY1", "DUMMY2", "DUMMY3"]
 
     def test_exposure_class_description_implemented(self) -> None:
         """Check if the exposure_class_description method returns the description of the subclass."""
@@ -159,6 +192,13 @@ class TestExposure:
     def test_description_of_the_environment(self) -> None:
         """Check if the description_of_the_environment method returns the description of the environment."""
         assert DummyExposureSubclass.DUMMY1.description_of_the_environment() == "Dummy environment"
+
+    def test_notation(self) -> None:
+        """Check if the notation method returns the correct notation."""
+        assert DummyExposureSubclass.notation() == "DUMMY"
+        assert DummyExposureSubclass.DUMMY1.notation() == "DUMMY"
+        assert DummyExposureSubclass.DUMMY2.notation() == "DUMMY"
+        assert DummyExposureSubclass.DUMMY3.notation() == "DUMMY"
 
 
 class TestCarbonation:
@@ -177,6 +217,10 @@ class TestCarbonation:
         """Check if the description_of_the_environment method returns the description of the environment."""
         assert DummyCarbonation.XC1.description_of_the_environment() == "Dummy environment"
 
+    def test_notation(self) -> None:
+        """Check if the notation method returns the correct notation."""
+        assert DummyCarbonation.notation() == "XC"
+
 
 class TestChloride:
     """Testing ChlorideBase class."""
@@ -193,6 +237,10 @@ class TestChloride:
     def test_description_of_the_environment(self) -> None:
         """Check if the description_of_the_environment method returns the description of the environment."""
         assert DummyChloride.XD1.description_of_the_environment() == "Dummy environment"
+
+    def test_notation(self) -> None:
+        """Check if the notation method returns the correct notation."""
+        assert DummyChloride.notation() == "XD"
 
 
 class TestChlorideSeawater:
@@ -211,6 +259,10 @@ class TestChlorideSeawater:
         """Check if the description_of_the_environment method returns the description of the environment."""
         assert DummyChlorideSeawater.XS1.description_of_the_environment() == "Dummy environment"
 
+    def test_notation(self) -> None:
+        """Check if the notation method returns the correct notation."""
+        assert DummyChlorideSeawater.notation() == "XS"
+
 
 class TestFreezeThaw:
     """Testing FreezeThawBase class."""
@@ -227,6 +279,10 @@ class TestFreezeThaw:
     def test_description_of_the_environment(self) -> None:
         """Check if the description_of_the_environment method returns the description of the environment."""
         assert DummyFreezeThaw.XF1.description_of_the_environment() == "Dummy environment"
+
+    def test_notation(self) -> None:
+        """Check if the notation method returns the correct notation."""
+        assert DummyFreezeThaw.notation() == "XF"
 
 
 class TestChemical:
@@ -245,18 +301,22 @@ class TestChemical:
         """Check if the description_of_the_environment method returns the description of the environment."""
         assert DummyChemical.XA1.description_of_the_environment() == "Dummy environment"
 
+    def test_notation(self) -> None:
+        """Check if the notation method returns the correct notation."""
+        assert DummyChemical.notation() == "XA"
+
 
 class TestExposureClasses:
     """Testing ExposureClasses class."""
 
     def test_str(self) -> None:
         """Check if the __str__ method returns the correct string representation of the exposure classes."""
-        exposure_classes = ExposureClassesBase(
-            carbonation=DummyCarbonation("XC1"),
-            chloride=DummyChloride("XD1"),
-            chloride_seawater=DummyChlorideSeawater("Not applicable"),
-            freeze=DummyFreezeThaw("XF1"),
-            chemical=DummyChemical("XA1"),
+        exposure_classes = DummyExposureClasses(
+            dummy_carbonation=DummyCarbonation("XC1"),
+            dummy_chloride=DummyChloride("XD1"),
+            dummy_chloride_seawater=DummyChlorideSeawater("Not applicable"),
+            dummy_freeze_thaw=DummyFreezeThaw("XF1"),
+            dummy_chemical=DummyChemical("XA1"),
         )
         assert str(exposure_classes) == "XC1, XD1, XF1, XA1"
 
@@ -264,36 +324,74 @@ class TestExposureClasses:
         """Check if the __str__ method returns the correct string representation of the exposure classes
         when all exposure classes are not applicable.
         """
-        exposureclasses = ExposureClassesBase(
-            carbonation=DummyCarbonation("Not applicable"),
-            chloride=DummyChloride("Not applicable"),
-            chloride_seawater=DummyChlorideSeawater("Not applicable"),
-            freeze=DummyFreezeThaw("Not applicable"),
-            chemical=DummyChemical("Not applicable"),
+        exposureclasses = DummyExposureClasses(
+            dummy_carbonation=DummyCarbonation("Not applicable"),
+            dummy_chloride=DummyChloride("Not applicable"),
+            dummy_chloride_seawater=DummyChlorideSeawater("Not applicable"),
+            dummy_freeze_thaw=DummyFreezeThaw("Not applicable"),
+            dummy_chemical=DummyChemical("Not applicable"),
         )
         assert str(exposureclasses) == "X0"
 
     def test_no_risk(self) -> None:
         """Check if the no_risk method returns True if the exposure classes are all not applicable."""
-        exposureclasses = ExposureClassesBase(
-            carbonation=DummyCarbonation("Not applicable"),
-            chloride=DummyChloride("Not applicable"),
-            chloride_seawater=DummyChlorideSeawater("Not applicable"),
-            freeze=DummyFreezeThaw("Not applicable"),
-            chemical=DummyChemical("Not applicable"),
+        exposureclasses = DummyExposureClasses(
+            dummy_carbonation=DummyCarbonation("Not applicable"),
+            dummy_chloride=DummyChloride("Not applicable"),
+            dummy_chloride_seawater=DummyChlorideSeawater("Not applicable"),
+            dummy_freeze_thaw=DummyFreezeThaw("Not applicable"),
+            dummy_chemical=DummyChemical("Not applicable"),
         )
         assert exposureclasses.no_risk is True
 
     def test_no_risk_false(self) -> None:
         """Check if the no_risk method returns False if at least one exposure class is applicable."""
-        exposureclasses = ExposureClassesBase(
-            carbonation=DummyCarbonation("XC1"),
-            chloride=DummyChloride("XD1"),
-            chloride_seawater=DummyChlorideSeawater("Not applicable"),
-            freeze=DummyFreezeThaw("XF1"),
-            chemical=DummyChemical("XA1"),
+        exposureclasses = DummyExposureClasses(
+            dummy_carbonation=DummyCarbonation("XC1"),
+            dummy_chloride=DummyChloride("XD1"),
+            dummy_chloride_seawater=DummyChlorideSeawater("Not applicable"),
+            dummy_freeze_thaw=DummyFreezeThaw("XF1"),
+            dummy_chemical=DummyChemical("XA1"),
         )
         assert exposureclasses.no_risk is False
+
+    def test_iter(self) -> None:
+        """Check if the __iter__ method returns an iterator over the exposure classes."""
+        exposure_classes = DummyExposureClasses(
+            dummy_carbonation=DummyCarbonation("XC1"),
+            dummy_chloride=DummyChloride("XD1"),
+            dummy_chloride_seawater=DummyChlorideSeawater("XS1"),
+            dummy_freeze_thaw=DummyFreezeThaw("XF1"),
+            dummy_chemical=DummyChemical("XA1"),
+        )
+        iterator = iter(exposure_classes)
+        assert next(iterator) == DummyCarbonation("XC1")
+        assert next(iterator) == DummyChloride("XD1")
+        assert next(iterator) == DummyChlorideSeawater("XS1")
+        assert next(iterator) == DummyFreezeThaw("XF1")
+        assert next(iterator) == DummyChemical("XA1")
+
+    def test_from_exposure_list(self) -> None:
+        """Check if the from_exposure_list method creates an instance from a sequence of exposure classes."""
+        carbonation = "XC1"
+        chloride = "XD1"
+        chloride_seawater = "XS1"
+        freeze_thaw = "XF1"
+        exposure_classes = DummyExposureClasses.from_exposure_list([carbonation, chloride, chloride_seawater, freeze_thaw])
+        assert exposure_classes.dummy_carbonation == DummyCarbonation(carbonation)
+        assert exposure_classes.dummy_chloride == DummyChloride(chloride)
+        assert exposure_classes.dummy_chloride_seawater == DummyChlorideSeawater(chloride_seawater)
+        assert exposure_classes.dummy_freeze_thaw == DummyFreezeThaw(freeze_thaw)
+        assert exposure_classes.dummy_chemical == DummyChemical("Not applicable")
+
+    def test_from_exposure_list_empty(self) -> None:
+        """Check if the from_exposure_list method creates an instance with all exposure classes as not applicable."""
+        exposure_classes = DummyExposureClasses.from_exposure_list([])
+        assert exposure_classes.dummy_carbonation == DummyCarbonation("Not applicable")
+        assert exposure_classes.dummy_chloride == DummyChloride("Not applicable")
+        assert exposure_classes.dummy_chloride_seawater == DummyChlorideSeawater("Not applicable")
+        assert exposure_classes.dummy_freeze_thaw == DummyFreezeThaw("Not applicable")
+        assert exposure_classes.dummy_chemical == DummyChemical("Not applicable")
 
 
 def test_comparing_different_types_raises_error() -> None:

--- a/tests/codes/eurocode/test_structural_class.py
+++ b/tests/codes/eurocode/test_structural_class.py
@@ -4,13 +4,19 @@ from typing import Self
 
 import pytest
 
-from blueprints.codes.eurocode.exposure_classes import ExposureClassesBase as ExposureClasses
 from blueprints.codes.eurocode.structural_class import (
     AbstractConcreteStructuralClassCalculator,
     ConcreteStructuralClassBase,
 )
 from blueprints.materials.concrete import ConcreteMaterial
-from tests.codes.eurocode.test_exposure_classes import DummyCarbonation, DummyChemical, DummyChloride, DummyChlorideSeawater, DummyFreezeThaw
+from tests.codes.eurocode.test_exposure_classes import (
+    DummyCarbonation,
+    DummyChemical,
+    DummyChloride,
+    DummyChlorideSeawater,
+    DummyExposureClasses,
+    DummyFreezeThaw,
+)
 
 
 class MockConcreteStructuralClassCalculator(AbstractConcreteStructuralClassCalculator):
@@ -22,7 +28,7 @@ class MockConcreteStructuralClassCalculator(AbstractConcreteStructuralClassCalcu
 
     def __init__(
         self,
-        exposure_classes: ExposureClasses,
+        exposure_classes: DummyExposureClasses,
         design_working_life: float,
         concrete_material: ConcreteMaterial,
         plate_geometry: bool,
@@ -69,12 +75,12 @@ class MockConcreteStructuralClass(ConcreteStructuralClassBase):
 @pytest.fixture
 def structural_class() -> MockConcreteStructuralClass:
     """Fixture that returns an instance of the structural class for testing."""
-    exposure_classes = ExposureClasses(
-        carbonation=DummyCarbonation.XC1,
-        chloride=DummyChloride.NA,
-        chloride_seawater=DummyChlorideSeawater.NA,
-        freeze=DummyFreezeThaw.NA,
-        chemical=DummyChemical.XA1,
+    exposure_classes = DummyExposureClasses(
+        dummy_carbonation=DummyCarbonation.XC1,
+        dummy_chloride=DummyChloride.NA,
+        dummy_chloride_seawater=DummyChlorideSeawater.NA,
+        dummy_freeze_thaw=DummyFreezeThaw.NA,
+        dummy_chemical=DummyChemical.XA1,
     )
     design_working_life = 50.0
     concrete_material = ConcreteMaterial()
@@ -92,12 +98,12 @@ def structural_class() -> MockConcreteStructuralClass:
 @pytest.fixture
 def calculator() -> MockConcreteStructuralClassCalculator:
     """Fixture that returns an instance of the calculator for testing."""
-    exposure_classes = ExposureClasses(
-        carbonation=DummyCarbonation.XC1,
-        chloride=DummyChloride.NA,
-        chloride_seawater=DummyChlorideSeawater.NA,
-        freeze=DummyFreezeThaw.NA,
-        chemical=DummyChemical.XA1,
+    exposure_classes = DummyExposureClasses(
+        dummy_carbonation=DummyCarbonation.XC1,
+        dummy_chloride=DummyChloride.NA,
+        dummy_chloride_seawater=DummyChlorideSeawater.NA,
+        dummy_freeze_thaw=DummyFreezeThaw.NA,
+        dummy_chemical=DummyChemical.XA1,
     )
     design_working_life = 50.0
     concrete_material = ConcreteMaterial()


### PR DESCRIPTION
## Description

Exposure class is slightly restructured to facilitate flexibility and make it possible to implement national versions of Exposure classes and the combination of exposure classes.

Fixes #621 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) 
    The breaking changes is both small and necessary: freeze was used as a parameter to ExposureClasses. It is now called freeze_thaw which is the correct name and consistent with the rest of the code base. So far, there was no use for freeze and if it was passed as a required argument, it was most likely internal. I expect that the consequences of this breaking change would be negligible.

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
