### PR TITLE
feat: add formulas 8.27 and 8.28 from FprEN 1992-1-1:2023 clause 8.2.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_27.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_27.py
@@ -1,0 +1,122 @@
+"""Formula 8.27 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot27DesignShearStressResistance(Formula):
+    """Class representing formula 8.27 for the calculation of the design value of the shear stress resistance
+    of members without shear reinforcement.
+    """
+
+    label = "8.27"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        gamma_v: DIMENSIONLESS,
+        rho_l: DIMENSIONLESS,
+        f_ck: MPA,
+        d_dg: MM,
+        d: MM,
+        tau_rdc_min: MPA,
+    ) -> None:
+        r"""[$\tau_{Rd,c}$] Design value of the shear stress resistance of members without shear reinforcement [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (2) - Formula (8.27)
+
+        The standard writes this as an expression bounded from below by [$\tau_{Rdc,min}$], which is implemented
+        as the maximum of the two.
+
+        Parameters
+        ----------
+        gamma_v : DIMENSIONLESS
+            [$\gamma_V$] Partial factor for shear design according to Table 4.3 (NDP) or Tables A.1 (NDP)
+            and A.2 (NDP) [$-$].
+        rho_l : DIMENSIONLESS
+            [$\rho_l$] Longitudinal tensile reinforcement ratio according to Formula (8.28), see
+            Form8Dot28LongitudinalReinforcementRatio [$-$].
+        f_ck : MPA
+            [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
+        d_dg : MM
+            [$d_{dg}$] Size parameter describing the failure zone roughness, which depends on the concrete type
+            and its aggregate properties. The standard gives it as [$16 + D_{lower} \leq 40$] for concrete with
+            [$f_{ck} \leq 60$] MPa, and as [$16 + D_{lower} \cdot \left(60/f_{ck}\right)^2 \leq 40$] for concrete
+            with [$f_{ck} > 60$] MPa, both in millimetres. [$D_{lower}$] is the smallest value of the upper sieve
+            size [$D$] in an aggregate for the coarsest fraction of aggregates in the concrete permitted by the
+            specification of concrete according to EN 206; where [$D_{max}$] is known it may replace
+            [$D_{lower}$], see the NOTE 2 to 8.2.1(4) [$mm$].
+        d : MM
+            [$d$] Effective depth [$d_{nom}$]. The value [$d$] may be refined according to 8.2.2(3) and 8.2.2(4) for
+            non-slender members and members with axial force, by replacing it with the mechanical shear span
+            [$a_v$] or by multiplying it with [$k_{vp}$]. That refinement is the responsibility of the caller,
+            which passes the already adjusted value [$mm$].
+        tau_rdc_min : MPA
+            [$\tau_{Rdc,min}$] Minimum shear stress resistance according to Formula (8.20), see
+            Form8Dot20MinimumShearStressResistance [$MPa$].
+        """
+        super().__init__()
+        self.gamma_v = gamma_v
+        self.rho_l = rho_l
+        self.f_ck = f_ck
+        self.d_dg = d_dg
+        self.d = d
+        self.tau_rdc_min = tau_rdc_min
+
+    @staticmethod
+    def _evaluate(
+        gamma_v: DIMENSIONLESS,
+        rho_l: DIMENSIONLESS,
+        f_ck: MPA,
+        d_dg: MM,
+        d: MM,
+        tau_rdc_min: MPA,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, tau_rdc_min=tau_rdc_min)
+        raise_if_less_or_equal_to_zero(gamma_v=gamma_v, d=d)
+
+        return max((0.66 / gamma_v) * (100 * rho_l * f_ck * (d_dg / d)) ** (1 / 3), tau_rdc_min)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.27."""
+        _equation: str = (
+            r"\max\left(\frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot "
+            r"\frac{d_{dg}}{d}\right)^{\frac{1}{3}}, \tau_{Rdc,min}\right)"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\gamma_V": f"{self.gamma_v:.{n}f}",
+                r"\rho_l": f"{self.rho_l:.{n}f}",
+                r"f_{ck}": f"{self.f_ck:.{n}f}",
+                r"d_{dg}": f"{self.d_dg:.{n}f}",
+                r"{d}": "{" + f"{self.d:.{n}f}" + "}",
+                r"\tau_{Rdc,min}": f"{self.tau_rdc_min:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\gamma_V": f"{self.gamma_v:.{n}f}",
+                r"\rho_l": f"{self.rho_l:.{n}f}",
+                r"f_{ck}": rf"{self.f_ck:.{n}f} \ MPa",
+                r"d_{dg}": rf"{self.d_dg:.{n}f} \ mm",
+                r"{d}": "{" + rf"{self.d:.{n}f} \ mm" + "}",
+                r"\tau_{Rdc,min}": rf"{self.tau_rdc_min:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rd,c}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_28.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_28.py
@@ -1,0 +1,86 @@
+"""Formula 8.28 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MM2
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot28LongitudinalReinforcementRatio(Formula):
+    r"""Class representing formula 8.28 for the calculation of the longitudinal tensile reinforcement ratio.
+
+    Which effective depth belongs here is not settled by the standard. The "where" list is shared between
+    Formulas (8.27) and (8.28) and says that [$d$] may be refined according to 8.2.2(3) and 8.2.2(4), while both
+    of those paragraphs name Formula (8.27) alone: (3) replaces [$d$] in Formula (8.27) by the mechanical shear
+    span [$a_v$], and (4) multiplies [$d$] in Formula (8.27) or [$a_v$] in Formula (8.29) by [$k_{vp}$].
+    Neither mentions (8.28).
+
+    This class therefore takes the unrefined effective depth. A caller who reads the shared list the other way
+    can pass the refined value instead, and should be aware that it then also enters (8.27) through
+    [$\rho_l$].
+    """
+
+    label = "8.28"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, a_sl: MM2, b_w: MM, d: MM) -> None:
+        r"""[$\rho_l$] Longitudinal tensile reinforcement ratio [$-$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (2) - Formula (8.28)
+
+        Parameters
+        ----------
+        a_sl : MM2
+            [$A_{sl}$] Effective area of tensile reinforcement at the distance [$d$] beyond the section considered,
+            see Figure 8.7 [$mm^2$].
+        b_w : MM
+            [$b_w$] Width of the cross-section of linear members. The width [$b_w$] for cross-sections with variable width
+            and for circular cross-sections is defined in 8.2.3(9) [$mm$].
+        d : MM
+            [$d$] Effective depth [$d_{nom}$]. The value [$d$] may be refined according to 8.2.2(3) and 8.2.2(4) for
+            non-slender members and members with axial force [$mm$].
+        """
+        super().__init__()
+        self.a_sl = a_sl
+        self.b_w = b_w
+        self.d = d
+
+    @staticmethod
+    def _evaluate(a_sl: MM2, b_w: MM, d: MM) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_sl=a_sl)
+        raise_if_less_or_equal_to_zero(b_w=b_w, d=d)
+
+        return a_sl / (b_w * d)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.28."""
+        _equation: str = r"\frac{A_{sl}}{b_w \cdot d}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_{sl}": f"{self.a_sl:.{n}f}",
+                r"b_w": f"{self.b_w:.{n}f}",
+                r"\cdot d": rf"\cdot {self.d:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_{sl}": rf"{self.a_sl:.{n}f} \ mm^2",
+                r"b_w": rf"{self.b_w:.{n}f} \ mm",
+                r"\cdot d": rf"\cdot {self.d:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\rho_l",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -88,8 +88,8 @@ Total of 602 formulas present.
 |      8.24      | :heavy_check_mark: |         | Form8Dot22To24EffectiveDepth                                       |
 |      8.25      | :heavy_check_mark: |         | Form8Dot25EffectiveDepthFromPrincipalShearForce                    |
 |      8.26      | :heavy_check_mark: |         | Form8Dot26AngleBetweenPrincipalShearForceAndXAxis                  |
-|      8.27      |        :x:         |         |                                                                    |
-|      8.28      |        :x:         |         |                                                                    |
+|      8.27      | :heavy_check_mark: |         | Form8Dot27DesignShearStressResistance                              |
+|      8.28      | :heavy_check_mark: |         | Form8Dot28LongitudinalReinforcementRatio                           |
 |      8.29      |        :x:         |         |                                                                    |
 |      8.30      |        :x:         |         |                                                                    |
 |      8.31      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_27.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_27.py
@@ -1,0 +1,99 @@
+"""Testing formula 8.27 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_27 import Form8Dot27DesignShearStressResistance
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot27DesignShearStressResistance:
+    """Validation for formula 8.27 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression governs."""
+        # Example values
+        gamma_v = 1.4
+        rho_l = 0.01
+        f_ck = 30.0
+        d_dg = 32.0
+        d = 500.0
+        tau_rdc_min = 0.522
+
+        # Object to test
+        formula = Form8Dot27DesignShearStressResistance(gamma_v=gamma_v, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d=d, tau_rdc_min=tau_rdc_min)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.585935  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_minimum_governs(self) -> None:
+        """Tests the evaluation of the result when the lower bound governs."""
+        # Example values, with a reinforcement ratio low enough for the expression to fall below the minimum
+        formula = Form8Dot27DesignShearStressResistance(gamma_v=1.4, rho_l=0.002, f_ck=30.0, d_dg=32.0, d=500.0, tau_rdc_min=0.522)
+
+        # Expected result, manually calculated: the expression yields 0.342657, so the minimum governs
+        manually_calculated_result = 0.522  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("gamma_v", "rho_l", "f_ck", "d_dg", "d", "tau_rdc_min"),
+        [
+            (1.4, -0.01, 30.0, 32.0, 500.0, 0.522),  # rho_l is negative
+            (1.4, 0.01, -30.0, 32.0, 500.0, 0.522),  # f_ck is negative
+            (1.4, 0.01, 30.0, -32.0, 500.0, 0.522),  # d_dg is negative
+            (1.4, 0.01, 30.0, 32.0, 500.0, -0.522),  # tau_rdc_min is negative
+            (-1.4, 0.01, 30.0, 32.0, 500.0, 0.522),  # gamma_v is negative
+            (0.0, 0.01, 30.0, 32.0, 500.0, 0.522),  # gamma_v is zero
+            (1.4, 0.01, 30.0, 32.0, -500.0, 0.522),  # d is negative
+            (1.4, 0.01, 30.0, 32.0, 0.0, 0.522),  # d is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(
+        self, gamma_v: float, rho_l: float, f_ck: float, d_dg: float, d: float, tau_rdc_min: float
+    ) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot27DesignShearStressResistance(gamma_v=gamma_v, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d=d, tau_rdc_min=tau_rdc_min)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Rd,c} = \max\left(\frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot "
+                r"\frac{d_{dg}}{d}\right)^{\frac{1}{3}}, \tau_{Rdc,min}\right) = "
+                r"\max\left(\frac{0.66}{1.400} \cdot \left(100 \cdot 0.010 \cdot 30.000 \cdot "
+                r"\frac{32.000}{500.000}\right)^{\frac{1}{3}}, 0.522\right) = 0.586 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Rd,c} = \max\left(\frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot "
+                r"\frac{d_{dg}}{d}\right)^{\frac{1}{3}}, \tau_{Rdc,min}\right) = "
+                r"\max\left(\frac{0.66}{1.400} \cdot \left(100 \cdot 0.010 \cdot 30.000 \ MPa \cdot "
+                r"\frac{32.000 \ mm}{500.000 \ mm}\right)^{\frac{1}{3}}, 0.522 \ MPa\right) = 0.586 \ MPa",
+            ),
+            ("short", r"\tau_{Rd,c} = 0.586 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        gamma_v = 1.4
+        rho_l = 0.01
+        f_ck = 30.0
+        d_dg = 32.0
+        d = 500.0
+        tau_rdc_min = 0.522
+
+        # Object to test
+        latex = Form8Dot27DesignShearStressResistance(gamma_v=gamma_v, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d=d, tau_rdc_min=tau_rdc_min).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_28.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_28.py
@@ -1,0 +1,74 @@
+"""Testing formula 8.28 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_28 import (
+    Form8Dot28LongitudinalReinforcementRatio,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot28LongitudinalReinforcementRatio:
+    """Validation for formula 8.28 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_sl = 1500.0
+        b_w = 300.0
+        d = 500.0
+
+        # Object to test
+        formula = Form8Dot28LongitudinalReinforcementRatio(a_sl=a_sl, b_w=b_w, d=d)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.01  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_sl", "b_w", "d"),
+        [
+            (-1500.0, 300.0, 500.0),  # a_sl is negative
+            (1500.0, -300.0, 500.0),  # b_w is negative
+            (1500.0, 0.0, 500.0),  # b_w is zero
+            (1500.0, 300.0, -500.0),  # d is negative
+            (1500.0, 300.0, 0.0),  # d is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_sl: float, b_w: float, d: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot28LongitudinalReinforcementRatio(a_sl=a_sl, b_w=b_w, d=d)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\rho_l = \frac{A_{sl}}{b_w \cdot d} = \frac{1500.000}{300.000 \cdot 500.000} = 0.010 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"\rho_l = \frac{A_{sl}}{b_w \cdot d} = \frac{1500.000 \ mm^2}{300.000 \ mm \cdot 500.000 \ mm} = 0.010 \ -",
+            ),
+            ("short", r"\rho_l = 0.010 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_sl = 1500.0
+        b_w = 300.0
+        d = 500.0
+
+        # Object to test
+        latex = Form8Dot28LongitudinalReinforcementRatio(a_sl=a_sl, b_w=b_w, d=d).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Description

Implements Formulas (8.27) and (8.28) of clause 8.2.2(2), the detailed verification for members without shear reinforcement:

- `Form8Dot27DesignShearStressResistance` for (8.27), the design value of the shear stress resistance.
- `Form8Dot28LongitudinalReinforcementRatio` for (8.28), the longitudinal tensile reinforcement ratio that feeds it.

Points worth a reviewer's attention:

- (8.27) is printed as an expression bounded from below by `tau_Rdc,min`. It is implemented as the maximum of the two, following `formula_6_50.py`. Both outcomes have a test.
- The exponent one third applies to the whole bracket `(100 * rho_l * f_ck * d_dg / d)`, with the factor `0.66 / gamma_V` outside it.
- `rho_l` is returned as a ratio, not a percentage. The factor 100 lives in (8.27), where the standard prints it.
- 8.2.2(3) and 8.2.2(4) allow `d` in (8.27) to be replaced by `a_v` or multiplied by `k_vp`. That refinement is left to the caller and stated in the docstring. The wording of 8.2.2(3) points at the `d` of (8.27), not at the `d` inside (8.28), which is noted there as well.

Clause 8.2.2 also holds Formulas (8.29) to (8.31), which follow in a separate pull request.

Contributes to #1083

## Formulas as implemented

**Formula (8.27)**, `Form8Dot27DesignShearStressResistance`

`equation`

$$
\tau_{Rd,c} = \max\left(\frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d}\right)^{\frac{1}{3}}, \tau_{Rdc,min}\right)
$$

`complete`

$$
\tau_{Rd,c} = \max\left(\frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d}\right)^{\frac{1}{3}}, \tau_{Rdc,min}\right) = \max\left(\frac{0.66}{1.400} \cdot \left(100 \cdot 0.010 \cdot 30.000 \cdot \frac{32.000}{500.000}\right)^{\frac{1}{3}}, 0.522\right) = 0.586 \ MPa
$$

`complete_with_units`

$$
\tau_{Rd,c} = \max\left(\frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d}\right)^{\frac{1}{3}}, \tau_{Rdc,min}\right) = \max\left(\frac{0.66}{1.400} \cdot \left(100 \cdot 0.010 \cdot 30.000 \ MPa \cdot \frac{32.000 \ mm}{500.000 \ mm}\right)^{\frac{1}{3}}, 0.522 \ MPa\right) = 0.586 \ MPa
$$

**Formula (8.28)**, `Form8Dot28LongitudinalReinforcementRatio`

`equation`

$$
\rho_l = \frac{A_{sl}}{b_w \cdot d}
$$

`complete`

$$
\rho_l = \frac{A_{sl}}{b_w \cdot d} = \frac{1500.000}{300.000 \cdot 500.000} = 0.010 \ -
$$

`complete_with_units`

$$
\rho_l = \frac{A_{sl}}{b_w \cdot d} = \frac{1500.000 \ mm^2}{300.000 \ mm \cdot 500.000 \ mm} = 0.010 \ -
$$

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Tests for both governing cases of (8.27) and every raise
- [x] Docstrings added, with variable descriptions taken from the standard
- [x] Documentation table updated with the class names
- [x] `blueprints check` passes: lint, format, type check, and 100% coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Eurocode 2 formulas 8.27 and 8.28.
  * Calculate design shear stress resistance for members without shear reinforcement.
  * Calculate the longitudinal tensile reinforcement ratio.
  * Added LaTeX representations for both formulas, including numeric values and units.

* **Documentation**
  * Marked formulas 8.27 and 8.28 as implemented in the Eurocode formula guide.

* **Tests**
  * Added coverage for calculations, input validation, and LaTeX output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->