### PR TITLE
feat: add formulas 8.21 to 8.24 from FprEN 1992-1-1:2023 clause 8.2.1

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_21.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_21.py
@@ -1,0 +1,73 @@
+"""Formula 8.21 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import N_MM
+
+
+class Form8Dot21DesignShearForcePerUnitWidth(Formula):
+    """Class representing formula 8.21 for the calculation of the design shear force per unit width in planar members
+    with out-of-plane shear forces acting in two directions.
+    """
+
+    label = "8.21"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, v_ed_x: N_MM, v_ed_y: N_MM) -> None:
+        r"""[$v_{Ed}$] Design shear force per unit width in planar members [$N/mm$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.1 (5) - Formula (8.21)
+
+        Both components enter squared, so the sign of either of them does not reach the result. They are
+        components of a shear force vector and the standard places no restriction on their sign, so a negative
+        one is accepted and gives the same result as its positive counterpart.
+
+        Parameters
+        ----------
+        v_ed_x : N_MM
+            [$v_{Ed,x}$] Out-of-plane design shear force per unit width acting on the cross-section perpendicular
+            to the x direction [$N/mm$].
+        v_ed_y : N_MM
+            [$v_{Ed,y}$] Out-of-plane design shear force per unit width acting on the cross-section perpendicular
+            to the y direction [$N/mm$].
+        """
+        super().__init__()
+        self.v_ed_x = v_ed_x
+        self.v_ed_y = v_ed_y
+
+    @staticmethod
+    def _evaluate(v_ed_x: N_MM, v_ed_y: N_MM) -> N_MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        return float(np.sqrt(v_ed_x**2 + v_ed_y**2))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.21."""
+        _equation: str = r"\sqrt{\left(v_{Ed,x}\right)^2 + \left(v_{Ed,y}\right)^2}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"v_{Ed,x}": f"{self.v_ed_x:.{n}f}",
+                r"v_{Ed,y}": f"{self.v_ed_y:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"v_{Ed,x}": rf"{self.v_ed_x:.{n}f} \ N/mm",
+                r"v_{Ed,y}": rf"{self.v_ed_y:.{n}f} \ N/mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"v_{Ed}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="N/mm",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_22_23_24.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_22_23_24.py
@@ -1,0 +1,121 @@
+"""Formula 8.22, 8.23 and 8.24 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, N_MM
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form8Dot22To24EffectiveDepth(Formula):
+    """Class representing formulas 8.22, 8.23 and 8.24 for the calculation of the effective depth of planar members,
+    taken as a function of the ratio of the shear forces.
+    """
+
+    label = "8.22/8.23/8.24"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, v_ed_x: N_MM, v_ed_y: N_MM, d_x: MM, d_y: MM) -> None:
+        r"""[$d$] Effective depth of planar members, as a function of the ratio of the shear forces
+        [$v_{Ed,y}/v_{Ed,x}$] [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.1 (5) - Formula (8.22), (8.23) and (8.24)
+
+        The boundaries of the ratio are one-sided as printed: a ratio of exactly 0.5 falls under Formula (8.22)
+        and a ratio of exactly 2 falls under Formula (8.24). The standard gives no rule for [$v_{Ed,x} = 0$],
+        for which the ratio is undefined, so that input is rejected.
+
+        Both shear forces are taken as magnitudes, and the standard does not settle that: it prints no absolute
+        value bars and defines no sign convention. Read literally, the ratio is signed, so any pair with
+        opposite signs is negative, always satisfies the first condition, and selects [$d_x$] even where
+        [$\left|v_{Ed,y}\right|$] dominates. Flipping the positive direction of the y axis would then change
+        the effective depth, which cannot be intended.
+
+        The alternative the standard prints on the same page settles it: Formula (8.26) gives
+        [$\alpha_v = \arctan(v_{Ed,y}/v_{Ed,x})$] and Formula (8.25) gives
+        [$d = d_x \cdot \cos^2\alpha_v + d_y \cdot \sin^2\alpha_v$], which is even in [$\alpha_v$] and therefore
+        insensitive to the sign. Formulas (8.22) to (8.24) are the stepped approximation of that same continuous
+        function, so their boundaries of 0,5 and 2 order a ratio of magnitudes. Formula (8.21) reaches the same
+        place by squaring both components.
+
+        The LaTeX prints the absolute value bars that the standard leaves out, so that the substituted numbers
+        match the branch that was taken.
+
+        The requirement that [$d_x$] and [$d_y$] be strictly positive is an addition made here: neither appears
+        in a denominator in these three formulas, and the standard prints no such condition. An effective depth
+        of zero is not a cross-section.
+
+        Parameters
+        ----------
+        v_ed_x : N_MM
+            [$v_{Ed,x}$] Out-of-plane design shear force per unit width acting on the cross-section perpendicular
+            to the x direction [$N/mm$].
+        v_ed_y : N_MM
+            [$v_{Ed,y}$] Out-of-plane design shear force per unit width acting on the cross-section perpendicular
+            to the y direction [$N/mm$].
+        d_x : MM
+            [$d_x$] Effective depth in the x direction [$mm$].
+        d_y : MM
+            [$d_y$] Effective depth in the y direction [$mm$].
+        """
+        super().__init__()
+        self.v_ed_x = v_ed_x
+        self.v_ed_y = v_ed_y
+        self.d_x = d_x
+        self.d_y = d_y
+
+    @staticmethod
+    def _evaluate(v_ed_x: N_MM, v_ed_y: N_MM, d_x: MM, d_y: MM) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(abs_v_ed_x=abs(v_ed_x), d_x=d_x, d_y=d_y)
+
+        ratio = abs(v_ed_y) / abs(v_ed_x)
+        if ratio <= 0.5:
+            return d_x
+        if ratio < 2:
+            return 0.5 * (d_x + d_y)
+        return d_y
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formulas 8.22, 8.23 and 8.24."""
+        _equation: str = (
+            r"\begin{cases} d_x & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \leq 0.5 \\ "
+            r"0.5 \cdot (d_x + d_y) & \text{if } 0.5 < \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} < 2 \\ "
+            r"d_y & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \geq 2 \end{cases}"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"v_{Ed,x}": f"{self.v_ed_x:.{n}f}",
+                r"v_{Ed,y}": f"{self.v_ed_y:.{n}f}",
+                r"d_x": f"{self.d_x:.{n}f}",
+                r"d_y": f"{self.d_y:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"v_{Ed,x}": rf"{self.v_ed_x:.{n}f} \ N/mm",
+                r"v_{Ed,y}": rf"{self.v_ed_y:.{n}f} \ N/mm",
+                r"d_x": rf"{self.d_x:.{n}f} \ mm",
+                r"d_y": rf"{self.d_y:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        # Only the middle branch has a step between the selected expression and the result. LatexFormula skips
+        # an empty intermediate result, so the other two branches show none.
+        _intermediate: str = ""
+        if 0.5 < abs(self.v_ed_y) / abs(self.v_ed_x) < 2:
+            _intermediate = rf"0.5 \cdot ({self.d_x:.{n}f} + {self.d_y:.{n}f})"
+
+        return LatexFormula(
+            return_symbol=r"d",
+            result=f"{self:.{n}f}",
+            intermediate_result=_intermediate,
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -82,10 +82,10 @@ Total of 602 formulas present.
 |      8.18      | :heavy_check_mark: |         | Form8Dot18AverageShearStress                                       |
 |      8.19      | :heavy_check_mark: |         | Form8Dot19AverageShearStressPlanarMembers                          |
 |      8.20      | :heavy_check_mark: |         | Form8Dot20MinimumShearStressResistance                             |
-|      8.21      |        :x:         |         |                                                                    |
-|      8.22      |        :x:         |         |                                                                    |
-|      8.23      |        :x:         |         |                                                                    |
-|      8.24      |        :x:         |         |                                                                    |
+|      8.21      | :heavy_check_mark: |         | Form8Dot21DesignShearForcePerUnitWidth                             |
+|      8.22      | :heavy_check_mark: |         | Form8Dot22To24EffectiveDepth                                       |
+|      8.23      | :heavy_check_mark: |         | Form8Dot22To24EffectiveDepth                                       |
+|      8.24      | :heavy_check_mark: |         | Form8Dot22To24EffectiveDepth                                       |
 |      8.25      | :heavy_check_mark: |         | Form8Dot25EffectiveDepthFromPrincipalShearForce                    |
 |      8.26      | :heavy_check_mark: |         | Form8Dot26AngleBetweenPrincipalShearForceAndXAxis                  |
 |      8.27      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_21.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_21.py
@@ -1,0 +1,85 @@
+"""Testing formula 8.21 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_21 import Form8Dot21DesignShearForcePerUnitWidth
+
+
+class TestForm8Dot21DesignShearForcePerUnitWidth:
+    """Validation for formula 8.21 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        v_ed_x = 100.0
+        v_ed_y = 40.0
+
+        # Object to test
+        formula = Form8Dot21DesignShearForcePerUnitWidth(v_ed_x=v_ed_x, v_ed_y=v_ed_y)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 107.703296  # N/mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_with_shear_in_one_direction_only(self) -> None:
+        """Tests the evaluation when the shear force acts in one direction only."""
+        # Object to test
+        formula = Form8Dot21DesignShearForcePerUnitWidth(v_ed_x=0.0, v_ed_y=250.0)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 250.0  # N/mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y"),
+        [
+            (100.0, 40.0),  # both positive
+            (-100.0, 40.0),  # v_ed_x is negative
+            (100.0, -40.0),  # v_ed_y is negative
+            (-100.0, -40.0),  # both negative
+        ],
+    )
+    def test_sign_of_the_components_does_not_reach_the_result(self, v_ed_x: float, v_ed_y: float) -> None:
+        """The components are squared, so all four sign combinations give the same magnitude.
+
+        They are components of a shear force vector and the standard places no restriction on their sign,
+        so a negative one is ordinary input rather than an error.
+        """
+        formula = Form8Dot21DesignShearForcePerUnitWidth(v_ed_x=v_ed_x, v_ed_y=v_ed_y)
+
+        assert formula == pytest.approx(expected=107.703296, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"v_{Ed} = \sqrt{\left(v_{Ed,x}\right)^2 + \left(v_{Ed,y}\right)^2} = "
+                r"\sqrt{\left(100.000\right)^2 + \left(40.000\right)^2} = 107.703 \ N/mm",
+            ),
+            (
+                "complete_with_units",
+                r"v_{Ed} = \sqrt{\left(v_{Ed,x}\right)^2 + \left(v_{Ed,y}\right)^2} = "
+                r"\sqrt{\left(100.000 \ N/mm\right)^2 + \left(40.000 \ N/mm\right)^2} = 107.703 \ N/mm",
+            ),
+            ("short", r"v_{Ed} = 107.703 \ N/mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        v_ed_x = 100.0
+        v_ed_y = 40.0
+
+        # Object to test
+        latex = Form8Dot21DesignShearForcePerUnitWidth(v_ed_x=v_ed_x, v_ed_y=v_ed_y).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_22_23_24.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_22_23_24.py
@@ -1,0 +1,125 @@
+"""Testing formulas 8.22, 8.23 and 8.24 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_22_23_24 import Form8Dot22To24EffectiveDepth
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm8Dot22To24EffectiveDepth:
+    """Validation for formulas 8.22, 8.23 and 8.24 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y", "expected"),
+        [
+            (100.0, 40.0, 300.0),  # ratio 0.4, formula 8.22
+            (100.0, 50.0, 300.0),  # ratio 0.5 exactly, still formula 8.22
+            (100.0, 100.0, 275.0),  # ratio 1.0, formula 8.23
+            (100.0, 150.0, 275.0),  # ratio 1.5, formula 8.23
+            (100.0, 200.0, 250.0),  # ratio 2.0 exactly, formula 8.24
+            (100.0, 250.0, 250.0),  # ratio 2.5, formula 8.24
+        ],
+    )
+    def test_evaluation(self, v_ed_x: float, v_ed_y: float, expected: float) -> None:
+        """Tests the evaluation of the result for each of the three cases and both boundaries."""
+        # Example values
+        d_x = 300.0
+        d_y = 250.0
+
+        # Object to test
+        formula = Form8Dot22To24EffectiveDepth(v_ed_x=v_ed_x, v_ed_y=v_ed_y, d_x=d_x, d_y=d_y)
+
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y"),
+        [
+            (100.0, 150.0),  # both positive
+            (100.0, -150.0),  # v_ed_y is negative
+            (-100.0, 150.0),  # v_ed_x is negative
+            (-100.0, -150.0),  # both negative
+        ],
+    )
+    def test_sign_of_the_shear_forces_does_not_reach_the_result(self, v_ed_x: float, v_ed_y: float) -> None:
+        """The ratio is taken on magnitudes, so all four sign combinations select the same branch.
+
+        A signed ratio would turn negative as soon as one component does, and every negative value falls under
+        Formula (8.22) regardless of which direction actually carries the shear. Formula (8.21) reaches the same
+        place by squaring both components.
+        """
+        formula = Form8Dot22To24EffectiveDepth(v_ed_x=v_ed_x, v_ed_y=v_ed_y, d_x=300.0, d_y=250.0)
+
+        # ratio 1.5, so the middle branch of Formula (8.23)
+        assert formula == pytest.approx(expected=275.0, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y", "d_x", "d_y"),
+        [
+            (0.0, 100.0, 300.0, 250.0),  # v_ed_x is zero, for which the ratio is undefined
+            (100.0, 100.0, 0.0, 250.0),  # d_x is zero, which is not a cross-section
+            (100.0, 100.0, -300.0, 250.0),  # d_x is negative
+            (100.0, 100.0, 300.0, 0.0),  # d_y is zero
+            (100.0, 100.0, 300.0, -250.0),  # d_y is negative
+        ],
+    )
+    def test_raise_error_when_less_or_equal_to_zero(self, v_ed_x: float, v_ed_y: float, d_x: float, d_y: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less.
+
+        The guard on the shear force is on its magnitude, so a negative one passes it and only zero is refused.
+        """
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot22To24EffectiveDepth(v_ed_x=v_ed_x, v_ed_y=v_ed_y, d_x=d_x, d_y=d_y)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"d = \begin{cases} d_x & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \leq 0.5 \\ "
+                r"0.5 \cdot (d_x + d_y) & \text{if } 0.5 < \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} < 2 \\ "
+                r"d_y & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \geq 2 \end{cases} = "
+                r"\begin{cases} 300.000 & \text{if } \frac{\left|100.000\right|}{\left|100.000\right|} \leq 0.5 \\ "
+                r"0.5 \cdot (300.000 + 250.000) & \text{if } 0.5 < \frac{\left|100.000\right|}{\left|100.000\right|} < 2 \\ "
+                r"250.000 & \text{if } \frac{\left|100.000\right|}{\left|100.000\right|} \geq 2 \end{cases} = "
+                r"0.5 \cdot (300.000 + 250.000) = 275.000 \ mm",
+            ),
+            (
+                "complete_with_units",
+                r"d = \begin{cases} d_x & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \leq 0.5 \\ "
+                r"0.5 \cdot (d_x + d_y) & \text{if } 0.5 < \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} < 2 \\ "
+                r"d_y & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \geq 2 \end{cases} = "
+                r"\begin{cases} 300.000 \ mm & \text{if } \frac{\left|100.000 \ N/mm\right|}{\left|100.000 \ N/mm\right|} \leq 0.5 \\ "
+                r"0.5 \cdot (300.000 \ mm + 250.000 \ mm) & "
+                r"\text{if } 0.5 < \frac{\left|100.000 \ N/mm\right|}{\left|100.000 \ N/mm\right|} < 2 \\ "
+                r"250.000 \ mm & \text{if } \frac{\left|100.000 \ N/mm\right|}{\left|100.000 \ N/mm\right|} \geq 2 \end{cases} = "
+                r"0.5 \cdot (300.000 + 250.000) = 275.000 \ mm",
+            ),
+            ("short", r"d = 275.000 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        v_ed_x = 100.0
+        v_ed_y = 100.0
+        d_x = 300.0
+        d_y = 250.0
+
+        # Object to test
+        latex = Form8Dot22To24EffectiveDepth(v_ed_x=v_ed_x, v_ed_y=v_ed_y, d_x=d_x, d_y=d_y).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."
+
+    def test_no_intermediate_result_outside_the_middle_branch(self) -> None:
+        """Only Formula (8.23) has a step between the selected expression and the result."""
+        outer = Form8Dot22To24EffectiveDepth(v_ed_x=100.0, v_ed_y=40.0, d_x=300.0, d_y=250.0).latex()
+        middle = Form8Dot22To24EffectiveDepth(v_ed_x=100.0, v_ed_y=100.0, d_x=300.0, d_y=250.0).latex()
+
+        assert outer.intermediate_result == ""
+        assert middle.intermediate_result == r"0.5 \cdot (300.000 + 250.000)"


### PR DESCRIPTION
## Description

Implements Formulas (8.21) to (8.24) of clause 8.2.1(5), for planar members with out-of-plane shear forces acting in two directions:

- `Form8Dot21DesignShearForcePerUnitWidth` for (8.21), the resultant design shear force per unit width.
- `Form8Dot22To24EffectiveDepth` for (8.22), (8.23) and (8.24), the effective depth as a function of the ratio of the shear forces. The three numbered formulas are branches of a single rule, so they share one class, following the pattern of `Form6Dot58And59TensileForce`. All three rows in the documentation table point at it.

Points worth a reviewer's attention:

- The branch boundaries in (8.22) to (8.24) are one-sided as printed. A ratio of exactly 0.5 falls under (8.22) and a ratio of exactly 2 falls under (8.24). Both have their own test case.
- The standard gives no rule for `v_Ed,x = 0`, where the ratio is undefined, and none for negative shear forces, where a negative ratio would land in (8.22) unintentionally. Both are rejected by validation and the choice is stated in the docstring.
- The two shear force components are taken as magnitudes in (8.21) as well, so the API is consistent across the clause.

The package rename of #1082 is merged, and this branch is rebased onto `main`. It does not depend on #1084.

Contributes to #1083

## Formulas as implemented

**Formula (8.21)**, `Form8Dot21DesignShearForcePerUnitWidth`

`equation`

$$
v_{Ed} = \sqrt{\left(v_{Ed,x}\right)^2 + \left(v_{Ed,y}\right)^2}
$$

`complete`

$$
v_{Ed} = \sqrt{\left(v_{Ed,x}\right)^2 + \left(v_{Ed,y}\right)^2} = \sqrt{\left(100.000\right)^2 + \left(40.000\right)^2} = 107.703 \ N/mm
$$

`complete_with_units`

$$
v_{Ed} = \sqrt{\left(v_{Ed,x}\right)^2 + \left(v_{Ed,y}\right)^2} = \sqrt{\left(100.000 \ N/mm\right)^2 + \left(40.000 \ N/mm\right)^2} = 107.703 \ N/mm
$$

**Formula (8.22/8.23/8.24)**, `Form8Dot22To24EffectiveDepth`

`equation`

$$
d = \begin{cases} d_x & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ 0.5 \cdot (d_x + d_y) & \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ d_y & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases}
$$

`complete`

$$
d = \begin{cases} d_x & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ 0.5 \cdot (d_x + d_y) & \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ d_y & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases} = \begin{cases} 300.000 & \text{if } \frac{100.000}{100.000} \leq 0.5 \\ 0.5 \cdot (300.000 + 250.000) & \text{if } 0.5 < \frac{100.000}{100.000} < 2 \\ 250.000 & \text{if } \frac{100.000}{100.000} \geq 2 \end{cases} = 275.000 \ mm
$$

`complete_with_units`

$$
d = \begin{cases} d_x & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ 0.5 \cdot (d_x + d_y) & \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ d_y & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases} = \begin{cases} 300.000 \ mm & \text{if } \frac{100.000 \ N/mm}{100.000 \ N/mm} \leq 0.5 \\ 0.5 \cdot (300.000 \ mm + 250.000 \ mm) & \text{if } 0.5 < \frac{100.000 \ N/mm}{100.000 \ N/mm} < 2 \\ 250.000 \ mm & \text{if } \frac{100.000 \ N/mm}{100.000 \ N/mm} \geq 2 \end{cases} = 275.000 \ mm
$$

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Tests for both classes, all three branches, both boundaries and every raise
- [x] Docstrings added, with variable descriptions taken from the standard
- [x] Documentation table updated with the class names
- [x] `blueprints check` passes: lint, format, type check, and 100% coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2:2023 calculations for design shear force per unit width (Formula 8.21).
  * Added effective-depth calculations for planar members (Formulas 8.22–8.24), including ratio-based cases and input validation.
  * Added LaTeX representations for symbolic and numeric formula results.

* **Documentation**
  * Marked Formulas 8.21–8.24 as completed in the Eurocode documentation.

* **Tests**
  * Added coverage for calculations, boundary conditions, validation errors, and LaTeX output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->