### PR TITLE
fix: update IProfile corrosion calculations to adjust corner radii

### DIFF
--- a/blueprints/structural_sections/steel/profile_definitions/i_profile.py
+++ b/blueprints/structural_sections/steel/profile_definitions/i_profile.py
@@ -147,6 +147,8 @@ class IProfile(Profile):
         bottom_flange_thickness = self.bottom_flange_thickness - corrosion * 2
         total_height = self.total_height - corrosion * 2
         web_thickness = self.web_thickness - corrosion * 2
+        top_radius = self.top_radius + corrosion
+        bottom_radius = self.bottom_radius + corrosion
 
         if any(
             thickness < FULL_CORROSION_TOLERANCE
@@ -167,8 +169,8 @@ class IProfile(Profile):
             bottom_flange_thickness=bottom_flange_thickness,
             total_height=total_height,
             web_thickness=web_thickness,
-            top_radius=self.top_radius,
-            bottom_radius=self.bottom_radius,
+            top_radius=top_radius,
+            bottom_radius=bottom_radius,
             name=name,
             plotter=self.plotter,
         )

--- a/tests/structural_sections/steel/profile_definitions/test_i_profile.py
+++ b/tests/structural_sections/steel/profile_definitions/test_i_profile.py
@@ -96,9 +96,9 @@ class TestIProfile:
         assert pytest.approx(corroded_profile.total_height, rel=1e-6) == h_profile.total_height - corrosion * 2
         assert pytest.approx(corroded_profile.web_thickness, rel=1e-6) == h_profile.web_thickness - corrosion * 2
 
-        # Check radius values remain unchanged
-        assert corroded_profile.top_radius == h_profile.top_radius
-        assert corroded_profile.bottom_radius == h_profile.bottom_radius
+        # Check radius values are increased by corrosion
+        assert corroded_profile.top_radius == h_profile.top_radius + corrosion
+        assert corroded_profile.bottom_radius == h_profile.bottom_radius + corrosion
 
         # Check name is updated with corrosion info
         expected_name = "HEB360 (corrosion: 2.0 mm)"


### PR DESCRIPTION
## Description

fix: update IProfile corrosion calculations to adjust corner radii

inner corner radii become larger when corrsion is present

Fixes #941 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected I-profile corrosion calculation: radii now properly increase by the corrosion amount to reflect material expansion behavior. Other corrosion-related dimension adjustments (thicknesses and heights) remain consistent with existing calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->