### PR TITLE
fix: UNP with lots of corrosion

### DIFF
--- a/blueprints/structural_sections/steel/profile_definitions/unp_profile.py
+++ b/blueprints/structural_sections/steel/profile_definitions/unp_profile.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -95,6 +95,8 @@ class UNPProfile(Profile):
     """The name of the profile. Default is "UNP-Profile". If corrosion is applied, the name will include the corrosion value."""
     plotter: Callable[[Profile], plt.Figure] = plot_shapes
     """The plotter function to visualize the profile (default: `plot_shapes`)."""
+    _polygon_override: Polygon | None = field(default=None, kw_only=True, repr=False, compare=False)
+    """Optional polygon override for corroded profiles."""
 
     # Attributes set in __post_init__ (for type checkers)
     top_root_fillet_height: float = field(init=False, repr=False)
@@ -171,30 +173,32 @@ class UNPProfile(Profile):
             self.total_height / 2 - self.bottom_toe_total_height - self.bottom_slope_height - self.bottom_root_fillet_height,
         )
 
-        raise_if_negative(
-            top_slope=self.top_slope,
-            bottom_slope=self.bottom_slope,
-            top_root_fillet_height=self.top_root_fillet_height,
-            top_root_fillet_width=self.top_root_fillet_width,
-            bottom_root_fillet_height=self.bottom_root_fillet_height,
-            bottom_root_fillet_width=self.bottom_root_fillet_width,
-            top_toe_radius_height=self.top_toe_radius_height,
-            top_toe_radius_width=self.top_toe_radius_width,
-            bottom_toe_radius_height=self.bottom_toe_radius_height,
-            bottom_toe_radius_width=self.bottom_toe_radius_width,
-            top_slope_width=self.top_slope_width,
-            top_slope_height=self.top_slope_height,
-            top_slope_length=self.top_slope_length,
-            bottom_slope_width=self.bottom_slope_width,
-            bottom_slope_height=self.bottom_slope_height,
-            bottom_slope_length=self.bottom_slope_length,
-            top_toe_total_height=self.top_toe_total_height,
-            top_toe_flat_height=self.top_toe_flat_height,
-            bottom_toe_total_height=self.bottom_toe_total_height,
-            bottom_toe_flat_height=self.bottom_toe_flat_height,
-            web_inner_height_top=self.web_inner_height_top,
-            web_inner_height_bottom=self.web_inner_height_bottom,
-        )
+        # Only validate dimensions for non-corroded profiles, as corrosion can lead to negative dimensions which are handled in with_corrosion method
+        if not self._polygon_override:
+            raise_if_negative(
+                top_slope=self.top_slope,
+                bottom_slope=self.bottom_slope,
+                top_root_fillet_height=self.top_root_fillet_height,
+                top_root_fillet_width=self.top_root_fillet_width,
+                bottom_root_fillet_height=self.bottom_root_fillet_height,
+                bottom_root_fillet_width=self.bottom_root_fillet_width,
+                top_toe_radius_height=self.top_toe_radius_height,
+                top_toe_radius_width=self.top_toe_radius_width,
+                bottom_toe_radius_height=self.bottom_toe_radius_height,
+                bottom_toe_radius_width=self.bottom_toe_radius_width,
+                top_slope_width=self.top_slope_width,
+                top_slope_height=self.top_slope_height,
+                top_slope_length=self.top_slope_length,
+                bottom_slope_width=self.bottom_slope_width,
+                bottom_slope_height=self.bottom_slope_height,
+                bottom_slope_length=self.bottom_slope_length,
+                top_toe_total_height=self.top_toe_total_height,
+                top_toe_flat_height=self.top_toe_flat_height,
+                bottom_toe_total_height=self.bottom_toe_total_height,
+                bottom_toe_flat_height=self.bottom_toe_flat_height,
+                web_inner_height_top=self.web_inner_height_top,
+                web_inner_height_bottom=self.web_inner_height_bottom,
+            )
 
     @property
     def max_thickness(self) -> MM:
@@ -204,6 +208,8 @@ class UNPProfile(Profile):
     @property
     def _polygon(self) -> Polygon:
         """Return the polygon of the UNP profile without the offset and rotation applied."""
+        if self._polygon_override is not None:  # for corroded profiles, which make the flange toe act complex
+            return self._polygon_override
         return (
             PolygonBuilder(starting_point=(0, 0))
             # Starting halfway along the web, going up
@@ -282,9 +288,12 @@ class UNPProfile(Profile):
         ):
             raise ValueError("The profile has fully corroded.")
 
+        # Apply corrosion by buffering the polygon inward by the corrosion amount
+        corroded_polygon = self._polygon.buffer(-corrosion)
         name = update_name_with_corrosion(self.name, corrosion=corrosion)
 
-        return UNPProfile(
+        return replace(
+            self,
             top_flange_total_width=buffer["top_flange_total_width"],
             top_flange_thickness=buffer["top_flange_thickness"],
             bottom_flange_total_width=buffer["bottom_flange_total_width"],
@@ -297,8 +306,6 @@ class UNPProfile(Profile):
             bottom_root_fillet_radius=buffer["bottom_root_fillet_radius"],
             bottom_toe_radius=buffer["bottom_toe_radius"],
             bottom_outer_corner_radius=buffer["bottom_outer_corner_radius"],
-            top_slope=self.top_slope,
-            bottom_slope=self.bottom_slope,
+            _polygon_override=corroded_polygon,
             name=name,
-            plotter=self.plotter,
         )

--- a/tests/structural_sections/steel/profile_definitions/test_unp_profile.py
+++ b/tests/structural_sections/steel/profile_definitions/test_unp_profile.py
@@ -141,7 +141,12 @@ class TestUNPProfile:
         assert pytest.approx(second_corroded_profile.total_height, rel=1e-6) == unp_profile.total_height - total_corrosion * 2
         assert pytest.approx(second_corroded_profile.web_thickness, rel=1e-6) == unp_profile.web_thickness - total_corrosion * 2
 
-    def test_negative_calculated_values(self, unp_profile: UNPProfile) -> None:
-        """Test that applying excessive corrosion raises NegativeValueError for calculated properties."""
-        with pytest.raises(NegativeValueError):
-            unp_profile.with_corrosion(corrosion=4)
+    def test_90_percent_corrosion(self, unp_profile: UNPProfile) -> None:
+        """Test that applying corrosion that reduces dimensions by 90% does not raise an error."""
+        # Calculate corrosion that reduces web thickness by 90%
+        corrosion = unp_profile.web_thickness * 0.9 / 2  # Divide by 2 because corrosion is applied on both sides
+        corroded_profile = unp_profile.with_corrosion(corrosion=corrosion)
+
+        # Check that the profile is still valid and has positive dimensions
+        assert corroded_profile.web_thickness > 0
+        assert corroded_profile.top_flange_thickness > 0


### PR DESCRIPTION
## Description

Lots of corrosion makes the toe of the flanges act weirdly. the 90-degree corner and the curve start to blend, creating a sharp corner together. Current code crashes cause it calcs the toe height, which has become negative now. using a replace and shapely buffer fixes this.

<img width="475" height="303" alt="image" src="https://github.com/user-attachments/assets/d234b77c-6c11-4576-8daf-b70ae9ec8f39" />
<img width="624" height="690" alt="image" src="https://github.com/user-attachments/assets/47d7f776-a255-4226-ad84-f0de6ed3f7ec" />


Fixes #1062

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Steel profiles with severe corrosion are now handled more robustly, preventing calculation errors that previously occurred with excessive corrosion.
  * Profiles maintain positive key structural dimensions even when subjected to high levels of corrosion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->