### PR TITLE
739 refactor move the plot function to cross section abstract base class

### DIFF
--- a/blueprints/structural_sections/_cross_section.py
+++ b/blueprints/structural_sections/_cross_section.py
@@ -104,7 +104,7 @@ class CrossSection(ABC):
     @property
     def plotter(self) -> Callable[[Any], plt.Figure]:
         """Default plotter function for the cross-section."""
-        raise NotImplementedError("Subclasses must implement the plotter property.")
+        raise AttributeError("No plotter is defined.")
 
     def plot(self, plotter: Callable[[Any], plt.Figure] | None = None, *args, **kwargs) -> plt.Figure:
         """Plot the cross-section. Making use of the standard plotter.

--- a/blueprints/structural_sections/_cross_section.py
+++ b/blueprints/structural_sections/_cross_section.py
@@ -1,7 +1,10 @@
 """Cross-section base class."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
 
+import matplotlib.pyplot as plt
 from sectionproperties.analysis import Section
 from sectionproperties.post.post import SectionProperties
 from sectionproperties.pre import Geometry
@@ -97,3 +100,28 @@ class CrossSection(ABC):
             section.calculate_plastic_properties()
 
         return section.section_props
+
+    @property
+    def plotter(self) -> Callable[[Any], plt.Figure]:
+        """Default plotter function for the cross-section."""
+        raise NotImplementedError("Subclasses must implement the plotter property.")
+
+    def plot(self, plotter: Callable[[Any], plt.Figure] | None = None, *args, **kwargs) -> plt.Figure:
+        """Plot the cross-section. Making use of the standard plotter.
+
+        Parameters
+        ----------
+        plotter : Callable[Any, plt.Figure] | None
+            The plotter function to use. If None, the default Blueprints plotter of the subclass is used.
+        *args
+            Additional arguments passed to the plotter.
+        **kwargs
+            Additional keyword arguments passed to the plotter.
+        """
+        if plotter is None:
+            plotter = self.plotter
+        return plotter(
+            self,
+            *args,
+            **kwargs,
+        )

--- a/blueprints/structural_sections/steel/steel_cross_sections/chs_profile.py
+++ b/blueprints/structural_sections/steel/steel_cross_sections/chs_profile.py
@@ -27,11 +27,14 @@ class CHSSteelProfile(CombinedSteelCrossSection):
         The outer diameter of the CHS profile [mm].
     wall_thickness : MM
         The wall thickness of the CHS profile [mm].
+    plotter : Callable[[CombinedSteelCrossSection], plt.Figure]
+        The plotter function to visualize the cross-section (default: `plot_shapes`).
     """
 
     steel_material: SteelMaterial
     outer_diameter: MM
     wall_thickness: MM
+    plotter: Callable[[CombinedSteelCrossSection], plt.Figure] = plot_shapes
 
     def __post_init__(self) -> None:
         """Initialize the CHS profile."""
@@ -97,24 +100,4 @@ class CHSSteelProfile(CombinedSteelCrossSection):
             wall_thickness=adjusted_thickness,
             steel_material=steel_material,
             name=name,
-        )
-
-    def plot(self, plotter: Callable[[CombinedSteelCrossSection], plt.Figure] | None = None, *args, **kwargs) -> plt.Figure:
-        """Plot the cross-section. Making use of the standard plotter.
-
-        Parameters
-        ----------
-        plotter : Callable[CombinedSteelCrossSection, plt.Figure] | None
-            The plotter function to use. If None, the default Blueprints plotter for steel sections is used.
-        *args
-            Additional arguments passed to the plotter.
-        **kwargs
-            Additional keyword arguments passed to the plotter.
-        """
-        if plotter is None:
-            plotter = plot_shapes
-        return plotter(
-            self,
-            *args,
-            **kwargs,
         )

--- a/blueprints/structural_sections/steel/steel_cross_sections/i_profile.py
+++ b/blueprints/structural_sections/steel/steel_cross_sections/i_profile.py
@@ -52,6 +52,8 @@ class ISteelProfile(CombinedSteelCrossSection):
         The radius of the curved corners of the bottom flange. Default is None, the corner radius is then taken as the thickness.
     name : str
         The name of the profile. Default is "I-Profile". If corrosion is applied, the name will include the corrosion value.
+    plotter : Callable[[CombinedSteelCrossSection], plt.Figure]
+        The plotter function to visualize the cross-section (default: `plot_shapes`).
     """
 
     steel_material: SteelMaterial
