### PR TITLE
feat: add formulas 8.19 and 8.20 from FprEN 1992-1-1:2023 clause 8.2.1

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_19.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_19.py
@@ -1,62 +1,57 @@
-"""Formula 8.18 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+"""Formula 8.19 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
 
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
-from blueprints.type_alias import MM, MPA, N
+from blueprints.type_alias import MM, MPA, N_MM
 from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
 
 
-class Form8Dot18AverageShearStress(Formula):
-    """Class representing formula 8.18 for the calculation of the average shear stress over the cross-section
-    of linear members in regions without geometric discontinuities.
+class Form8Dot19AverageShearStressPlanarMembers(Formula):
+    """Class representing formula 8.19 for the calculation of the average shear stress over the cross-section
+    of planar members in regions without geometric discontinuities.
     """
 
-    label = "8.18"
+    label = "8.19"
     source_document = FPR_EN_1992_1_1_2023
 
-    def __init__(self, v_ed: N, b_w: MM, z: MM) -> None:
+    def __init__(self, v_ed: N_MM, z: MM) -> None:
         r"""[$\tau_{Ed}$] Average shear stress over the cross-section area in regions of members without geometric discontinuities [$MPa$].
 
-        FprEN 1992-1-1:2023 (E) art 8.2.1 (3) - Formula (8.18)
+        FprEN 1992-1-1:2023 (E) art 8.2.1 (3) - Formula (8.19)
 
         Parameters
         ----------
