### PR TITLE
add ability to iterate over standard profiles

### DIFF
--- a/blueprints/structural_sections/steel/standard_profiles/chs.py
+++ b/blueprints/structural_sections/steel/standard_profiles/chs.py
@@ -295,7 +295,7 @@ class CHS(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available CHS profiles:
         >>> for profile in CHS:
-        >>>     print(isinstance(profile, CHSProfile))  # True
+        ...     print(isinstance(profile, CHSProfile))  # True
     """
 
     _factory = CHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/chs.py
+++ b/blueprints/structural_sections/steel/standard_profiles/chs.py
@@ -291,6 +291,11 @@ class CHS(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = CHS.CHS21_3x2_3
+        >>> print(isinstance(profile, CHSProfile))  # True
+        >>>
+        >>> # To iterate over all available CHS profiles:
+        >>> for profile in CHS:
+        >>>     print(isinstance(profile, CHSProfile))  # True
     """
 
     _factory = CHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/hea.py
+++ b/blueprints/structural_sections/steel/standard_profiles/hea.py
@@ -68,6 +68,11 @@ class HEA(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = HEA.HEA200
+        >>> print(isinstance(profile, IProfile))  # True
+        >>>
+        >>> # To iterate over all available HEA profiles:
+        >>> for profile in HEA:
+        >>>     print(isinstance(profile, IProfile))  # True
     """
 
     _factory = IProfile

--- a/blueprints/structural_sections/steel/standard_profiles/hea.py
+++ b/blueprints/structural_sections/steel/standard_profiles/hea.py
@@ -72,7 +72,7 @@ class HEA(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available HEA profiles:
         >>> for profile in HEA:
-        >>>     print(isinstance(profile, IProfile))  # True
+        ...     print(isinstance(profile, IProfile))  # True
     """
 
     _factory = IProfile

--- a/blueprints/structural_sections/steel/standard_profiles/heb.py
+++ b/blueprints/structural_sections/steel/standard_profiles/heb.py
@@ -68,6 +68,11 @@ class HEB(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = HEB.HEB200
+        >>> print(isinstance(profile, IProfile))  # True
+        >>>
+        >>> # To iterate over all available HEB profiles:
+        >>> for profile in HEB:
+        >>>     print(isinstance(profile, IProfile))  # True
     """
 
     _factory = IProfile

--- a/blueprints/structural_sections/steel/standard_profiles/heb.py
+++ b/blueprints/structural_sections/steel/standard_profiles/heb.py
@@ -72,7 +72,7 @@ class HEB(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available HEB profiles:
         >>> for profile in HEB:
-        >>>     print(isinstance(profile, IProfile))  # True
+        ...     print(isinstance(profile, IProfile))  # True
     """
 
     _factory = IProfile

--- a/blueprints/structural_sections/steel/standard_profiles/hem.py
+++ b/blueprints/structural_sections/steel/standard_profiles/hem.py
@@ -72,7 +72,7 @@ class HEM(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available HEM profiles:
         >>> for profile in HEM:
-        >>>     print(isinstance(profile, IProfile))  # True
+        ...     print(isinstance(profile, IProfile))  # True
     """
 
     _factory = IProfile

--- a/blueprints/structural_sections/steel/standard_profiles/hem.py
+++ b/blueprints/structural_sections/steel/standard_profiles/hem.py
@@ -68,6 +68,11 @@ class HEM(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = HEM.HEM200
+        >>> print(isinstance(profile, IProfile))  # True
+        >>>
+        >>> # To iterate over all available HEM profiles:
+        >>> for profile in HEM:
+        >>>     print(isinstance(profile, IProfile))  # True
     """
 
     _factory = IProfile

--- a/blueprints/structural_sections/steel/standard_profiles/ipe.py
+++ b/blueprints/structural_sections/steel/standard_profiles/ipe.py
@@ -66,7 +66,7 @@ class IPE(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available IPE profiles:
         >>> for profile in IPE:
-        >>>     print(isinstance(profile, IProfile))  # True
+        ...     print(isinstance(profile, IProfile))  # True
     """
 
     _factory = IProfile

--- a/blueprints/structural_sections/steel/standard_profiles/ipe.py
+++ b/blueprints/structural_sections/steel/standard_profiles/ipe.py
@@ -62,6 +62,11 @@ class IPE(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = IPE.IPE200
+        >>> print(isinstance(profile, IProfile))  # True
+        >>>
+        >>> # To iterate over all available IPE profiles:
+        >>> for profile in IPE:
+        >>>     print(isinstance(profile, IProfile))  # True
     """
 
     _factory = IProfile

--- a/blueprints/structural_sections/steel/standard_profiles/lnp.py
+++ b/blueprints/structural_sections/steel/standard_profiles/lnp.py
@@ -140,6 +140,11 @@ class LNP(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = LNP.LNP40x40x4
+        >>> print(isinstance(profile, LNPProfile))  # True
+        >>>
+        >>> # To iterate over all available LNP profiles:
+        >>> for profile in LNP:
+        >>>     print(isinstance(profile, LNPProfile))  # True
     """
 
     _factory = LNPProfile

--- a/blueprints/structural_sections/steel/standard_profiles/lnp.py
+++ b/blueprints/structural_sections/steel/standard_profiles/lnp.py
@@ -144,7 +144,7 @@ class LNP(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available LNP profiles:
         >>> for profile in LNP:
-        >>>     print(isinstance(profile, LNPProfile))  # True
+        ...     print(isinstance(profile, LNPProfile))  # True
     """
 
     _factory = LNPProfile

--- a/blueprints/structural_sections/steel/standard_profiles/rhs.py
+++ b/blueprints/structural_sections/steel/standard_profiles/rhs.py
@@ -176,7 +176,7 @@ class RHS(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available RHS profiles:
         >>> for profile in RHS:
-        >>>     print(isinstance(profile, RHSProfile))  # True
+        ...     print(isinstance(profile, RHSProfile))  # True
     """
 
     _factory = RHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/rhs.py
+++ b/blueprints/structural_sections/steel/standard_profiles/rhs.py
@@ -172,6 +172,11 @@ class RHS(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = RHS.RHS100x50x4
+        >>> print(isinstance(profile, RHSProfile))  # True
+        >>>
+        >>> # To iterate over all available RHS profiles:
+        >>> for profile in RHS:
+        >>>     print(isinstance(profile, RHSProfile))  # True
     """
 
     _factory = RHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/rhscf.py
+++ b/blueprints/structural_sections/steel/standard_profiles/rhscf.py
@@ -223,7 +223,7 @@ class RHSCF(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available RHSCF profiles:
         >>> for profile in RHSCF:
-        >>>     print(isinstance(profile, RHSProfile))  # True
+        ...     print(isinstance(profile, RHSProfile))  # True
     """
 
     _factory = RHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/rhscf.py
+++ b/blueprints/structural_sections/steel/standard_profiles/rhscf.py
@@ -219,6 +219,11 @@ class RHSCF(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = RHSCF.RHSCF100x50x4
+        >>> print(isinstance(profile, RHSProfile))  # True
+        >>>
+        >>> # To iterate over all available RHSCF profiles:
+        >>> for profile in RHSCF:
+        >>>     print(isinstance(profile, RHSProfile))  # True
     """
 
     _factory = RHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/shs.py
+++ b/blueprints/structural_sections/steel/standard_profiles/shs.py
@@ -170,7 +170,7 @@ class SHS(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available SHS profiles:
         >>> for profile in SHS:
-        >>>     print(isinstance(profile, RHSProfile))  # True
+        ...     print(isinstance(profile, RHSProfile))  # True
     """
 
     _factory = RHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/shs.py
+++ b/blueprints/structural_sections/steel/standard_profiles/shs.py
@@ -166,6 +166,11 @@ class SHS(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = SHS.SHS100x5
+        >>> print(isinstance(profile, RHSProfile))  # True
+        >>>
+        >>> # To iterate over all available SHS profiles:
+        >>> for profile in SHS:
+        >>>     print(isinstance(profile, RHSProfile))  # True
     """
 
     _factory = RHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/shscf.py
+++ b/blueprints/structural_sections/steel/standard_profiles/shscf.py
@@ -208,6 +208,11 @@ class SHSCF(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = SHSCF.SHSCF100x6
+        >>> print(isinstance(profile, RHSProfile))  # True
+        >>>
+        >>> # To iterate over all available SHSCF profiles:
+        >>> for profile in SHSCF:
+        >>>     print(isinstance(profile, RHSProfile))  # True
     """
 
     _factory = RHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/shscf.py
+++ b/blueprints/structural_sections/steel/standard_profiles/shscf.py
@@ -212,7 +212,7 @@ class SHSCF(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available SHSCF profiles:
         >>> for profile in SHSCF:
-        >>>     print(isinstance(profile, RHSProfile))  # True
+        ...     print(isinstance(profile, RHSProfile))  # True
     """
 
     _factory = RHSProfile

--- a/blueprints/structural_sections/steel/standard_profiles/strip.py
+++ b/blueprints/structural_sections/steel/standard_profiles/strip.py
@@ -98,7 +98,7 @@ class Strip(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available Strip profiles:
         >>> for profile in Strip:
-        >>>     print(isinstance(profile, StripProfile))  # True
+        ...     print(isinstance(profile, StripProfile))  # True
     """
 
     _factory = StripProfile

--- a/blueprints/structural_sections/steel/standard_profiles/strip.py
+++ b/blueprints/structural_sections/steel/standard_profiles/strip.py
@@ -94,6 +94,11 @@ class Strip(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = Strip.STRIP200x10
+        >>> print(isinstance(profile, StripProfile))  # True
+        >>>
+        >>> # To iterate over all available Strip profiles:
+        >>> for profile in Strip:
+        >>>     print(isinstance(profile, StripProfile))  # True
     """
 
     _factory = StripProfile

--- a/blueprints/structural_sections/steel/standard_profiles/unp.py
+++ b/blueprints/structural_sections/steel/standard_profiles/unp.py
@@ -55,6 +55,12 @@ class UNP(metaclass=StandardProfileMeta):
     Usage example
     -------------
         >>> profile = UNP.UNP200
+        >>> print(isinstance(profile, UNPProfile))  # True
+        >>>
+        >>> # To iterate over all available UNP profiles:
+        >>> for profile in UNP:
+        >>>     print(isinstance(profile, UNPProfile))  # True
+
     """
 
     _factory = UNPProfile

--- a/blueprints/structural_sections/steel/standard_profiles/unp.py
+++ b/blueprints/structural_sections/steel/standard_profiles/unp.py
@@ -59,7 +59,7 @@ class UNP(metaclass=StandardProfileMeta):
         >>>
         >>> # To iterate over all available UNP profiles:
         >>> for profile in UNP:
-        >>>     print(isinstance(profile, UNPProfile))  # True
+        ...     print(isinstance(profile, UNPProfile))  # True
 
     """
 

--- a/blueprints/structural_sections/steel/standard_profiles/utils.py
+++ b/blueprints/structural_sections/steel/standard_profiles/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import NamedTuple, Protocol
 
 from blueprints.structural_sections._profile import Profile
@@ -43,3 +43,7 @@ class StandardProfileMeta(type):
         except KeyError as e:
             raise AttributeError(f"Profile '{name}' does not exist in database.") from e
         return cls._factory(**profile._asdict())
+
+    def __iter__(cls: StandardProfileProtocol) -> Iterator[Profile]:
+        """Iterate over the profiles in the class database."""
+        return (cls.__getattr__(profile_key) for profile_key in cls._database)

--- a/blueprints/structural_sections/steel/standard_profiles/utils.py
+++ b/blueprints/structural_sections/steel/standard_profiles/utils.py
@@ -46,4 +46,4 @@ class StandardProfileMeta(type):
 
     def __iter__(cls: StandardProfileProtocol) -> Iterator[Profile]:
         """Iterate over the profiles in the class database."""
-        return (cls.__getattr__(profile_key) for profile_key in cls._database)
+        return (getattr(cls, profile_key) for profile_key in cls._database)

--- a/tests/structural_sections/steel/standard_profiles/test_chs.py
+++ b/tests/structural_sections/steel/standard_profiles/test_chs.py
@@ -40,3 +40,10 @@ class TestCHS:
 
         profile3 = CHS.CHS1016x20
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the CHS class yields valid profiles."""
+        for profile in CHS:
+            assert isinstance(profile, CHSProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_hea.py
+++ b/tests/structural_sections/steel/standard_profiles/test_hea.py
@@ -46,3 +46,10 @@ class TestHEA:
 
         profile3 = HEA.HEA300
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the HEA class yields valid profiles."""
+        for profile in HEA:
+            assert isinstance(profile, IProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_heb.py
+++ b/tests/structural_sections/steel/standard_profiles/test_heb.py
@@ -46,3 +46,10 @@ class TestHEB:
 
         profile3 = HEB.HEB300
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the HEB class yields valid profiles."""
+        for profile in HEB:
+            assert isinstance(profile, IProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_hem.py
+++ b/tests/structural_sections/steel/standard_profiles/test_hem.py
@@ -46,3 +46,10 @@ class TestHEM:
 
         profile3 = HEM.HEM300
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the HEM class yields valid profiles."""
+        for profile in HEM:
+            assert isinstance(profile, IProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_ipe.py
+++ b/tests/structural_sections/steel/standard_profiles/test_ipe.py
@@ -46,3 +46,10 @@ class TestIPE:
 
         profile3 = IPE.IPE300
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the IPE class yields valid profiles."""
+        for profile in IPE:
+            assert isinstance(profile, IProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_lnp.py
+++ b/tests/structural_sections/steel/standard_profiles/test_lnp.py
@@ -46,3 +46,10 @@ class TestLNP:
 
         profile3 = LNP.LNP60x40x7
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the LNP class yields valid profiles."""
+        for profile in LNP:
+            assert isinstance(profile, LNPProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_rhs.py
+++ b/tests/structural_sections/steel/standard_profiles/test_rhs.py
@@ -52,3 +52,10 @@ class TestRHS:
 
         profile3 = RHS.RHS200x100x8
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the RHS class yields valid profiles."""
+        for profile in RHS:
+            assert isinstance(profile, RHSProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_rhscf.py
+++ b/tests/structural_sections/steel/standard_profiles/test_rhscf.py
@@ -52,3 +52,10 @@ class TestRHSCF:
 
         profile3 = RHSCF.RHSCF200x100x8
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the RHSCF class yields valid profiles."""
+        for profile in RHSCF:
+            assert isinstance(profile, RHSProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_shs.py
+++ b/tests/structural_sections/steel/standard_profiles/test_shs.py
@@ -52,3 +52,10 @@ class TestSHS:
 
         profile3 = SHS.SHS200x8
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the SHS class yields valid profiles."""
+        for profile in SHS:
+            assert isinstance(profile, RHSProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_shscf.py
+++ b/tests/structural_sections/steel/standard_profiles/test_shscf.py
@@ -52,3 +52,10 @@ class TestSHSCF:
 
         profile3 = SHSCF.SHSCF200x8
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the SHSCF class yields valid profiles."""
+        for profile in SHSCF:
+            assert isinstance(profile, RHSProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_strip.py
+++ b/tests/structural_sections/steel/standard_profiles/test_strip.py
@@ -40,3 +40,10 @@ class TestStrip:
 
         profile3 = Strip.STRIP180x5
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the Strip class yields valid profiles."""
+        for profile in Strip:
+            assert isinstance(profile, StripProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0

--- a/tests/structural_sections/steel/standard_profiles/test_unp.py
+++ b/tests/structural_sections/steel/standard_profiles/test_unp.py
@@ -50,3 +50,10 @@ class TestUNP:
 
         profile3 = UNP.UNP300
         assert profile1 != profile3
+
+    def test_iteration(self) -> None:
+        """Test that iterating over the UNP class yields valid profiles."""
+        for profile in UNP:
+            assert isinstance(profile, UNPProfile)
+            assert profile.polygon.is_valid
+            assert profile.area > 0


### PR DESCRIPTION
## Description

Hi there, a small PR that makes it possible to iterate over standard profiles like:

```python
import HEA

for hea in HEA:
    print(hea.area)
    ...
```

Adding type inference is extremely difficult. So, I have to take care of that in a seperate PR.

Fixes #980 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Steel profile classes are now iterable, allowing direct iteration to enumerate all predefined profiles.

* **Tests**
  * Added iteration tests for every steel profile type to verify each yielded profile has a valid geometry and positive area.

* **Documentation**
  * Updated usage examples across steel profile docs to demonstrate iteration and runtime type checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->