### PR TITLE
fix: set default title for Report to "Untitled Report" and update tests accordingly

### DIFF
--- a/blueprints/utils/_report_to_word.py
+++ b/blueprints/utils/_report_to_word.py
@@ -296,6 +296,10 @@ class _ReportToWordConverter:
             return  # pragma: no cover
         extracted_content = brace_match.group(1).strip()
 
+        # Skip adding if \title{} is empty
+        if heading_type == "title" and not extracted_content:
+            return
+
         # Add numbering to sections
         if heading_type == "section":
             self.section_counter += 1

--- a/blueprints/utils/report.py
+++ b/blueprints/utils/report.py
@@ -71,7 +71,7 @@ class Report:
     >>> print(latex_document)  # prints the complete LaTeX document string, which can be compiled with pdflatex in for example Overleaf.
     """
 
-    title: str = "Untitled Report"
+    title: str = ""
     content: str = field(default="", init=False)
 
     def add_paragraph(self, text: str, bold: bool = False, italic: bool = False) -> Self:

--- a/blueprints/utils/report.py
+++ b/blueprints/utils/report.py
@@ -71,7 +71,7 @@ class Report:
     >>> print(latex_document)  # prints the complete LaTeX document string, which can be compiled with pdflatex in for example Overleaf.
     """
 
-    title: str | None = None
+    title: str = "Untitled Report"
     content: str = field(default="", init=False)
 
     def add_paragraph(self, text: str, bold: bool = False, italic: bool = False) -> Self:
@@ -506,7 +506,7 @@ class Report:
         figures = self.content.count(r"\begin{figure}")
         lists = self.content.count(r"\begin{itemize}") + self.content.count(r"\begin{enumerate}")
 
-        title_str = f'title="{self.title}"' if self.title else "title=None"
+        title_str = f'title="{self.title}"'
         stats = (
             f"sections={sections}, subsections={subsections}, "
             f"equations={equations}, tables={tables}, figures={figures}, "
@@ -526,7 +526,7 @@ class Report:
 
         lines = [
             "=" * 60,
-            f"LaTeX Report: {self.title or '(untitled)'}",
+            f"LaTeX Report: {self.title}",
             "=" * 60,
             f"Sections:      {sections}",
             f"Subsections:   {subsections}",
@@ -583,9 +583,6 @@ class Report:
         >>> from pathlib import Path
         >>> report.to_latex(Path("report.tex"))
         """
-        # Use provided title or fall back to instance title
-        doc_title = self.title or ""
-
         # Build the preamble with styling to match Word document converter (pdflatex compatible)
         preamble = (
             r"\documentclass[11pt]{article}" + "\n"
@@ -647,7 +644,7 @@ class Report:
             r"\parindent 0in" + "\n"  # No paragraph indentation
             # Begin document
             r"\begin{document}" + "\n"
-            rf"\title{{{doc_title}}}" + "\n"  # Set document title
+            rf"\title{{{self.title}}}" + "\n"  # Set document title
             r"\date{}" + "\n"  # No date displayed
             r"\maketitle" + "\n"  # Generate the title
         )

--- a/tests/utils/test_report.py
+++ b/tests/utils/test_report.py
@@ -71,7 +71,7 @@ class TestReport:
         """Test that Report initializes with empty content."""
         report = Report()
         assert report.content == ""
-        assert report.title is None
+        assert report.title == "Untitled Report"
 
     def test_initialization_with_title(self) -> None:
         """Test that Report initializes with title."""
@@ -331,7 +331,7 @@ class TestReport:
         """Test generating document without any title."""
         report = Report()
         document = report.to_latex()
-        assert r"\title{}" in document
+        assert r"\title{Untitled Report}" in document
 
     def test_to_document_includes_preamble(self, fixture_report: Report) -> None:
         """Test that document includes all necessary preamble packages."""
@@ -462,7 +462,7 @@ class TestReport:
         """Test string representation of untitled report."""
         report = Report()
         str_repr = str(report)
-        assert "LaTeX Report: (untitled)" in str_repr
+        assert "LaTeX Report: Untitled Report" in str_repr
 
     def test_to_latex_returns_string_when_path_is_none(self) -> None:
         """Test that to_latex() returns string when path is None."""
@@ -689,7 +689,7 @@ class TestReport:
 
         combined = report1 + report2
 
-        assert combined.title is None
+        assert combined.title == "Untitled Report"
         assert "Chapter 1" in combined.content
         assert "Chapter 2" in combined.content
 
@@ -713,7 +713,7 @@ class TestReport:
 
         combined = report_no_title + report_with_title
 
-        assert combined.title is None
+        assert combined.title == "Untitled Report"
         assert "No title content" in combined.content
         assert "Titled content" in combined.content
 

--- a/tests/utils/test_report.py
+++ b/tests/utils/test_report.py
@@ -71,7 +71,7 @@ class TestReport:
         """Test that Report initializes with empty content."""
         report = Report()
         assert report.content == ""
-        assert report.title == "Untitled Report"
+        assert report.title == ""
 
     def test_initialization_with_title(self) -> None:
         """Test that Report initializes with title."""
@@ -331,7 +331,7 @@ class TestReport:
         """Test generating document without any title."""
         report = Report()
         document = report.to_latex()
-        assert r"\title{Untitled Report}" in document
+        assert r"\title{}" in document
 
     def test_to_document_includes_preamble(self, fixture_report: Report) -> None:
         """Test that document includes all necessary preamble packages."""
@@ -462,7 +462,7 @@ class TestReport:
         """Test string representation of untitled report."""
         report = Report()
         str_repr = str(report)
-        assert "LaTeX Report: Untitled Report" in str_repr
+        assert "LaTeX Report: " in str_repr
 
     def test_to_latex_returns_string_when_path_is_none(self) -> None:
         """Test that to_latex() returns string when path is None."""
@@ -689,7 +689,7 @@ class TestReport:
 
         combined = report1 + report2
 
-        assert combined.title == "Untitled Report"
+        assert combined.title == ""
         assert "Chapter 1" in combined.content
         assert "Chapter 2" in combined.content
 
@@ -713,7 +713,7 @@ class TestReport:
 
         combined = report_no_title + report_with_title
 
-        assert combined.title == "Untitled Report"
+        assert combined.title == ""
         assert "No title content" in combined.content
         assert "Titled content" in combined.content
 

--- a/tests/utils/test_report_to_word.py
+++ b/tests/utils/test_report_to_word.py
@@ -159,3 +159,15 @@ class TestReportToWordConverter:
         docx_buffer = BytesIO(result)
         docx_doc = DocxDocument(docx_buffer)
         assert docx_doc
+
+    def test_empty_report_title_not_added(self) -> None:
+        """Test that an empty report title is not added to the Word document."""
+        report = Report()
+        report.add_paragraph("Some content without a title.")
+
+        # Call without path argument
+        result = report.to_word()
+
+        # Verify result is bytes
+        assert isinstance(result, bytes)
+        assert len(result) > 0


### PR DESCRIPTION
## Description

Empty report gave issues when title is None. Now set to Untitled Report instead.

Fixes #952 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Untitled reports now default to an empty title instead of a placeholder; string and display outputs show the title as-is (blank when unspecified).
  * LaTeX export uses the actual title (may be empty).
  * Word export skips adding a title heading when the title is empty.

* **Tests**
  * Added/updated tests to reflect empty-title behavior and ensure exports produce expected output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->