### PR TITLE
[📚 Documentation] Add downloadbutton to each jupyter notebook example to directly download the example in .ipynb or .py

### DIFF
--- a/docs/_overrides/main.html
+++ b/docs/_overrides/main.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+{% if page.nb_url %}
+    <a href="{{ page.nb_url }}" download title="Download Example as notebook" class="md-content__button md-icon">
+        {% include ".icons/material/download.svg" %} {% include ".icons/simple/jupyter.svg" %} 
+    </a>
+    <a href="{{ page.nb_url | replace('.ipynb', '.py') }}" download title="Download Example as python code" class="md-content__button md-icon">
+        {% include ".icons/material/download.svg" %} {% include ".icons/simple/python.svg" %}
+    </a>
+{{ super() }}
+{% endif %}
+
+{% endblock content %}
+
+{% block site_meta %}
+{{ super() }}
+<meta name="readthedocs-addons-api-version" content="1" />
+{% endblock %}

--- a/docs/_overrides/main.html
+++ b/docs/_overrides/main.html
@@ -1,17 +1,21 @@
 {% extends "base.html" %}
 
 {% block content %}
-{% if page.nb_url %}
-    <a href="{{ page.nb_url }}" download title="Download example as notebook" class="md-content__button md-icon">
-        {% include ".icons/material/download.svg" %} {% include ".icons/simple/jupyter.svg" %} 
-    </a>
-    <a href="{{ page.nb_url | replace('.ipynb', '.py') }}" download title="Download example as python code" class="md-content__button md-icon">
-        {% include ".icons/material/download.svg" %} {% include ".icons/simple/python.svg" %}
-    </a>
+    {% if page.nb_url %}
+        <div class="admonition tip">
+            <p class="admonition-title">Download examples</p>
+            <p>You can download the examples in your chosen format using the buttons on the right.
+            <a href="{{ page.nb_url }}" download title="Download example as notebook" class="md-content__button md-icon">
+                {% include ".icons/material/download.svg" %} {% include ".icons/simple/jupyter.svg" %} 
+            </a>
+            <a href="{{ page.nb_url | replace('.ipynb', '.py') }}" download title="Download example as python code" class="md-content__button md-icon">
+                {% include ".icons/material/download.svg" %} {% include ".icons/simple/python.svg" %}
+            </a>
+            </p>
+        </div>
+    {% endif %}
 {{ super() }}
-{% endif %}
-
-{% endblock content %}
+{% endblock %}
 
 {% block site_meta %}
 {{ super() }}

--- a/docs/_overrides/main.html
+++ b/docs/_overrides/main.html
@@ -2,10 +2,10 @@
 
 {% block content %}
 {% if page.nb_url %}
-    <a href="{{ page.nb_url }}" download title="Download Example as notebook" class="md-content__button md-icon">
+    <a href="{{ page.nb_url }}" download title="Download example as notebook" class="md-content__button md-icon">
         {% include ".icons/material/download.svg" %} {% include ".icons/simple/jupyter.svg" %} 
     </a>
-    <a href="{{ page.nb_url | replace('.ipynb', '.py') }}" download title="Download Example as python code" class="md-content__button md-icon">
+    <a href="{{ page.nb_url | replace('.ipynb', '.py') }}" download title="Download example as python code" class="md-content__button md-icon">
         {% include ".icons/material/download.svg" %} {% include ".icons/simple/python.svg" %}
     </a>
 {{ super() }}

--- a/docs/_overrides/partials/main.html
+++ b/docs/_overrides/partials/main.html
@@ -1,6 +1,0 @@
-{% extends "base.html" %}
-
-{% block site_meta %}
-{{ super() }}
-<meta name="readthedocs-addons-api-version" content="1" />
-{% endblock %}

