### PR TITLE
feat: add formulas 8.29, 8.30 and 8.31 from FprEN 1992-1-1:2023 clause 8.2.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_29.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_29.py
@@ -6,7 +6,7 @@ from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
 from blueprints.type_alias import MM
-from blueprints.validations import raise_if_negative
+from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form8Dot29MechanicalShearSpan(Formula):
@@ -41,7 +41,10 @@ class Form8Dot29MechanicalShearSpan(Formula):
     @staticmethod
     def _evaluate(a_cs: MM, d: MM) -> MM:
         """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(a_cs=a_cs, d=d)
+        # An effective depth or shear span of zero is not a cross-section. The standard prints no such
+        # condition, so this is an addition made here, consistent with (8.22) to (8.24) and with (8.31),
+        # where a_cs sits in a denominator and is guarded the same way.
+        raise_if_less_or_equal_to_zero(a_cs=a_cs, d=d)
 
         return np.sqrt(a_cs / 4 * d)
 

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_29.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_29.py
@@ -1,0 +1,75 @@
+"""Formula 8.29 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot29MechanicalShearSpan(Formula):
+    """Class representing formula 8.29 for the calculation of the mechanical shear span, which may replace
+    the effective depth in Formula (8.27).
+    """
+
+    label = "8.29"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, a_cs: MM, d: MM) -> None:
+        r"""[$a_v$] Mechanical shear span [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (3) - Formula (8.29)
+
+        The value of [$d$] in Formula (8.27) may be replaced by [$a_v$], for members with an effective shear
+        span [$a_{cs}$] shorter than [$4 \cdot d$]. That condition is a matter of applicability rather than a
+        branch of the formula, so it is left to the caller and not enforced here.
+
+        Parameters
+        ----------
+        a_cs : MM
+            [$a_{cs}$] Effective shear span with respect to the control section according to Formula (8.30),
+            see Form8Dot30EffectiveShearSpan [$mm$].
+        d : MM
+            [$d$] Effective depth [$mm$].
+        """
+        super().__init__()
+        self.a_cs = a_cs
+        self.d = d
+
+    @staticmethod
+    def _evaluate(a_cs: MM, d: MM) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_cs=a_cs, d=d)
+
+        return np.sqrt(a_cs / 4 * d)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.29."""
+        _equation: str = r"\sqrt{\frac{a_{cs}}{4} \cdot d}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_{cs}": f"{self.a_cs:.{n}f}",
+                r"\cdot d": rf"\cdot {self.d:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_{cs}": rf"{self.a_cs:.{n}f} \ mm",
+                r"\cdot d": rf"\cdot {self.d:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"a_v",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_30.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_30.py
@@ -4,7 +4,7 @@ from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
 from blueprints.type_alias import MM, NMM, N
-from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form8Dot30EffectiveShearSpan(Formula):
@@ -43,8 +43,11 @@ class Form8Dot30EffectiveShearSpan(Formula):
     @staticmethod
     def _evaluate(m_ed: NMM, v_ed: N, d: MM) -> MM:
         """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(d=d)
