### PR TITLE
refactor: remove ImportError handling for default dependencies in report and translate modules

### DIFF
--- a/blueprints/utils/_report_to_word.py
+++ b/blueprints/utils/_report_to_word.py
@@ -3,25 +3,17 @@
 import re
 from typing import Any, cast
 
+import latex2mathml.converter
+import mathml2omml
 import numpy as np
-
-try:
-    import latex2mathml.converter
-    import mathml2omml
-    from docx import Document
-    from docx.document import Document as DocumentObject
-    from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
-    from docx.oxml import OxmlElement, parse_xml
-    from docx.oxml.ns import qn
-    from docx.oxml.xmlchemy import BaseOxmlElement
-    from docx.shared import Inches, Pt, RGBColor
-    from docx.text.paragraph import Paragraph
-except ImportError:  # pragma: no cover
-    raise ImportError(
-        "\n\nThe Word features require the word module of blueprints. Install it through:\n"
-        "- pip install blueprints[word]\n"
-        "- uv add blueprints[word]\n"
-    )  # pragma: no cover
+from docx import Document
+from docx.document import Document as DocumentObject
+from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
+from docx.oxml import OxmlElement, parse_xml
+from docx.oxml.ns import qn
+from docx.oxml.xmlchemy import BaseOxmlElement
+from docx.shared import Inches, Pt, RGBColor
+from docx.text.paragraph import Paragraph
 
 
 class _ReportToWordConverter:

--- a/blueprints/utils/language/translate.py
+++ b/blueprints/utils/language/translate.py
@@ -8,15 +8,7 @@ import re
 from pathlib import Path
 from typing import Any, cast
 
-try:
-    from googletrans import Translator
-except ImportError:  # pragma: no cover
-    raise ImportError(
-        "\n\nThe translate features require the translate module of blueprints. Install it through:\n"
-        "`pip install blueprints[translate]`\n"
-        "or using uv:\n"
-        "`uv add blueprints[translate]`\n"
-    )  # pragma: no cover
+from googletrans import Translator
 
 
 class LatexTranslator:


### PR DESCRIPTION
## Description

remove ImportError handling for default dependencies in report and translate modules

Fixes #939

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated word document and translation module imports to enforce strict dependency requirements at import time.
  * Dependency errors will now surface earlier during application startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->