--- a/docs/_scripts/generate_notebook_code.py
+++ b/docs/_scripts/generate_notebook_code.py
@@ -1,0 +1,73 @@
+"""Generate downloadable Python code files from Jupyter notebooks."""
+
+import json
+from pathlib import Path
+
+import mkdocs_gen_files
+
+
+def extract_code_from_notebook(notebook_path: Path) -> str:
+    """Extract all Python code cells from a Jupyter notebook.
+
+    Parameters
+    ----------
+    notebook_path : Path
+        Path to the notebook file.
+
+    Returns
+    -------
+    str
+        Combined Python code from all code cells.
+    """
+    with open(notebook_path, encoding="utf-8") as f:
+        notebook = json.load(f)
+
+    code_lines = []
+
+    # Add a header comment
+    code_lines.append(f'# Code automatically extracted from {notebook_path.name}.\n')
+
+    for cell in notebook.get("cells", []):
+        if cell.get("cell_type") == "code":
+            source = cell.get("source", [])
+            if source:
+                # Join source lines if it's a list, otherwise use as is
+                cell_code = "".join(source) if isinstance(source, list) else source
+
+                # Skip empty cells or cells with only whitespace
+                if cell_code.strip():
+                    code_lines.append(cell_code)
+                    # Add spacing between cells
+                    if not cell_code.endswith("\n"):
+                        code_lines.append("\n")
+                    code_lines.append("\n")
+
+    return "".join(code_lines).rstrip() + "\n"
+
+
+def main() -> None:
+    """Generate Python code files from all Jupyter notebooks in docs."""
+    root = Path(__file__).parents[2]
+    docs_dir = root / "docs"
+
+    # Find all notebook files recursively in docs
+    notebook_files = list(docs_dir.rglob("*.ipynb"))
+
+    for notebook_path in notebook_files:
+        # Extract code from notebook
+        code_content = extract_code_from_notebook(notebook_path)
+
+        # Calculate relative path from docs directory
+        relative_path = notebook_path.relative_to(docs_dir)
+        
+        # Generate corresponding .py file path preserving directory structure
+        py_filename = notebook_path.stem + ".py"
+        output_path = relative_path.parent / notebook_path.stem / py_filename
+
+        # Write the extracted code to a .py file
+        with mkdocs_gen_files.open(output_path, "w") as f:
+            f.write(code_content)
+
+        print(f"Generated {output_path} from {relative_path}")
+
+main()

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -2,9 +2,9 @@
 
 Here are some examples of how to use the 'Blueprints'.
 
-- [Create a Circular Reinforced Cross-section](circular_reinforced_concrete_cross_section.md)
-- [Create a Custom Circular Reinforced Cross-section](circular_custom_reinforced_concrete_cross_section.md)
-- [Create a Rectangular Reinforced Cross-section](rectangular_reinforced_concrete_cross_section.md)
-- [Create a Custom Rectangular Reinforced Cross-section](rectangular_custom_reinforced_concrete_cross_section.md)
+- [Create a Circular Reinforced Cross-section](circular_reinforced_concrete_cross_section.ipynb)
+- [Create a Custom Circular Reinforced Cross-section](circular_custom_reinforced_concrete_cross_section.ipynb)
+- [Create a Rectangular Reinforced Cross-section](rectangular_reinforced_concrete_cross_section.ipynb)
+- [Create a Custom Rectangular Reinforced Cross-section](rectangular_custom_reinforced_concrete_cross_section.ipynb)
 - [Nominal Concrete Cover](nominal_concrete_cover.ipynb)
 - [Steel Profile Shapes](steel_profile_shapes.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ plugins:
         - docs/_scripts/generate_reference_pages.py
         - docs/_scripts/generate_index.py
         - docs/_scripts/generate_quick_reference.py
+        - docs/_scripts/generate_notebook_code.py
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
Fixes #679
## Description

I've implemented functionality to be able to download the example directly.

This is how it works, for each example implemented as notebook:
- The code cells are extracted and put into a .py file
- A admonition with icon buttons will be added to each example
- With using the icon button a user can either download a '.py' or a '.ipynb' file

There is no need to add things to the notebooks, just write them as they are and the script will take care of the rest!

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires is a documentation update

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
