### PR TITLE
Fix outer radius calculations to prevent negative values in RHSSteelProfile

### DIFF
--- a/blueprints/structural_sections/steel/steel_cross_sections/rhs_profile.py
+++ b/blueprints/structural_sections/steel/steel_cross_sections/rhs_profile.py
@@ -254,10 +254,10 @@ class RHSSteelProfile(CombinedSteelCrossSection):
         top_left_inner_radius = profile.inner_radius + corrosion_inside
         bottom_right_inner_radius = profile.inner_radius + corrosion_inside
         bottom_left_inner_radius = profile.inner_radius + corrosion_inside
-        top_right_outer_radius = profile.outer_radius - corrosion_outside
-        top_left_outer_radius = profile.outer_radius - corrosion_outside
-        bottom_right_outer_radius = profile.outer_radius - corrosion_outside
-        bottom_left_outer_radius = profile.outer_radius - corrosion_outside
+        top_right_outer_radius = max(profile.outer_radius - corrosion_outside, 0)
+        top_left_outer_radius = max(profile.outer_radius - corrosion_outside, 0)
+        bottom_right_outer_radius = max(profile.outer_radius - corrosion_outside, 0)
+        bottom_left_outer_radius = max(profile.outer_radius - corrosion_outside, 0)
 
         if any(
             [


### PR DESCRIPTION
## Description

Makes sure outer radius doesnt get corroded below a zero radisus.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