-        v_ed : N
-            [$V_{Ed}$] Design shear force at the control section in linear members [$N$]. Note that this is the upper case
-            [$V_{Ed}$] of linear members, not the shear force per unit width [$v_{Ed}$] in [$N/mm$] used in Formula (8.19).
-        b_w : MM
-            [$b_w$] Width of the cross-section of linear members. The width [$b_w$] for cross-sections with variable width
-            and for circular cross-sections is defined in 8.2.3(9) [$mm$].
+        v_ed : N_MM
+            [$v_{Ed}$] Design shear force per unit width in planar members [$N/mm$]. Note that this is the lower case
+            [$v_{Ed}$] of planar members, not the shear force [$V_{Ed}$] in [$N$] used in Formula (8.18).
         z : MM
             [$z$] Lever arm for the shear stress calculation defined as [$z = 0.9 \cdot d$], where [$d$] refers to the
             centroid of tensile reinforcement [$mm$].
         """
         super().__init__()
         self.v_ed = v_ed
-        self.b_w = b_w
         self.z = z
 
     @staticmethod
-    def _evaluate(v_ed: N, b_w: MM, z: MM) -> MPA:
+    def _evaluate(v_ed: N_MM, z: MM) -> MPA:
         """Evaluates the formula, for more information see the __init__ method."""
         raise_if_negative(v_ed=v_ed)
-        raise_if_less_or_equal_to_zero(b_w=b_w, z=z)
-        return v_ed / (b_w * z)
+        raise_if_less_or_equal_to_zero(z=z)
+        return v_ed / z
 
     def latex(self, n: int = 3) -> LatexFormula:
-        """Returns LatexFormula object for formula 8.18."""
-        _equation: str = r"\frac{V_{Ed}}{b_w \cdot z}"
+        """Returns LatexFormula object for formula 8.19."""
+        _equation: str = r"\frac{v_{Ed}}{z}"
         _numeric_equation: str = latex_replace_symbols(
             template=_equation,
-            replacements={r"V_{Ed}": f"{self.v_ed:.{n}f}", r"b_w": f"{self.b_w:.{n}f}", r"z": f"{self.z:.{n}f}"},
+            replacements={r"v_{Ed}": f"{self.v_ed:.{n}f}", r"z": f"{self.z:.{n}f}"},
             unique_symbol_check=False,
         )
         _numeric_equation_with_units: str = latex_replace_symbols(
             template=_equation,
             replacements={
-                r"V_{Ed}": rf"{self.v_ed:.{n}f} \ N",
-                r"b_w": rf"{self.b_w:.{n}f} \ mm",
+                r"v_{Ed}": rf"{self.v_ed:.{n}f} \ N/mm",
                 r"z": rf"{self.z:.{n}f} \ mm",
             },
             unique_symbol_check=False,

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_20.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_20.py
@@ -1,0 +1,87 @@
+"""Formula 8.20 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot20MinimumShearStressResistance(Formula):
+    """Class representing formula 8.20 for the calculation of the minimum shear stress resistance."""
+
+    label = "8.20"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, gamma_v: DIMENSIONLESS, f_ck: MPA, f_yd: MPA, d_dg: MM, d: MM) -> None:
+        r"""[$\tau_{Rdc,min}$] Minimum shear stress resistance [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.1 (4) - Formula (8.20)
+
+        Parameters
+        ----------
+        gamma_v : DIMENSIONLESS
+            [$\gamma_V$] Partial factor for shear design according to Table 4.3 (NDP) or Tables A.1 (NDP)
+            and A.2 (NDP) [$-$].
+        f_ck : MPA
+            [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
+        f_yd : MPA
+            [$f_{yd}$] Design value of the yield strength which has been used to design the flexural
+            reinforcement [$MPa$].
+        d_dg : MM
+            [$d_{dg}$] Size parameter describing the failure zone roughness, which depends on the concrete type
+            and its aggregate properties [$mm$].
+        d : MM
+            [$d$] Effective depth of the flexural reinforcement. For prestressed members see 8.2.2(6) [$mm$].
+        """
+        super().__init__()
+        self.gamma_v = gamma_v
+        self.f_ck = f_ck
+        self.f_yd = f_yd
+        self.d_dg = d_dg
+        self.d = d
+
+    @staticmethod
+    def _evaluate(gamma_v: DIMENSIONLESS, f_ck: MPA, f_yd: MPA, d_dg: MM, d: MM) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(f_ck=f_ck, d_dg=d_dg)
+        raise_if_less_or_equal_to_zero(gamma_v=gamma_v, f_yd=f_yd, d=d)
+
+        return (11 / gamma_v) * np.sqrt((f_ck / f_yd) * (d_dg / d))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.20."""
+        _equation: str = r"\frac{11}{\gamma_V} \cdot \sqrt{\frac{f_{ck}}{f_{yd}} \cdot \frac{d_{dg}}{d}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\gamma_V": f"{self.gamma_v:.{n}f}",
+                r"f_{ck}": f"{self.f_ck:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+                r"d_{dg}": f"{self.d_dg:.{n}f}",
+                r"{d}": "{" + f"{self.d:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\gamma_V": f"{self.gamma_v:.{n}f}",
+                r"f_{ck}": rf"{self.f_ck:.{n}f} \ MPa",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+                r"d_{dg}": rf"{self.d_dg:.{n}f} \ mm",
+                r"{d}": "{" + rf"{self.d:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rdc,min}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -80,8 +80,8 @@ Total of 602 formulas present.
 |      8.16      |        :x:         |         |                                                                    |
 |      8.17      |        :x:         |         |                                                                    |
 |      8.18      | :heavy_check_mark: |         | Form8Dot18AverageShearStress                                       |
-|      8.19      |        :x:         |         |                                                                    |
-|      8.20      |        :x:         |         |                                                                    |
+|      8.19      | :heavy_check_mark: |         | Form8Dot19AverageShearStressPlanarMembers                          |
+|      8.20      | :heavy_check_mark: |         | Form8Dot20MinimumShearStressResistance                             |
 |      8.21      |        :x:         |         |                                                                    |
 |      8.22      |        :x:         |         |                                                                    |
 |      8.23      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_18.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_18.py
@@ -54,6 +54,10 @@ class TestForm8Dot18AverageShearStress:
         ("representation", "expected"),
         [
             ("complete", r"\tau_{Ed} = \frac{V_{Ed}}{b_w \cdot z} = \frac{10000.000}{50.000 \cdot 215.000} = 0.930 \ MPa"),
+            (
+                "complete_with_units",
+                r"\tau_{Ed} = \frac{V_{Ed}}{b_w \cdot z} = \frac{10000.000 \ N}{50.000 \ mm \cdot 215.000 \ mm} = 0.930 \ MPa",
+            ),
             ("short", r"\tau_{Ed} = 0.930 \ MPa"),
         ],
     )
@@ -67,6 +71,6 @@ class TestForm8Dot18AverageShearStress:
         # Object to test
         test_latex = Form8Dot18AverageShearStress(v_ed=v_ed, b_w=b_w, z=z).latex()
 
-        actual = {"complete": test_latex.complete, "short": test_latex.short}
+        actual = {"complete": test_latex.complete, "complete_with_units": test_latex.complete_with_units, "short": test_latex.short}
 
         assert expected == actual[representation]

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_19.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_19.py
@@ -1,0 +1,68 @@
+"""Testing formula 8.19 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_19 import Form8Dot19AverageShearStressPlanarMembers
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot19AverageShearStressPlanarMembers:
+    """Validation for formula 8.19 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        v_ed = 250.0
+        z = 450.0
+
+        # Object to test
+        formula = Form8Dot19AverageShearStressPlanarMembers(v_ed=v_ed, z=z)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.555556  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("v_ed", "z"),
+        [
+            (-250.0, 450.0),  # v_ed is negative
+            (250.0, -450.0),  # z is negative
+            (250.0, 0.0),  # z is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, v_ed: float, z: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot19AverageShearStressPlanarMembers(v_ed=v_ed, z=z)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Ed} = \frac{v_{Ed}}{z} = \frac{250.000}{450.000} = 0.556 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Ed} = \frac{v_{Ed}}{z} = \frac{250.000 \ N/mm}{450.000 \ mm} = 0.556 \ MPa",
+            ),
+            ("short", r"\tau_{Ed} = 0.556 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        v_ed = 250.0
+        z = 450.0
+
+        # Object to test
+        latex = Form8Dot19AverageShearStressPlanarMembers(v_ed=v_ed, z=z).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_20.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_20.py
@@ -1,0 +1,81 @@
+"""Testing formula 8.20 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_20 import Form8Dot20MinimumShearStressResistance
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot20MinimumShearStressResistance:
+    """Validation for formula 8.20 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        gamma_v = 1.4
+        f_ck = 30.0
+        f_yd = 435.0
+        d_dg = 32.0
+        d = 500.0
+
+        # Object to test
+        formula = Form8Dot20MinimumShearStressResistance(gamma_v=gamma_v, f_ck=f_ck, f_yd=f_yd, d_dg=d_dg, d=d)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.522000  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("gamma_v", "f_ck", "f_yd", "d_dg", "d"),
+        [
+            (1.4, -30.0, 435.0, 32.0, 500.0),  # f_ck is negative
+            (1.4, 30.0, 435.0, -32.0, 500.0),  # d_dg is negative
+            (-1.4, 30.0, 435.0, 32.0, 500.0),  # gamma_v is negative
+            (0.0, 30.0, 435.0, 32.0, 500.0),  # gamma_v is zero
+            (1.4, 30.0, -435.0, 32.0, 500.0),  # f_yd is negative
+            (1.4, 30.0, 0.0, 32.0, 500.0),  # f_yd is zero
+            (1.4, 30.0, 435.0, 32.0, -500.0),  # d is negative
+            (1.4, 30.0, 435.0, 32.0, 0.0),  # d is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, gamma_v: float, f_ck: float, f_yd: float, d_dg: float, d: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot20MinimumShearStressResistance(gamma_v=gamma_v, f_ck=f_ck, f_yd=f_yd, d_dg=d_dg, d=d)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Rdc,min} = \frac{11}{\gamma_V} \cdot \sqrt{\frac{f_{ck}}{f_{yd}} \cdot \frac{d_{dg}}{d}} = "
+                r"\frac{11}{1.400} \cdot \sqrt{\frac{30.000}{435.000} \cdot \frac{32.000}{500.000}} = 0.522 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Rdc,min} = \frac{11}{\gamma_V} \cdot \sqrt{\frac{f_{ck}}{f_{yd}} \cdot \frac{d_{dg}}{d}} = "
+                r"\frac{11}{1.400} \cdot \sqrt{\frac{30.000 \ MPa}{435.000 \ MPa} \cdot \frac{32.000 \ mm}{500.000 \ mm}} = 0.522 \ MPa",
+            ),
+            ("short", r"\tau_{Rdc,min} = 0.522 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        gamma_v = 1.4
+        f_ck = 30.0
+        f_yd = 435.0
+        d_dg = 32.0
+        d = 500.0
+
+        # Object to test
+        latex = Form8Dot20MinimumShearStressResistance(gamma_v=gamma_v, f_ck=f_ck, f_yd=f_yd, d_dg=d_dg, d=d).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Description

Implements clause 8.2.1 (General verification procedure) of section 8.2 Shear:

- Formula (8.19), average shear stress over the cross-section of planar members: `Form8Dot19AverageShearStressPlanarMembers`
- Formula (8.20), minimum shear stress resistance: `Form8Dot20MinimumShearStressResistance`

Formula (8.18) already existed and is completed in the same clause. It was missing `numeric_equation_with_units`, which silently degraded the `complete_with_units` representation, and its variable descriptions were incomplete. Both are now taken in full from the standard.

Two points worth a reviewer's attention:

- In (8.20) the square root spans both fractions, `(f_ck / f_yd) * (d_dg / d)`. A root over `f_ck / f_yd` alone would give 0.132 MPa instead of 0.522 MPa for the values used in the tests.
- The standard uses `V_Ed` in N for linear members in (8.18) and `v_Ed` in N/mm for planar members in (8.19). Both become `v_ed` in Python, so the distinction is carried by the type alias (`N` versus `N_MM`) and spelled out in both docstrings.

The package rename of #1082 is merged, and this branch is rebased onto `main`.

Contributes to #1083

## Formulas as implemented

**Formula (8.18)**, `Form8Dot18AverageShearStress`

`equation`

$$
\tau_{Ed} = \frac{V_{Ed}}{b_w \cdot z}
$$

`complete`

$$
\tau_{Ed} = \frac{V_{Ed}}{b_w \cdot z} = \frac{10000.000}{50.000 \cdot 215.000} = 0.930 \ MPa
$$

`complete_with_units`

$$
\tau_{Ed} = \frac{V_{Ed}}{b_w \cdot z} = \frac{10000.000 \ N}{50.000 \ mm \cdot 215.000 \ mm} = 0.930 \ MPa
$$

**Formula (8.19)**, `Form8Dot19AverageShearStressPlanarMembers`

`equation`

$$
\tau_{Ed} = \frac{v_{Ed}}{z}
$$

`complete`

$$
\tau_{Ed} = \frac{v_{Ed}}{z} = \frac{250.000}{450.000} = 0.556 \ MPa
$$

`complete_with_units`

$$
\tau_{Ed} = \frac{v_{Ed}}{z} = \frac{250.000 \ N/mm}{450.000 \ mm} = 0.556 \ MPa
$$

**Formula (8.20)**, `Form8Dot20MinimumShearStressResistance`

`equation`

$$
\tau_{Rdc,min} = \frac{11}{\gamma_V} \cdot \sqrt{\frac{f_{ck}}{f_{yd}} \cdot \frac{d_{dg}}{d}}
$$

`complete`

$$
\tau_{Rdc,min} = \frac{11}{\gamma_V} \cdot \sqrt{\frac{f_{ck}}{f_{yd}} \cdot \frac{d_{dg}}{d}} = \frac{11}{1.400} \cdot \sqrt{\frac{30.000}{435.000} \cdot \frac{32.000}{500.000}} = 0.522 \ MPa
$$

`complete_with_units`

$$
\tau_{Rdc,min} = \frac{11}{\gamma_V} \cdot \sqrt{\frac{f_{ck}}{f_{yd}} \cdot \frac{d_{dg}}{d}} = \frac{11}{1.400} \cdot \sqrt{\frac{30.000 \ MPa}{435.000 \ MPa} \cdot \frac{32.000 \ mm}{500.000 \ mm}} = 0.522 \ MPa
$$

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Tests added for every formula, every branch and every raise
- [x] Docstrings added, with variable descriptions taken from the standard
- [x] Documentation table updated with the class names
- [x] `blueprints check` passes: lint, format, type check, and 100% coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Eurocode formulas 8.19 and 8.20 for shear stress and minimum shear stress resistance calculations, including input validation.
- **Enhancements**
  - Improved Formula 8.18 LaTeX output to better clarify the application region and provide unit-annotated equation rendering.
- **Documentation**
  - Updated the formulas reference to mark 8.19 and 8.20 as available and added their object names.
- **Tests**
  - Added evaluation, error-handling, and LaTeX output coverage for formulas 8.19 and 8.20; extended LaTeX assertions for formula 8.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->