### PR TITLE
feat: add NEN-EN 1993-1-1+C2+A1:2016 formula 2.1 (design resistance)

### DIFF
--- a/blueprints/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/__init__.py
+++ b/blueprints/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/__init__.py
@@ -1,0 +1,3 @@
+"""NEN-EN 1993-1-1+C2+A1:2016 National Annex NL."""
+
+NEN_EN_1993_1_1_C2_A1_2016 = "NEN-EN 1993-1-1+C2+A1:2016"

--- a/blueprints/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/chapter_2_basis_of_design/__init__.py
+++ b/blueprints/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/chapter_2_basis_of_design/__init__.py
@@ -1,0 +1,2 @@
+"""Chapter 2: Basis of design."""
+

--- a/blueprints/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/chapter_2_basis_of_design/formula_2_1.py
+++ b/blueprints/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/chapter_2_basis_of_design/formula_2_1.py
@@ -1,0 +1,72 @@
+"""Formula 2.1 from NEN-EN 1993-1-1+C2+A1:2016: Chapter 2 - Basis of Design."""
+
+from blueprints.codes.eurocode.national_annex.nl.nen_en_1993_1_1_c2_a1_2016 import NEN_EN_1993_1_1_C2_A1_2016
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form2Dot1DesignResistance(Formula):
+    r"""Class representing formula 2.1 for the calculation of [$R_d$]."""
+
+    label = "2.1"
+    source_document = NEN_EN_1993_1_1_C2_A1_2016
+
+    def __init__(
+        self,
+        r_k: DIMENSIONLESS,
+        gamma_m: DIMENSIONLESS,
+    ) -> None:
+        r"""[$R_d$] Calculation of the design resistance.
+
+        NEN-EN 1993-1-1+C2+A1:2016 art.2 - Formula (2.1)
+
+        Parameters
+        ----------
+        r_k : DIMENSIONLESS
+            [$R_k$] Characteristic value of the resistance.
+        gamma_m : DIMENSIONLESS
+            [$\gamma_M$] Partial safety factor for resistance.
+        """
+        super().__init__()
+        self.r_k = r_k
+        self.gamma_m = gamma_m
+
+    @staticmethod
+    def _evaluate(
+        r_k: DIMENSIONLESS,
+        gamma_m: DIMENSIONLESS,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(gamma_m=gamma_m)
+
+        return r_k / gamma_m
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 2.1."""
+        _equation: str = r"\frac{R_k}{\gamma_M}"
+        _numeric_equation: str = latex_replace_symbols(
+            _equation,
+            {
+                r"R_k": f"{self.r_k:.{n}f}",
+                r"\gamma_M": f"{self.gamma_m:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            _equation,
+            {
+                r"R_k": rf"{self.r_k:.{n}f}",
+                r"\gamma_M": rf"{self.gamma_m:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"R_d",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+        )

--- a/tests/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/chapter_2_basis_of_design/__init__.py
+++ b/tests/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/chapter_2_basis_of_design/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for chapter 2 basis of design."""

--- a/tests/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/chapter_2_basis_of_design/test_formula_2_1.py
+++ b/tests/codes/eurocode/national_annex/nl/nen_en_1993_1_1_c2_a1_2016/chapter_2_basis_of_design/test_formula_2_1.py
@@ -1,0 +1,74 @@
+"""Testing formula 2.1 of NEN-EN 1993-1-1+C2+A1:2016."""
+
+import pytest
+
+from blueprints.codes.eurocode.national_annex.nl.nen_en_1993_1_1_c2_a1_2016.chapter_2_basis_of_design.formula_2_1 import (
+    Form2Dot1DesignResistance,
+)
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm2Dot1DesignResistance:
+    """Validation for formula 2.1 from NEN-EN 1993-1-1+C2+A1:2016."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        r_k = 355.0
+        gamma_m = 1.1
+
+        # Object to test
+        formula = Form2Dot1DesignResistance(r_k=r_k, gamma_m=gamma_m)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 322.727272727  # R_k / gamma_M = 355.0 / 1.1
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("r_k", "gamma_m"),
+        [
+            (355.0, 0.0),  # gamma_m is zero
+            (355.0, -1.1),  # gamma_m is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, r_k: float, gamma_m: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form2Dot1DesignResistance(r_k=r_k, gamma_m=gamma_m)
+
+    def test_evaluation_negative_r_k(self) -> None:
+        """Tests that a negative r_k evaluates correctly without raising an error."""
+        formula = Form2Dot1DesignResistance(r_k=-355.0, gamma_m=1.1)
+        assert formula == pytest.approx(expected=-322.727272727, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"R_d = \frac{R_k}{\gamma_M} = \frac{355.000}{1.100} = 322.727",
+            ),
+            (
+                "complete_with_units",
+                r"R_d = \frac{R_k}{\gamma_M} = \frac{355.000}{1.100} = 322.727",
+            ),
+            ("short", r"R_d = 322.727"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        r_k = 355.0
+        gamma_m = 1.1
+
+        # Object to test
+        latex = Form2Dot1DesignResistance(r_k=r_k, gamma_m=gamma_m).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Description

Implements Formula 2.1 (R_d = R_k / γ_M) from NEN-EN 1993-1-1+C2+A1:2016 Chapter 2 using the canonical equation prompt template. Includes full LaTeX representation with numeric_equation_with_units, proper type aliases, and validation using raise_if_less_or_equal_to_zero for the denominator.

Fixes #224 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Dutch NEN-EN 1993-1-1+C2+A1:2016 National Annex (NL), including its published identifier.
  * Introduced Formula 2.1 to compute design resistance as characteristic resistance divided by the partial factor, with LaTeX output.
  * Validates the partial factor is strictly greater than zero (negative characteristic resistance is allowed).
* **Documentation**
  * Added module-level documentation for the National Annex and Chapter 2 organization.
* **Tests**
  * Added pytest coverage for computation, validation behavior, and LaTeX rendering variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->