@@ -64,6 +66,7 @@ class ISteelProfile(CombinedSteelCrossSection):
     top_radius: MM | None = None
     bottom_radius: MM | None = None
     name: str = "I-Profile"
+    plotter: Callable[[CombinedSteelCrossSection], plt.Figure] = plot_shapes
 
     def __post_init__(self) -> None:
         """Initialize the I-profile steel section."""
@@ -258,24 +261,4 @@ class ISteelProfile(CombinedSteelCrossSection):
             top_radius=profile.top_radius,
             bottom_radius=profile.bottom_radius,
             name=name,
-        )
-
-    def plot(self, plotter: Callable[[CombinedSteelCrossSection], plt.Figure] | None = None, *args, **kwargs) -> plt.Figure:
-        """Plot the cross-section. Making use of the standard plotter.
-
-        Parameters
-        ----------
-        plotter : Callable[CombinedSteelCrossSection, plt.Figure] | None
-            The plotter function to use. If None, the default Blueprints plotter for steel sections is used.
-        *args
-            Additional arguments passed to the plotter.
-        **kwargs
-            Additional keyword arguments passed to the plotter.
-        """
-        if plotter is None:
-            plotter = plot_shapes
-        return plotter(
-            self,
-            *args,
-            **kwargs,
         )

--- a/blueprints/structural_sections/steel/steel_cross_sections/lnp_profile.py
+++ b/blueprints/structural_sections/steel/steel_cross_sections/lnp_profile.py
@@ -41,6 +41,8 @@ class LNPProfile(CombinedSteelCrossSection):
         The radius of the toe in the base. Default is None, the corner radius is then taken as sharp angle.
     name : str
         The name of the profile. Default is "LNP-Profile". If corrosion is applied, the name will include the corrosion value.
+    plotter : Callable[[CombinedSteelCrossSection], plt.Figure]
+        The plotter function to visualize the cross-section (default: `plot_shapes`).
     """
 
     steel_material: SteelMaterial
@@ -53,6 +55,7 @@ class LNPProfile(CombinedSteelCrossSection):
     web_toe_radius: MM | None
     base_toe_radius: MM | None
     name: str = "LNP-Profile"
+    plotter: Callable[[CombinedSteelCrossSection], plt.Figure] = plot_shapes
 
     def __post_init__(self) -> None:
         """Initialize the RHS- or SHS-profile steel section."""
@@ -177,24 +180,4 @@ class LNPProfile(CombinedSteelCrossSection):
             web_toe_radius=web_toe_radius,
             base_toe_radius=base_toe_radius,
             name=name,
-        )
-
-    def plot(self, plotter: Callable[[CombinedSteelCrossSection], plt.Figure] | None = None, *args, **kwargs) -> plt.Figure:
-        """Plot the cross-section. Making use of the standard plotter.
-
-        Parameters
-        ----------
-        plotter : Callable[CombinedSteelCrossSection, plt.Figure] | None
-            The plotter function to use. If None, the default Blueprints plotter for steel sections is used.
-        *args
-            Additional arguments passed to the plotter.
-        **kwargs
-            Additional keyword arguments passed to the plotter.
-        """
-        if plotter is None:
-            plotter = plot_shapes
-        return plotter(
-            self,
-            *args,
-            **kwargs,
         )

--- a/blueprints/structural_sections/steel/steel_cross_sections/rhs_profile.py
+++ b/blueprints/structural_sections/steel/steel_cross_sections/rhs_profile.py
@@ -57,6 +57,8 @@ class RHSSteelProfile(CombinedSteelCrossSection):
         The outer radius of the bottom left corner. Default is None, the corner radius is then taken as twice the thickness.
     name : str
         The name of the profile. Default is "RHS-Profile". If corrosion is applied, the name will include the corrosion value.
+    plotter : Callable[[CombinedSteelCrossSection], plt.Figure]
+        The plotter function to visualize the cross-section (default: `plot_shapes`).
     """
 
     steel_material: SteelMaterial
