### PR TITLE
[BUG FIX👟🪲] Round up polygon coordinates to avoid floating point conflicts

### DIFF
--- a/blueprints/structural_sections/_cross_section.py
+++ b/blueprints/structural_sections/_cross_section.py
@@ -13,6 +13,12 @@ from blueprints.type_alias import MM, MM2
 class CrossSection(ABC):
     """Base class for cross-section shapes."""
 
+    ACCURACY = 6
+    """Accuracy for rounding polygon coordinates in order to avoid floating point issues.
+    This value is used in the derived classes when creating the Shapely Polygon.
+    Since the coordinates are in mm, a value of 6 means that the coordinates are rounded to
+    the nearest nanometer which is more than sufficient for structural engineering purposes."""
+
     @property
     @abstractmethod
     def name(self) -> str:

--- a/blueprints/structural_sections/cross_section_cornered.py
+++ b/blueprints/structural_sections/cross_section_cornered.py
@@ -136,7 +136,7 @@ class CircularCorneredCrossSection(CrossSection):
 
         points = np.array([tuple(pt) for pt in points])
 
-        return Polygon(points)
+        return Polygon(np.round(points, self.ACCURACY))
 
     def geometry(self, mesh_size: MM | None = None) -> Geometry:
         """

--- a/blueprints/structural_sections/cross_section_hexagon.py
+++ b/blueprints/structural_sections/cross_section_hexagon.py
@@ -3,6 +3,7 @@
 import math
 from dataclasses import dataclass
 
+import numpy as np
 from sectionproperties.pre import Geometry
 from shapely.geometry import Polygon
 
@@ -73,7 +74,7 @@ class HexagonalCrossSection(CrossSection):
             The shapely Polygon representing the hexagon.
         """
         angle = math.pi / 3
-        points = [(self.x + self.radius * math.cos(i * angle), self.y + self.radius * math.sin(i * angle)) for i in range(6)]
+        points = [np.round((self.x + self.radius * math.cos(i * angle), self.y + self.radius * math.sin(i * angle)), self.ACCURACY) for i in range(6)]
         return Polygon(points)
 
     def geometry(

--- a/blueprints/structural_sections/cross_section_hexagon.py
+++ b/blueprints/structural_sections/cross_section_hexagon.py
@@ -74,7 +74,7 @@ class HexagonalCrossSection(CrossSection):
             The shapely Polygon representing the hexagon.
         """
         angle = math.pi / 3
-        points = [np.round((self.x + self.radius * math.cos(i * angle), self.y + self.radius * math.sin(i * angle)), self.ACCURACY) for i in range(6)]
+        points = np.round([(self.x + self.radius * math.cos(i * angle), self.y + self.radius * math.sin(i * angle)) for i in range(6)], self.ACCURACY)
         return Polygon(points)
 
     def geometry(

--- a/blueprints/structural_sections/cross_section_rectangle.py
+++ b/blueprints/structural_sections/cross_section_rectangle.py
@@ -59,14 +59,7 @@ class RectangularCrossSection(CrossSection):
         right_lower = (self.x + self.width / 2, self.y - self.height / 2)
         right_upper = (self.x + self.width / 2, self.y + self.height / 2)
         left_upper = (self.x - self.width / 2, self.y + self.height / 2)
-        return Polygon(
-            [
-                np.round(left_lower, self.ACCURACY),
-                np.round(right_lower, self.ACCURACY),
-                np.round(right_upper, self.ACCURACY),
-                np.round(left_upper, self.ACCURACY),
-            ]
-        )
+        return Polygon(np.round([left_lower, right_lower, right_upper, left_upper], self.ACCURACY))
 
     def geometry(
         self,

--- a/blueprints/structural_sections/cross_section_rectangle.py
+++ b/blueprints/structural_sections/cross_section_rectangle.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+import numpy as np
 from sectionproperties.pre import Geometry
 from shapely import Polygon
 
@@ -60,10 +61,10 @@ class RectangularCrossSection(CrossSection):
         left_upper = (self.x - self.width / 2, self.y + self.height / 2)
         return Polygon(
             [
-                left_lower,
-                right_lower,
-                right_upper,
-                left_upper,
+                np.round(left_lower, self.ACCURACY),
+                np.round(right_lower, self.ACCURACY),
+                np.round(right_upper, self.ACCURACY),
+                np.round(left_upper, self.ACCURACY),
             ]
         )
 

--- a/blueprints/structural_sections/cross_section_triangle.py
+++ b/blueprints/structural_sections/cross_section_triangle.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+import numpy as np
 from sectionproperties.pre import Geometry
 from shapely import Polygon
 
@@ -66,7 +67,7 @@ class RightAngledTriangularCrossSection(CrossSection):
         if self.mirrored_vertically:
             top = (top[0], 2 * left_lower[1] - top[1])
 
-        return Polygon([left_lower, right_lower, top])
+        return Polygon(np.round([left_lower, right_lower, top], self.ACCURACY))
 
     def geometry(
         self,


### PR DESCRIPTION
Thanks to the efforts made by @rickdegoeij, This PR fixes the failing IPE profile plot test.

## Description
We round up polygon coordinates in steel profile cross-sections and therefore avoid floating point inconsistency.

Fixes #723 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works (Done that already in a previous PR!)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