-        raise_if_less_or_equal_to_zero(v_ed=abs(v_ed))
+        # The guard is on the magnitude, so a negative shear force passes and only zero is refused. Naming
+        # the keyword after the magnitude keeps the error from claiming that a negative value is illegal.
+        # Refusing a shear force of zero is a reading of the standard, since it is a denominator. Refusing an
+        # effective depth of zero is an addition made here: the standard prints no such condition.
+        raise_if_less_or_equal_to_zero(abs_v_ed=abs(v_ed), d=d)
 
         return max(abs(m_ed / v_ed), d)
 

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_30.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_30.py
@@ -1,0 +1,80 @@
+"""Formula 8.30 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, NMM, N
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot30EffectiveShearSpan(Formula):
+    """Class representing formula 8.30 for the calculation of the effective shear span with respect to
+    the control section, for reinforced concrete members.
+    """
+
+    label = "8.30"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, m_ed: NMM, v_ed: N, d: MM) -> None:
+        r"""[$a_{cs}$] Effective shear span with respect to the control section [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (3) - Formula (8.30)
+
+        The standard prints this as a ratio in absolute value bars, bounded from below by [$d$], which is
+        implemented as the maximum of the two. Because of the absolute value, the signs of [$M_{Ed}$] and
+        [$V_{Ed}$] do not affect the result, so both may be passed signed.
+
+        Parameters
+        ----------
+        m_ed : NMM
+            [$M_{Ed}$] Design bending moment at the control section, including the effects of prestressing
+            according to 8.2.1(8) [$Nmm$].
+        v_ed : N
+            [$V_{Ed}$] Design shear force at the control section, including the effects of prestressing
+            according to 8.2.1(8) [$N$].
+        d : MM
+            [$d$] Effective depth [$mm$].
+        """
+        super().__init__()
+        self.m_ed = m_ed
+        self.v_ed = v_ed
+        self.d = d
+
+    @staticmethod
+    def _evaluate(m_ed: NMM, v_ed: N, d: MM) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(d=d)
+        raise_if_less_or_equal_to_zero(v_ed=abs(v_ed))
+
+        return max(abs(m_ed / v_ed), d)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.30."""
+        _equation: str = r"\max\left(\left|\frac{M_{Ed}}{V_{Ed}}\right|, d\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"M_{Ed}": f"{self.m_ed:.{n}f}",
+                r"V_{Ed}": f"{self.v_ed:.{n}f}",
+                r", d": f", {self.d:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"M_{Ed}": rf"{self.m_ed:.{n}f} \ Nmm",
+                r"V_{Ed}": rf"{self.v_ed:.{n}f} \ N",
+                r", d": rf", {self.d:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"a_{cs}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_31.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_31.py
@@ -1,0 +1,86 @@
+"""Formula 8.31 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, N
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot31AxialForceCoefficient(Formula):
+    """Class representing formula 8.31 for the calculation of the coefficient accounting for axial forces
+    at the control section.
+    """
+
+    label = "8.31"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, n_ed: N, v_ed: N, d: MM, a_cs: MM) -> None:
+        r"""[$k_{vp}$] Coefficient by which the effective depth in Formula (8.27), or the mechanical shear span
+        in Formula (8.29), is multiplied in the presence of axial forces [$-$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (4) - Formula (8.31)
+
+        The standard prints the shear force in absolute value bars but the axial force without them, so the sign
+        of [$N_{Ed}$] carries meaning and a negative value is valid: it lowers [$k_{vp}$]. The printed lower bound
+        of 0.1 is implemented as a maximum.
+
+        Parameters
+        ----------
+        n_ed : N
+            [$N_{Ed}$] Design axial force acting at the control section, passed with its sign [$N$].
+        v_ed : N
+            [$V_{Ed}$] Design shear force at the control section. Only its magnitude is used, so it may be
+            passed signed [$N$].
+        d : MM
+            [$d$] Effective depth [$mm$].
+        a_cs : MM
+            [$a_{cs}$] Effective shear span with respect to the control section according to Formula (8.30),
+            see Form8Dot30EffectiveShearSpan [$mm$].
+        """
+        super().__init__()
+        self.n_ed = n_ed
+        self.v_ed = v_ed
+        self.d = d
+        self.a_cs = a_cs
+
+    @staticmethod
+    def _evaluate(n_ed: N, v_ed: N, d: MM, a_cs: MM) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(d=d)
+        raise_if_less_or_equal_to_zero(v_ed=abs(v_ed), a_cs=a_cs)
+
+        return max(1 + (n_ed / abs(v_ed)) * (d / (3 * a_cs)), 0.1)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.31."""
+        _equation: str = r"\max\left(1 + \frac{N_{Ed}}{\left|V_{Ed}\right|} \cdot \frac{d}{3 \cdot a_{cs}}, 0.1\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"N_{Ed}": f"{self.n_ed:.{n}f}",
+                r"V_{Ed}": f"{self.v_ed:.{n}f}",
+                r"a_{cs}": f"{self.a_cs:.{n}f}",
+                r"{d}": "{" + f"{self.d:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"N_{Ed}": rf"{self.n_ed:.{n}f} \ N",
+                r"V_{Ed}": rf"{self.v_ed:.{n}f} \ N",
+                r"a_{cs}": rf"{self.a_cs:.{n}f} \ mm",
+                r"{d}": "{" + rf"{self.d:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"k_{vp}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_31.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_31.py
@@ -4,7 +4,7 @@ from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
 from blueprints.type_alias import DIMENSIONLESS, MM, N
-from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form8Dot31AxialForceCoefficient(Formula):
@@ -47,8 +47,11 @@ class Form8Dot31AxialForceCoefficient(Formula):
     @staticmethod
     def _evaluate(n_ed: N, v_ed: N, d: MM, a_cs: MM) -> DIMENSIONLESS:
         """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(d=d)
-        raise_if_less_or_equal_to_zero(v_ed=abs(v_ed), a_cs=a_cs)
+        # The guard is on the magnitude, so a negative shear force passes and only zero is refused. Naming
+        # the keyword after the magnitude keeps the error from claiming that a negative value is illegal.
+        # Refusing a shear force of zero is a reading of the standard, since it is a denominator. Refusing an
+        # effective depth of zero is an addition made here: the standard prints no such condition.
+        raise_if_less_or_equal_to_zero(abs_v_ed=abs(v_ed), a_cs=a_cs, d=d)
 
         return max(1 + (n_ed / abs(v_ed)) * (d / (3 * a_cs)), 0.1)
 

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -90,9 +90,9 @@ Total of 602 formulas present.
 |      8.26      | :heavy_check_mark: |         | Form8Dot26AngleBetweenPrincipalShearForceAndXAxis                  |
 |      8.27      |        :x:         |         |                                                                    |
 |      8.28      |        :x:         |         |                                                                    |
-|      8.29      |        :x:         |         |                                                                    |
-|      8.30      |        :x:         |         |                                                                    |
-|      8.31      |        :x:         |         |                                                                    |
+|      8.29      | :heavy_check_mark: |         | Form8Dot29MechanicalShearSpan                                      |
+|      8.30      | :heavy_check_mark: |         | Form8Dot30EffectiveShearSpan                                       |
+|      8.31      | :heavy_check_mark: |         | Form8Dot31AxialForceCoefficient                                    |
 |      8.32      |        :x:         |         |                                                                    |
 |      8.33      |        :x:         |         |                                                                    |
 |      8.34      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_29.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_29.py
@@ -3,7 +3,7 @@
 import pytest
 
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_29 import Form8Dot29MechanicalShearSpan
-from blueprints.validations import NegativeValueError
+from blueprints.validations import LessOrEqualToZeroError
 
 
 class TestForm8Dot29MechanicalShearSpan:
@@ -34,12 +34,14 @@ class TestForm8Dot29MechanicalShearSpan:
         ("a_cs", "d"),
         [
             (-1333.333333, 500.0),  # a_cs is negative
+            (0.0, 500.0),  # a_cs is zero
             (1333.333333, -500.0),  # d is negative
+            (1333.333333, 0.0),  # d is zero, which is not a cross-section
         ],
     )
-    def test_raise_error_when_invalid_values_are_given(self, a_cs: float, d: float) -> None:
-        """Test invalid values."""
-        with pytest.raises(NegativeValueError):
+    def test_raise_error_when_less_or_equal_to_zero(self, a_cs: float, d: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
             Form8Dot29MechanicalShearSpan(a_cs=a_cs, d=d)
 
     @pytest.mark.parametrize(

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_29.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_29.py
@@ -1,0 +1,74 @@
+"""Testing formula 8.29 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_29 import Form8Dot29MechanicalShearSpan
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot29MechanicalShearSpan:
+    """Validation for formula 8.29 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_cs = 1333.333333
+        d = 500.0
+
+        # Object to test
+        formula = Form8Dot29MechanicalShearSpan(a_cs=a_cs, d=d)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 408.248290  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_shear_span_equals_four_times_the_effective_depth(self) -> None:
+        """Tests the upper edge of the range of application, where the mechanical shear span equals the effective depth."""
+        # At a_cs = 4 * d the formula returns d itself
+        formula = Form8Dot29MechanicalShearSpan(a_cs=2000.0, d=500.0)
+
+        assert formula == pytest.approx(expected=500.0, rel=1e-9)
+
+    @pytest.mark.parametrize(
+        ("a_cs", "d"),
+        [
+            (-1333.333333, 500.0),  # a_cs is negative
+            (1333.333333, -500.0),  # d is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_cs: float, d: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot29MechanicalShearSpan(a_cs=a_cs, d=d)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"a_v = \sqrt{\frac{a_{cs}}{4} \cdot d} = \sqrt{\frac{1333.333}{4} \cdot 500.000} = 408.248 \ mm",
+            ),
+            (
+                "complete_with_units",
+                r"a_v = \sqrt{\frac{a_{cs}}{4} \cdot d} = \sqrt{\frac{1333.333 \ mm}{4} \cdot 500.000 \ mm} = 408.248 \ mm",
+            ),
+            ("short", r"a_v = 408.248 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_cs = 1333.333333
+        d = 500.0
+
+        # Object to test
+        latex = Form8Dot29MechanicalShearSpan(a_cs=a_cs, d=d).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_30.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_30.py
@@ -1,0 +1,95 @@
+"""Testing formula 8.30 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_30 import Form8Dot30EffectiveShearSpan
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot30EffectiveShearSpan:
+    """Validation for formula 8.30 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the moment to shear ratio governs."""
+        # Example values
+        m_ed = 200000000.0
+        v_ed = 150000.0
+        d = 500.0
+
+        # Object to test
+        formula = Form8Dot30EffectiveShearSpan(m_ed=m_ed, v_ed=v_ed, d=d)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1333.333333  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_effective_depth_governs(self) -> None:
+        """Tests the evaluation of the result when the lower bound governs."""
+        # Example values, with a moment to shear ratio of 333.333 mm, below the effective depth
+        formula = Form8Dot30EffectiveShearSpan(m_ed=50000000.0, v_ed=150000.0, d=500.0)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 500.0  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("m_ed", "v_ed"),
+        [
+            (-200000000.0, 150000.0),  # negative moment
+            (200000000.0, -150000.0),  # negative shear force
+            (-200000000.0, -150000.0),  # both negative
+        ],
+    )
+    def test_evaluation_is_insensitive_to_signs(self, m_ed: float, v_ed: float) -> None:
+        """Tests that the absolute value bars printed in the standard make the result sign insensitive."""
+        formula = Form8Dot30EffectiveShearSpan(m_ed=m_ed, v_ed=v_ed, d=500.0)
+
+        assert formula == pytest.approx(expected=1333.333333, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("m_ed", "v_ed", "d"),
+        [
+            (200000000.0, 0.0, 500.0),  # v_ed is zero
+            (200000000.0, 150000.0, -500.0),  # d is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, m_ed: float, v_ed: float, d: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot30EffectiveShearSpan(m_ed=m_ed, v_ed=v_ed, d=d)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"a_{cs} = \max\left(\left|\frac{M_{Ed}}{V_{Ed}}\right|, d\right) = "
+                r"\max\left(\left|\frac{200000000.000}{150000.000}\right|, 500.000\right) = 1333.333 \ mm",
+            ),
+            (
+                "complete_with_units",
+                r"a_{cs} = \max\left(\left|\frac{M_{Ed}}{V_{Ed}}\right|, d\right) = "
+                r"\max\left(\left|\frac{200000000.000 \ Nmm}{150000.000 \ N}\right|, 500.000 \ mm\right) = 1333.333 \ mm",
+            ),
+            ("short", r"a_{cs} = 1333.333 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        m_ed = 200000000.0
+        v_ed = 150000.0
+        d = 500.0
+
+        # Object to test
+        latex = Form8Dot30EffectiveShearSpan(m_ed=m_ed, v_ed=v_ed, d=d).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_30.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_30.py
@@ -3,7 +3,7 @@
 import pytest
 
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_30 import Form8Dot30EffectiveShearSpan
-from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+from blueprints.validations import LessOrEqualToZeroError
 
 
 class TestForm8Dot30EffectiveShearSpan:
@@ -51,14 +51,25 @@ class TestForm8Dot30EffectiveShearSpan:
     @pytest.mark.parametrize(
         ("m_ed", "v_ed", "d"),
         [
-            (200000000.0, 0.0, 500.0),  # v_ed is zero
+            (200000000.0, 0.0, 500.0),  # v_ed is zero, the only value of it that is refused
             (200000000.0, 150000.0, -500.0),  # d is negative
+            (200000000.0, 150000.0, 0.0),  # d is zero, which is not a cross-section
         ],
     )
-    def test_raise_error_when_invalid_values_are_given(self, m_ed: float, v_ed: float, d: float) -> None:
-        """Test invalid values."""
-        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+    def test_raise_error_when_less_or_equal_to_zero(self, m_ed: float, v_ed: float, d: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less.
+
+        The guard on the shear force is on its magnitude, so a negative one passes it. Only zero is refused.
+        """
+        with pytest.raises(LessOrEqualToZeroError):
             Form8Dot30EffectiveShearSpan(m_ed=m_ed, v_ed=v_ed, d=d)
+
+    @pytest.mark.parametrize("v_ed", [150000.0, -150000.0])
+    def test_a_negative_shear_force_is_accepted(self, v_ed: float) -> None:
+        """A negative shear force is ordinary input: the standard prints the ratio inside absolute value bars."""
+        formula = Form8Dot30EffectiveShearSpan(m_ed=200000000.0, v_ed=v_ed, d=500.0)
+
+        assert formula == pytest.approx(expected=1333.333333, rel=1e-4)
 
     @pytest.mark.parametrize(
         ("representation", "expected"),

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_31.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_31.py
@@ -3,7 +3,7 @@
 import pytest
 
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_31 import Form8Dot31AxialForceCoefficient
-from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+from blueprints.validations import LessOrEqualToZeroError
 
 
 class TestForm8Dot31AxialForceCoefficient:
@@ -49,15 +49,19 @@ class TestForm8Dot31AxialForceCoefficient:
     @pytest.mark.parametrize(
         ("n_ed", "v_ed", "d", "a_cs"),
         [
-            (-200000.0, 0.0, 500.0, 1333.333333),  # v_ed is zero
+            (-200000.0, 0.0, 500.0, 1333.333333),  # v_ed is zero, the only value of it that is refused
             (-200000.0, 150000.0, -500.0, 1333.333333),  # d is negative
+            (-200000.0, 150000.0, 0.0, 1333.333333),  # d is zero, which is not a cross-section
             (-200000.0, 150000.0, 500.0, -1333.333333),  # a_cs is negative
             (-200000.0, 150000.0, 500.0, 0.0),  # a_cs is zero
         ],
     )
-    def test_raise_error_when_invalid_values_are_given(self, n_ed: float, v_ed: float, d: float, a_cs: float) -> None:
-        """Test invalid values."""
-        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+    def test_raise_error_when_less_or_equal_to_zero(self, n_ed: float, v_ed: float, d: float, a_cs: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less.
+
+        The guard on the shear force is on its magnitude, so a negative one passes it. Only zero is refused.
+        """
+        with pytest.raises(LessOrEqualToZeroError):
             Form8Dot31AxialForceCoefficient(n_ed=n_ed, v_ed=v_ed, d=d, a_cs=a_cs)
 
     @pytest.mark.parametrize(
@@ -95,3 +99,32 @@ class TestForm8Dot31AxialForceCoefficient:
         }
 
         assert expected == actual[representation], f"{representation} representation failed."
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"k_{vp} = \max\left(1 + \frac{N_{Ed}}{\left|V_{Ed}\right|} \cdot \frac{d}{3 \cdot a_{cs}}, 0.1\right) = "
+                r"\max\left(1 + \frac{-200000.000}{\left|-150000.000\right|} \cdot "
+                r"\frac{500.000}{3 \cdot 1333.333}, 0.1\right) = 0.833 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"k_{vp} = \max\left(1 + \frac{N_{Ed}}{\left|V_{Ed}\right|} \cdot \frac{d}{3 \cdot a_{cs}}, 0.1\right) = "
+                r"\max\left(1 + \frac{-200000.000 \ N}{\left|-150000.000 \ N\right|} \cdot "
+                r"\frac{500.000 \ mm}{3 \cdot 1333.333 \ mm}, 0.1\right) = 0.833 \ -",
+            ),
+        ],
+    )
+    def test_latex_with_both_forces_negative(self, representation: str, expected: str) -> None:
+        """Both a negative axial force and a negative shear force keep their sign in the output.
+
+        The axial force is printed signed, and the shear force appears inside the absolute value bars that
+        the standard prints, so the reader can see that the magnitude is what enters the division.
+        """
+        latex = Form8Dot31AxialForceCoefficient(n_ed=-200000.0, v_ed=-150000.0, d=500.0, a_cs=1333.333333).latex()
+
+        actual = {"complete": latex.complete, "complete_with_units": latex.complete_with_units}
+
+        assert expected == actual[representation]

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_31.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_31.py
@@ -1,0 +1,97 @@
+"""Testing formula 8.31 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_31 import Form8Dot31AxialForceCoefficient
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot31AxialForceCoefficient:
+    """Validation for formula 8.31 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("n_ed", "expected"),
+        [
+            (-200000.0, 0.833333),  # axial force lowering the coefficient
+            (0.0, 1.0),  # no axial force
+            (200000.0, 1.166667),  # axial force raising the coefficient
+        ],
+    )
+    def test_evaluation(self, n_ed: float, expected: float) -> None:
+        """Tests the evaluation of the result for both signs of the axial force."""
+        # Example values
+        v_ed = 150000.0
+        d = 500.0
+        a_cs = 1333.333333
+
+        # Object to test
+        formula = Form8Dot31AxialForceCoefficient(n_ed=n_ed, v_ed=v_ed, d=d, a_cs=a_cs)
+
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    def test_evaluation_when_the_lower_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the printed lower bound of 0.1 governs."""
+        # Example values, with an axial force large enough to drive the expression below 0.1
+        formula = Form8Dot31AxialForceCoefficient(n_ed=-2000000.0, v_ed=150000.0, d=500.0, a_cs=1333.333333)
+
+        # Expected result, manually calculated: the expression yields -0.666667, so the lower bound governs
+        manually_calculated_result = 0.1  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_is_insensitive_to_the_sign_of_the_shear_force(self) -> None:
+        """Tests that the absolute value bars printed around the shear force make its sign irrelevant."""
+        positive = Form8Dot31AxialForceCoefficient(n_ed=-200000.0, v_ed=150000.0, d=500.0, a_cs=1333.333333)
+        negative = Form8Dot31AxialForceCoefficient(n_ed=-200000.0, v_ed=-150000.0, d=500.0, a_cs=1333.333333)
+
+        assert float(positive) == pytest.approx(expected=float(negative), rel=1e-9)
+
+    @pytest.mark.parametrize(
+        ("n_ed", "v_ed", "d", "a_cs"),
+        [
+            (-200000.0, 0.0, 500.0, 1333.333333),  # v_ed is zero
+            (-200000.0, 150000.0, -500.0, 1333.333333),  # d is negative
+            (-200000.0, 150000.0, 500.0, -1333.333333),  # a_cs is negative
+            (-200000.0, 150000.0, 500.0, 0.0),  # a_cs is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, n_ed: float, v_ed: float, d: float, a_cs: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot31AxialForceCoefficient(n_ed=n_ed, v_ed=v_ed, d=d, a_cs=a_cs)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"k_{vp} = \max\left(1 + \frac{N_{Ed}}{\left|V_{Ed}\right|} \cdot \frac{d}{3 \cdot a_{cs}}, 0.1\right) = "
+                r"\max\left(1 + \frac{-200000.000}{\left|150000.000\right|} \cdot \frac{500.000}{3 \cdot 1333.333}, 0.1\right) = 0.833 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"k_{vp} = \max\left(1 + \frac{N_{Ed}}{\left|V_{Ed}\right|} \cdot \frac{d}{3 \cdot a_{cs}}, 0.1\right) = "
+                r"\max\left(1 + \frac{-200000.000 \ N}{\left|150000.000 \ N\right|} \cdot "
+                r"\frac{500.000 \ mm}{3 \cdot 1333.333 \ mm}, 0.1\right) = 0.833 \ -",
+            ),
+            ("short", r"k_{vp} = 0.833 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        n_ed = -200000.0
+        v_ed = 150000.0
+        d = 500.0
+        a_cs = 1333.333333
+
+        # Object to test
+        latex = Form8Dot31AxialForceCoefficient(n_ed=n_ed, v_ed=v_ed, d=d, a_cs=a_cs).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Description

Implements Formulas (8.29), (8.30) and (8.31) of clause 8.2.2(3) and 8.2.2(4), the refinements of the effective depth used by Formula (8.27):

- `Form8Dot30EffectiveShearSpan` for (8.30), the effective shear span with respect to the control section.
- `Form8Dot29MechanicalShearSpan` for (8.29), the mechanical shear span that may replace `d` for short shear spans.
- `Form8Dot31AxialForceCoefficient` for (8.31), the coefficient applied in the presence of axial forces.

Points worth a reviewer's attention:

- **Signs are not uniform across these formulas, and that is deliberate.** In (8.30) the absolute value bars enclose the whole quotient `M_Ed / V_Ed`, so both may be passed signed and the result does not change. In (8.31) the bars appear around `V_Ed` only, so the sign of `N_Ed` carries meaning and a negative value is valid and lowers the coefficient. `N_Ed` therefore has no sign guard, which is intentional: rejecting it would defeat the purpose of the formula. There is a test for each sign.
- The standard does not state a sign convention for `N_Ed` on this page, so none is imposed. The value is used as given.
- Both printed bounds are implemented as a maximum: `>= d` in (8.30) and `>= 0,1` in (8.31). Both governing cases have a test.
- In (8.29) the radical covers `a_cs / 4` as well as `d`. Reading it as `sqrt(a_cs / 4) * d` would give 9128.71 mm instead of 408.25 mm for the test values, and would also be dimensionally wrong.
- 8.2.2(3) limits the substitution to members with `a_cs` shorter than `4 * d`. That is a condition on where the formula may be applied rather than a branch inside it, so it is documented instead of enforced. At `a_cs = 4 * d` the formula degenerates to `a_v = d`, which has a test.

Clause 8.2.2 continues with Formula (8.32) in 8.2.2(5), which follows in a separate pull request.

Contributes to #1083

## Formulas as implemented

**Formula (8.29)**, `Form8Dot29MechanicalShearSpan`

`equation`

$$
a_v = \sqrt{\frac{a_{cs}}{4} \cdot d}
$$

`complete`

$$
a_v = \sqrt{\frac{a_{cs}}{4} \cdot d} = \sqrt{\frac{1333.333}{4} \cdot 500.000} = 408.248 \ mm
$$

`complete_with_units`

$$
a_v = \sqrt{\frac{a_{cs}}{4} \cdot d} = \sqrt{\frac{1333.333 \ mm}{4} \cdot 500.000 \ mm} = 408.248 \ mm
$$

**Formula (8.30)**, `Form8Dot30EffectiveShearSpan`

`equation`

$$
a_{cs} = \max\left(\left|\frac{M_{Ed}}{V_{Ed}}\right|, d\right)
$$

`complete`

$$
a_{cs} = \max\left(\left|\frac{M_{Ed}}{V_{Ed}}\right|, d\right) = \max\left(\left|\frac{200000000.000}{150000.000}\right|, 500.000\right) = 1333.333 \ mm
$$

`complete_with_units`

$$
a_{cs} = \max\left(\left|\frac{M_{Ed}}{V_{Ed}}\right|, d\right) = \max\left(\left|\frac{200000000.000 \ Nmm}{150000.000 \ N}\right|, 500.000 \ mm\right) = 1333.333 \ mm
$$

**Formula (8.31)**, `Form8Dot31AxialForceCoefficient`

`equation`

$$
k_{vp} = \max\left(1 + \frac{N_{Ed}}{\left|V_{Ed}\right|} \cdot \frac{d}{3 \cdot a_{cs}}, 0.1\right)
$$

`complete`

$$
k_{vp} = \max\left(1 + \frac{N_{Ed}}{\left|V_{Ed}\right|} \cdot \frac{d}{3 \cdot a_{cs}}, 0.1\right) = \max\left(1 + \frac{-200000.000}{\left|150000.000\right|} \cdot \frac{500.000}{3 \cdot 1333.333}, 0.1\right) = 0.833 \ -
$$

`complete_with_units`

$$
k_{vp} = \max\left(1 + \frac{N_{Ed}}{\left|V_{Ed}\right|} \cdot \frac{d}{3 \cdot a_{cs}}, 0.1\right) = \max\left(1 + \frac{-200000.000 \ N}{\left|150000.000 \ N\right|} \cdot \frac{500.000 \ mm}{3 \cdot 1333.333 \ mm}, 0.1\right) = 0.833 \ -
$$

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Tests for both signs of the axial force, both governing bounds, the sign insensitivity of (8.30) and every raise
- [x] Docstrings added, with variable descriptions taken from the standard
- [x] Documentation table updated with the class names
- [x] `blueprints check` passes: lint, format, type check, and 100% coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2:2023 formulas for mechanical shear span (8.29), effective shear span (8.30), and axial-force coefficient (8.31).
  * Added symbolic and numeric LaTeX representations for each new formula.
* **Documentation**
  * Updated the Eurocode 2 (2023) formula tracking table to reflect implementation status for formulas 8.29–8.31.
* **Tests**
  * Added tests covering numeric evaluation, input validation, boundary behavior, sign handling, clamping behavior, and LaTeX output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->