@@ -75,6 +77,7 @@ class RHSSteelProfile(CombinedSteelCrossSection):
     bottom_right_outer_radius: MM | None = None
     bottom_left_outer_radius: MM | None = None
     name: str = "RHS-Profile"
+    plotter: Callable[[CombinedSteelCrossSection], plt.Figure] = plot_shapes
 
     def __post_init__(self) -> None:
         """Initialize the RHS- or SHS-profile steel section."""
@@ -294,24 +297,4 @@ class RHSSteelProfile(CombinedSteelCrossSection):
             bottom_right_outer_radius=bottom_right_outer_radius,
             bottom_left_outer_radius=bottom_left_outer_radius,
             name=name,
-        )
-
-    def plot(self, plotter: Callable[[CombinedSteelCrossSection], plt.Figure] | None = None, *args, **kwargs) -> plt.Figure:
-        """Plot the cross-section. Making use of the standard plotter.
-
-        Parameters
-        ----------
-        plotter : Callable[CombinedSteelCrossSection, plt.Figure] | None
-            The plotter function to use. If None, the default Blueprints plotter for steel sections is used.
-        *args
-            Additional arguments passed to the plotter.
-        **kwargs
-            Additional keyword arguments passed to the plotter.
-        """
-        if plotter is None:
-            plotter = plot_shapes
-        return plotter(
-            self,
-            *args,
-            **kwargs,
         )

--- a/blueprints/structural_sections/steel/steel_cross_sections/strip_profile.py
+++ b/blueprints/structural_sections/steel/steel_cross_sections/strip_profile.py
@@ -34,11 +34,14 @@ class StripSteelProfile(CombinedSteelCrossSection):
         The width of the strip profile [mm].
     height : MM
         The height (thickness) of the strip profile [mm].
+    plotter : Callable[[CombinedSteelCrossSection], plt.Figure]
+        The plotter function to visualize the cross-section (default: `plot_shapes`).
     """
 
     steel_material: SteelMaterial
     strip_width: MM
     strip_height: MM
+    plotter: Callable[[CombinedSteelCrossSection], plt.Figure] = plot_shapes
 
     def __post_init__(self) -> None:
         """Initialize the Steel Strip profile."""
@@ -93,24 +96,4 @@ class StripSteelProfile(CombinedSteelCrossSection):
             strip_width=width,
             strip_height=height,
             name=name,
-        )
-
-    def plot(self, plotter: Callable[[CombinedSteelCrossSection], plt.Figure] | None = None, *args, **kwargs) -> plt.Figure:
-        """Plot the cross-section. Making use of the standard plotter.
-
-        Parameters
-        ----------
-        plotter : Callable[CombinedSteelCrossSection, plt.Figure] | None
-            The plotter function to use. If None, the default Blueprints plotter for steel sections is used.
-        *args
-            Additional arguments passed to the plotter.
-        **kwargs
-            Additional keyword arguments passed to the plotter.
-        """
-        if plotter is None:
-            plotter = plot_shapes
-        return plotter(
-            self,
-            *args,
-            **kwargs,
         )

--- a/tests/structural_sections/test_cross_section_annular_sector.py
+++ b/tests/structural_sections/test_cross_section_annular_sector.py
@@ -137,3 +137,8 @@ class TestAnnularSectorCrossSection:
             y=250.0,
         )
         assert annular_sector.area == pytest.approx(expected=expected_area, rel=1e-3)
+
+    def test_no_plotter_defined(self, annular_sector_cross_section: AnnularSectorCrossSection) -> None:
+        """Test that accessing the plotter property raises an AttributeError if no plotter is defined."""
+        with pytest.raises(AttributeError, match="No plotter is defined."):
+            _ = annular_sector_cross_section.plotter

--- a/tests/structural_sections/test_cross_section_circle.py
+++ b/tests/structural_sections/test_cross_section_circle.py
@@ -37,3 +37,8 @@ class TestCircularCrossSection:
         """Test the geometry property of the CircularCrossSection class."""
         geometry = circular_cross_section.geometry()
         assert geometry is not None
+
+    def test_no_plotter_defined(self, annular_sector_cross_section: CircularCrossSection) -> None:
+        """Test that accessing the plotter property raises an AttributeError if no plotter is defined."""
+        with pytest.raises(AttributeError, match="No plotter is defined."):
+            _ = annular_sector_cross_section.plotter

--- a/tests/structural_sections/test_cross_section_cornered.py
+++ b/tests/structural_sections/test_cross_section_cornered.py
@@ -57,3 +57,8 @@ class TestCircularCorneredCrossSection:
                 outer_radius=10,
                 corner_direction=4,
             )
+
+    def test_no_plotter_defined(self, qcs_cross_section: CircularCorneredCrossSection) -> None:
+        """Test that accessing the plotter property raises an AttributeError if no plotter is defined."""
+        with pytest.raises(AttributeError, match="No plotter is defined."):
+            _ = qcs_cross_section.plotter

--- a/tests/structural_sections/test_cross_section_hexagon.py
+++ b/tests/structural_sections/test_cross_section_hexagon.py
@@ -44,3 +44,8 @@ class TestHexagonalCrossSection:
         """Test the parameters_as_dict method of the HexagonalCrossSection class."""
         params = hexagonal_cross_section.section_properties().asdict()
         assert params
+
+    def test_no_plotter_defined(self, hexagonal_cross_section: HexagonalCrossSection) -> None:
+        """Test that accessing the plotter property raises an AttributeError if no plotter is defined."""
+        with pytest.raises(AttributeError, match="No plotter is defined."):
+            _ = hexagonal_cross_section.plotter

--- a/tests/structural_sections/test_cross_section_rectangle.py
+++ b/tests/structural_sections/test_cross_section_rectangle.py
@@ -49,3 +49,8 @@ class TestRectangularCrossSection:
         """Test the geometry property of the RectangularCrossSection class."""
         geometry = rectangular_cross_section.geometry()
         assert geometry is not None
+
+    def test_no_plotter_defined(self, rectangular_cross_section: RectangularCrossSection) -> None:
+        """Test that accessing the plotter property raises an AttributeError if no plotter is defined."""
+        with pytest.raises(AttributeError, match="No plotter is defined."):
+            _ = rectangular_cross_section.plotter

--- a/tests/structural_sections/test_cross_section_triangle.py
+++ b/tests/structural_sections/test_cross_section_triangle.py
@@ -42,3 +42,8 @@ class TestRightAngledTriangularCrossSection:
         assert len(polygon.exterior.coords) == 4
         assert (polygon.exterior.coords[1][0], polygon.exterior.coords[1][1]) == (-100.0, 0)
         assert (polygon.exterior.coords[2][0], polygon.exterior.coords[2][1]) == (0, -200.0)
+
+    def test_no_plotter_defined(self, triangular_cross_section: RightAngledTriangularCrossSection) -> None:
+        """Test that accessing the plotter property raises an AttributeError if no plotter is defined."""
+        with pytest.raises(AttributeError, match="No plotter is defined."):
+            _ = triangular_cross_section.plotter

--- a/tests/structural_sections/test_cross_section_tube.py
+++ b/tests/structural_sections/test_cross_section_tube.py
@@ -44,3 +44,8 @@ class TestTubeCrossSection:
         """Test the geometry property of the TubeCrossSection class."""
         geometry = tube_cross_section.geometry()
         assert geometry is not None
+
+    def test_no_plotter_defined(self, tube_cross_section: TubeCrossSection) -> None:
+        """Test that accessing the plotter property raises an AttributeError if no plotter is defined."""
+        with pytest.raises(AttributeError, match="No plotter is defined."):
+            _ = tube_cross_section.plotter


### PR DESCRIPTION
## Description

This is the first step to[ refactor steel profiles implementation](https://github.com/Blueprints-org/blueprints/issues/734). In this PR:
- the plot() method is moved to the parent CrossSection class.

In the following PR's, I will:
- Improve the inheritance structure of the steel profile classes


Fixes #734 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
