### PR TITLE
feat: add formulas 8.33, 8.34 and 8.35 from FprEN 1992-1-1:2023 clause 8.2.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_33.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_33.py
@@ -1,0 +1,108 @@
+"""Formula 8.33 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot33ShearStressResistanceWithoutAxialForce(Formula):
+    """Class representing formula 8.33 for the calculation of the design value of the shear stress resistance
+    without the effect of compressive normal forces.
+    """
+
+    label = "8.33"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        gamma_v: DIMENSIONLESS,
+        rho_l: DIMENSIONLESS,
+        f_ck: MPA,
+        d_dg: MM,
+        d: MM,
+    ) -> None:
+        r"""[$\tau_{Rdc,0}$] Design value of the shear stress resistance without the effect of compressive
+        normal forces [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (5) - Formula (8.33)
+
+        This is the expression of Formula (8.27) without its lower bound. It feeds Formula (8.32) and
+        Formula (8.35).
+
+        For the factor [$k_1$] according to Formula (8.34), the effective depth [$d$] may be replaced by
+        [$a_{v,0}$], determined according to Formulas (8.29) and (8.30) without considering in [$M_{Ed}$] and
+        [$V_{Ed}$] the effect of prestressing or external load that produces the compressive axial force. That
+        substitution is left to the caller.
+
+        Parameters
+        ----------
+        gamma_v : DIMENSIONLESS
+            [$\gamma_V$] Partial factor for shear design according to Table 4.3 (NDP) or Tables A.1 (NDP)
+            and A.2 (NDP) [$-$].
+        rho_l : DIMENSIONLESS
+            [$\rho_l$] Longitudinal tensile reinforcement ratio according to Formula (8.28), see
+            Form8Dot28LongitudinalReinforcementRatio [$-$].
+        f_ck : MPA
+            [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
+        d_dg : MM
+            [$d_{dg}$] Size parameter describing the failure zone roughness, defined in 8.2.1(4) [$mm$].
+        d : MM
+            [$d$] Effective depth [$mm$].
+        """
+        super().__init__()
+        self.gamma_v = gamma_v
+        self.rho_l = rho_l
+        self.f_ck = f_ck
+        self.d_dg = d_dg
+        self.d = d
+
+    @staticmethod
+    def _evaluate(
+        gamma_v: DIMENSIONLESS,
+        rho_l: DIMENSIONLESS,
+        f_ck: MPA,
+        d_dg: MM,
+        d: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(rho_l=rho_l, f_ck=f_ck, d_dg=d_dg)
+        raise_if_less_or_equal_to_zero(gamma_v=gamma_v, d=d)
+
+        return (0.66 / gamma_v) * (100 * rho_l * f_ck * (d_dg / d)) ** (1 / 3)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.33."""
+        _equation: str = r"\frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d}\right)^{\frac{1}{3}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\gamma_V": f"{self.gamma_v:.{n}f}",
+                r"\rho_l": f"{self.rho_l:.{n}f}",
+                r"f_{ck}": f"{self.f_ck:.{n}f}",
+                r"d_{dg}": f"{self.d_dg:.{n}f}",
+                r"{d}": "{" + f"{self.d:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\gamma_V": f"{self.gamma_v:.{n}f}",
+                r"\rho_l": f"{self.rho_l:.{n}f}",
+                r"f_{ck}": rf"{self.f_ck:.{n}f} \ MPa",
+                r"d_{dg}": rf"{self.d_dg:.{n}f} \ mm",
+                r"{d}": "{" + rf"{self.d:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rdc,0}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_33.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_33.py
@@ -47,7 +47,13 @@ class Form8Dot33ShearStressResistanceWithoutAxialForce(Formula):
         f_ck : MPA
             [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
         d_dg : MM
-            [$d_{dg}$] Size parameter describing the failure zone roughness, defined in 8.2.1(4) [$mm$].
+            [$d_{dg}$] Size parameter describing the failure zone roughness, which depends on the concrete type
+            and its aggregate properties. The standard gives it as [$16 + D_{lower} \leq 40$] for concrete with
+            [$f_{ck} \leq 60$] MPa, and as [$16 + D_{lower} \cdot \left(60/f_{ck}\right)^2 \leq 40$] for concrete
+            with [$f_{ck} > 60$] MPa, both in millimetres. [$D_{lower}$] is the smallest value of the upper sieve
+            size [$D$] in an aggregate for the coarsest fraction of aggregates in the concrete permitted by the
+            specification of concrete according to EN 206; where [$D_{max}$] is known it may replace
+            [$D_{lower}$], see the NOTE 2 to 8.2.1(4) [$mm$].
         d : MM
             [$d$] Effective depth [$mm$].
         """

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_34.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_34.py
@@ -1,0 +1,102 @@
+"""Formula 8.34 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MM2
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot34FactorK1(Formula):
+    """Class representing formula 8.34 for the calculation of the factor accounting for the effect of
+    compressive normal forces.
+    """
+
+    label = "8.34"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, a_cs_0: MM, e_p: MM, d: MM, a_c: MM2, b_w: MM, z: MM) -> None:
+        r"""[$k_1$] Factor accounting for the effect of compressive normal forces [$-$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (5) - Formula (8.34)
+
+        The standard offers this factor unless the National Annex gives another value. The printed upper
+        bound is implemented as a minimum.
+
+        Parameters
+        ----------
+        a_cs_0 : MM
+            [$a_{cs,0}$] Effective shear span determined according to Formula (8.30), without considering in
+            [$M_{Ed}$] and [$V_{Ed}$] the effect of prestressing or external load that produces the compressive
+            axial force [$mm$].
+        e_p : MM
+            [$e_p$] Eccentricity of the prestressing force or of the external load that produces the compressive
+            axial force, with respect to the centre of gravity of the cross-section, considered as positive
+            towards the tensile side. A negative value is therefore valid. For statically indeterminate members,
+            the effect of hyperstatic moments due to prestressing should be considered by modifying the tendons
+            eccentricity accordingly [$mm$].
+        d : MM
+            [$d$] Effective depth [$mm$].
+        a_c : MM2
+            [$A_c$] Area of concrete cross-section [$mm^2$].
+        b_w : MM
+            [$b_w$] Width of the cross-section of linear members [$mm$].
+        z : MM
+            [$z$] Lever arm for the shear stress calculation [$mm$].
+        """
+        super().__init__()
+        self.a_cs_0 = a_cs_0
+        self.e_p = e_p
+        self.d = d
+        self.a_c = a_c
+        self.b_w = b_w
+        self.z = z
+
+    @staticmethod
+    def _evaluate(a_cs_0: MM, e_p: MM, d: MM, a_c: MM2, b_w: MM, z: MM) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(d=d, a_c=a_c)
+        raise_if_less_or_equal_to_zero(a_cs_0=a_cs_0, b_w=b_w, z=z)
+
+        ratio = a_c / (b_w * z)
+        return min((0.5 / a_cs_0) * (e_p + d / 3) * ratio, 0.18 * ratio)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.34."""
+        _equation: str = (
+            r"\min\left(\frac{0.5}{a_{cs,0}} \cdot \left(e_p + \frac{d}{3}\right) \cdot "
+            r"\frac{A_c}{b_w \cdot z}, 0.18 \cdot \frac{A_c}{b_w \cdot z}\right)"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_{cs,0}": f"{self.a_cs_0:.{n}f}",
+                r"e_p": f"{self.e_p:.{n}f}",
+                r"{d}": "{" + f"{self.d:.{n}f}" + "}",
+                r"A_c": f"{self.a_c:.{n}f}",
+                r"b_w": f"{self.b_w:.{n}f}",
+                r"z": f"{self.z:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_{cs,0}": rf"{self.a_cs_0:.{n}f} \ mm",
+                r"e_p": rf"{self.e_p:.{n}f} \ mm",
+                r"{d}": "{" + rf"{self.d:.{n}f} \ mm" + "}",
+                r"A_c": rf"{self.a_c:.{n}f} \ mm^2",
+                r"b_w": rf"{self.b_w:.{n}f} \ mm",
+                r"z": rf"{self.z:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"k_1",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_34.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_34.py
@@ -4,7 +4,7 @@ from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
 from blueprints.type_alias import DIMENSIONLESS, MM, MM2
-from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+from blueprints.validations import raise_if_less_or_equal_to_zero
 
 
 class Form8Dot34FactorK1(Formula):
@@ -55,8 +55,14 @@ class Form8Dot34FactorK1(Formula):
     @staticmethod
     def _evaluate(a_cs_0: MM, e_p: MM, d: MM, a_c: MM2, b_w: MM, z: MM) -> DIMENSIONLESS:
         """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(d=d, a_c=a_c)
-        raise_if_less_or_equal_to_zero(a_cs_0=a_cs_0, b_w=b_w, z=z)
+        # Zero is refused for all of these. For the ones that sit in a denominator that is a reading of the
+        # standard. For a_cs_0 it is also a reading, one step removed: Formula (8.30) defines the effective
+        # shear span as at least the effective depth, so it cannot be zero. For the rest it is an addition made
+        # here, so that the same quantity is not admitted in one formula of this clause and refused in the next.
+        # The eccentricity e_p is deliberately not guarded: the standard defines it as positive towards the
+        # tensile side, so a negative value is ordinary input and may drive the result below zero, which the
+        # standard does not bound.
+        raise_if_less_or_equal_to_zero(a_cs_0=a_cs_0, b_w=b_w, z=z, d=d, a_c=a_c)
 
         ratio = a_c / (b_w * z)
         return min((0.5 / a_cs_0) * (e_p + d / 3) * ratio, 0.18 * ratio)

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_35.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_35.py
@@ -42,8 +42,12 @@ class Form8Dot35MaximumShearStressResistance(Formula):
     @staticmethod
     def _evaluate(tau_rdc_0: MPA, a_cs_0: MM, d: MM) -> MPA:
         """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(tau_rdc_0=tau_rdc_0, a_cs_0=a_cs_0)
-        raise_if_less_or_equal_to_zero(d=d)
+        # Zero is refused for all of these. For the ones that sit in a denominator that is a reading of the
+        # standard. For a_cs_0 it is also a reading, one step removed: Formula (8.30) defines the effective
+        # shear span as at least the effective depth, so it cannot be zero. For the rest it is an addition made
+        # here, so that the same quantity is not admitted in one formula of this clause and refused in the next.
+        raise_if_negative(tau_rdc_0=tau_rdc_0)
+        raise_if_less_or_equal_to_zero(a_cs_0=a_cs_0, d=d)
 
         return min(2.15 * tau_rdc_0 * (a_cs_0 / d) ** (1 / 6), 2.7 * tau_rdc_0)
 

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_35.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_35.py
@@ -1,0 +1,82 @@
+"""Formula 8.35 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot35MaximumShearStressResistance(Formula):
+    """Class representing formula 8.35 for the calculation of the upper bound of the shear stress resistance
+    used in Formula (8.32).
+    """
+
+    label = "8.35"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, tau_rdc_0: MPA, a_cs_0: MM, d: MM) -> None:
+        r"""[$\tau_{Rdc,max}$] Maximum shear stress resistance [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (5) - Formula (8.35)
+
+        The printed upper bound of [$2.7 \cdot \tau_{Rdc,0}$] is implemented as a minimum.
+
+        Parameters
+        ----------
+        tau_rdc_0 : MPA
+            [$\tau_{Rdc,0}$] Design value of the shear stress resistance without the effect of compressive
+            normal forces according to Formula (8.33), see Form8Dot33ShearStressResistanceWithoutAxialForce [$MPa$].
+        a_cs_0 : MM
+            [$a_{cs,0}$] Effective shear span determined according to Formula (8.30), without considering in
+            [$M_{Ed}$] and [$V_{Ed}$] the effect of prestressing or external load that produces the compressive
+            axial force [$mm$].
+        d : MM
+            [$d$] Effective depth [$mm$].
+        """
+        super().__init__()
+        self.tau_rdc_0 = tau_rdc_0
+        self.a_cs_0 = a_cs_0
+        self.d = d
+
+    @staticmethod
+    def _evaluate(tau_rdc_0: MPA, a_cs_0: MM, d: MM) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(tau_rdc_0=tau_rdc_0, a_cs_0=a_cs_0)
+        raise_if_less_or_equal_to_zero(d=d)
+
+        return min(2.15 * tau_rdc_0 * (a_cs_0 / d) ** (1 / 6), 2.7 * tau_rdc_0)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.35."""
+        _equation: str = (
+            r"\min\left(2.15 \cdot \tau_{Rdc,0} \cdot \left(\frac{a_{cs,0}}{d}\right)^{\frac{1}{6}}, "
+            r"2.7 \cdot \tau_{Rdc,0}\right)"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Rdc,0}": f"{self.tau_rdc_0:.{n}f}",
+                r"a_{cs,0}": f"{self.a_cs_0:.{n}f}",
+                r"{d}": "{" + f"{self.d:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Rdc,0}": rf"{self.tau_rdc_0:.{n}f} \ MPa",
+                r"a_{cs,0}": rf"{self.a_cs_0:.{n}f} \ mm",
+                r"{d}": "{" + rf"{self.d:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rdc,max}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -94,9 +94,9 @@ Total of 602 formulas present.
 |      8.30      |        :x:         |         |                                                                    |
 |      8.31      |        :x:         |         |                                                                    |
 |      8.32      |        :x:         |         |                                                                    |
-|      8.33      |        :x:         |         |                                                                    |
-|      8.34      |        :x:         |         |                                                                    |
-|      8.35      |        :x:         |         |                                                                    |
+|      8.33      | :heavy_check_mark: |         | Form8Dot33ShearStressResistanceWithoutAxialForce                   |
+|      8.34      | :heavy_check_mark: |         | Form8Dot34FactorK1                                                 |
+|      8.35      | :heavy_check_mark: |         | Form8Dot35MaximumShearStressResistance                             |
 |      8.36      |        :x:         |         |                                                                    |
 |      8.37      |        :x:         |         |                                                                    |
 |      8.38      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_33.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_33.py
@@ -1,0 +1,90 @@
+"""Testing formula 8.33 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_33 import (
+    Form8Dot33ShearStressResistanceWithoutAxialForce,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot33ShearStressResistanceWithoutAxialForce:
+    """Validation for formula 8.33 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        gamma_v = 1.4
+        rho_l = 0.01
+        f_ck = 30.0
+        d_dg = 32.0
+        d = 500.0
+
+        # Object to test
+        formula = Form8Dot33ShearStressResistanceWithoutAxialForce(gamma_v=gamma_v, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d=d)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.585935  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_without_reinforcement(self) -> None:
+        """Tests the evaluation of the result when there is no longitudinal reinforcement."""
+        formula = Form8Dot33ShearStressResistanceWithoutAxialForce(gamma_v=1.4, rho_l=0.0, f_ck=30.0, d_dg=32.0, d=500.0)
+
+        assert formula == pytest.approx(expected=0.0, abs=1e-12)
+
+    @pytest.mark.parametrize(
+        ("gamma_v", "rho_l", "f_ck", "d_dg", "d"),
+        [
+            (1.4, -0.01, 30.0, 32.0, 500.0),  # rho_l is negative
+            (1.4, 0.01, -30.0, 32.0, 500.0),  # f_ck is negative
+            (1.4, 0.01, 30.0, -32.0, 500.0),  # d_dg is negative
+            (-1.4, 0.01, 30.0, 32.0, 500.0),  # gamma_v is negative
+            (0.0, 0.01, 30.0, 32.0, 500.0),  # gamma_v is zero
+            (1.4, 0.01, 30.0, 32.0, -500.0),  # d is negative
+            (1.4, 0.01, 30.0, 32.0, 0.0),  # d is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, gamma_v: float, rho_l: float, f_ck: float, d_dg: float, d: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot33ShearStressResistanceWithoutAxialForce(gamma_v=gamma_v, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d=d)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Rdc,0} = \frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot "
+                r"\frac{d_{dg}}{d}\right)^{\frac{1}{3}} = \frac{0.66}{1.400} \cdot \left(100 \cdot 0.010 \cdot 30.000 \cdot "
+                r"\frac{32.000}{500.000}\right)^{\frac{1}{3}} = 0.586 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Rdc,0} = \frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot "
+                r"\frac{d_{dg}}{d}\right)^{\frac{1}{3}} = \frac{0.66}{1.400} \cdot \left(100 \cdot 0.010 \cdot 30.000 \ MPa \cdot "
+                r"\frac{32.000 \ mm}{500.000 \ mm}\right)^{\frac{1}{3}} = 0.586 \ MPa",
+            ),
+            ("short", r"\tau_{Rdc,0} = 0.586 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        gamma_v = 1.4
+        rho_l = 0.01
+        f_ck = 30.0
+        d_dg = 32.0
+        d = 500.0
+
+        # Object to test
+        latex = Form8Dot33ShearStressResistanceWithoutAxialForce(gamma_v=gamma_v, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d=d).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_34.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_34.py
@@ -1,0 +1,120 @@
+"""Testing formula 8.34 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_34 import Form8Dot34FactorK1
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot34FactorK1:
+    """Validation for formula 8.34 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression governs."""
+        # Example values
+        a_cs_0 = 1333.333333
+        e_p = 100.0
+        d = 500.0
+        a_c = 180000.0
+        b_w = 300.0
+        z = 450.0
+
+        # Object to test
+        formula = Form8Dot34FactorK1(a_cs_0=a_cs_0, e_p=e_p, d=d, a_c=a_c, b_w=b_w, z=z)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.133333  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_upper_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the printed upper bound governs."""
+        # Example values, with a short shear span so the expression exceeds the bound
+        formula = Form8Dot34FactorK1(a_cs_0=500.0, e_p=100.0, d=500.0, a_c=180000.0, b_w=300.0, z=450.0)
+
+        # Expected result, manually calculated: 0.18 * 180000 / (300 * 450)
+        manually_calculated_result = 0.24  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_with_negative_eccentricity(self) -> None:
+        """Tests that an eccentricity on the compressive side, which the standard defines as negative, is accepted."""
+        formula = Form8Dot34FactorK1(a_cs_0=1333.333333, e_p=-100.0, d=500.0, a_c=180000.0, b_w=300.0, z=450.0)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.033333  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_can_return_a_negative_factor(self) -> None:
+        """Tests that no lower bound is imposed, since the standard prints none.
+
+        For an eccentricity more negative than minus one third of the effective depth, the bracket turns
+        negative and so does the factor.
+        """
+        formula = Form8Dot34FactorK1(a_cs_0=1333.333333, e_p=-300.0, d=500.0, a_c=180000.0, b_w=300.0, z=450.0)
+
+        # Expected result, manually calculated: (0.5 / 1333.333333) * (-300 + 500 / 3) * (180000 / 135000)
+        manually_calculated_result = -0.066667  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_cs_0", "e_p", "d", "a_c", "b_w", "z"),
+        [
+            (1333.333333, 100.0, -500.0, 180000.0, 300.0, 450.0),  # d is negative
+            (1333.333333, 100.0, 500.0, -180000.0, 300.0, 450.0),  # a_c is negative
+            (-1333.333333, 100.0, 500.0, 180000.0, 300.0, 450.0),  # a_cs_0 is negative
+            (0.0, 100.0, 500.0, 180000.0, 300.0, 450.0),  # a_cs_0 is zero
+            (1333.333333, 100.0, 500.0, 180000.0, -300.0, 450.0),  # b_w is negative
+            (1333.333333, 100.0, 500.0, 180000.0, 0.0, 450.0),  # b_w is zero
+            (1333.333333, 100.0, 500.0, 180000.0, 300.0, -450.0),  # z is negative
+            (1333.333333, 100.0, 500.0, 180000.0, 300.0, 0.0),  # z is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_cs_0: float, e_p: float, d: float, a_c: float, b_w: float, z: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot34FactorK1(a_cs_0=a_cs_0, e_p=e_p, d=d, a_c=a_c, b_w=b_w, z=z)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"k_1 = \min\left(\frac{0.5}{a_{cs,0}} \cdot \left(e_p + \frac{d}{3}\right) \cdot "
+                r"\frac{A_c}{b_w \cdot z}, 0.18 \cdot \frac{A_c}{b_w \cdot z}\right) = "
+                r"\min\left(\frac{0.5}{1333.333} \cdot \left(100.000 + \frac{500.000}{3}\right) \cdot "
+                r"\frac{180000.000}{300.000 \cdot 450.000}, 0.18 \cdot \frac{180000.000}{300.000 \cdot 450.000}\right) = 0.133 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"k_1 = \min\left(\frac{0.5}{a_{cs,0}} \cdot \left(e_p + \frac{d}{3}\right) \cdot "
+                r"\frac{A_c}{b_w \cdot z}, 0.18 \cdot \frac{A_c}{b_w \cdot z}\right) = "
+                r"\min\left(\frac{0.5}{1333.333 \ mm} \cdot \left(100.000 \ mm + \frac{500.000 \ mm}{3}\right) \cdot "
+                r"\frac{180000.000 \ mm^2}{300.000 \ mm \cdot 450.000 \ mm}, 0.18 \cdot "
+                r"\frac{180000.000 \ mm^2}{300.000 \ mm \cdot 450.000 \ mm}\right) = 0.133 \ -",
+            ),
+            ("short", r"k_1 = 0.133 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_cs_0 = 1333.333333
+        e_p = 100.0
+        d = 500.0
+        a_c = 180000.0
+        b_w = 300.0
+        z = 450.0
+
+        # Object to test
+        latex = Form8Dot34FactorK1(a_cs_0=a_cs_0, e_p=e_p, d=d, a_c=a_c, b_w=b_w, z=z).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_34.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_34.py
@@ -3,7 +3,7 @@
 import pytest
 
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_34 import Form8Dot34FactorK1
-from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+from blueprints.validations import LessOrEqualToZeroError
 
 
 class TestForm8Dot34FactorK1:
@@ -63,7 +63,9 @@ class TestForm8Dot34FactorK1:
         ("a_cs_0", "e_p", "d", "a_c", "b_w", "z"),
         [
             (1333.333333, 100.0, -500.0, 180000.0, 300.0, 450.0),  # d is negative
+            (1333.333333, 100.0, 0.0, 180000.0, 300.0, 450.0),  # d is zero, which is not a cross-section
             (1333.333333, 100.0, 500.0, -180000.0, 300.0, 450.0),  # a_c is negative
+            (1333.333333, 100.0, 500.0, 0.0, 300.0, 450.0),  # a_c is zero
             (-1333.333333, 100.0, 500.0, 180000.0, 300.0, 450.0),  # a_cs_0 is negative
             (0.0, 100.0, 500.0, 180000.0, 300.0, 450.0),  # a_cs_0 is zero
             (1333.333333, 100.0, 500.0, 180000.0, -300.0, 450.0),  # b_w is negative
@@ -72,9 +74,9 @@ class TestForm8Dot34FactorK1:
             (1333.333333, 100.0, 500.0, 180000.0, 300.0, 0.0),  # z is zero
         ],
     )
-    def test_raise_error_when_invalid_values_are_given(self, a_cs_0: float, e_p: float, d: float, a_c: float, b_w: float, z: float) -> None:
-        """Test invalid values."""
-        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+    def test_raise_error_when_less_or_equal_to_zero(self, a_cs_0: float, e_p: float, d: float, a_c: float, b_w: float, z: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
             Form8Dot34FactorK1(a_cs_0=a_cs_0, e_p=e_p, d=d, a_c=a_c, b_w=b_w, z=z)
 
     @pytest.mark.parametrize(

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_35.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_35.py
@@ -1,0 +1,87 @@
+"""Testing formula 8.35 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_35 import (
+    Form8Dot35MaximumShearStressResistance,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot35MaximumShearStressResistance:
+    """Validation for formula 8.35 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression governs."""
+        # Example values
+        tau_rdc_0 = 0.585935
+        a_cs_0 = 1333.333333
+        d = 500.0
+
+        # Object to test
+        formula = Form8Dot35MaximumShearStressResistance(tau_rdc_0=tau_rdc_0, a_cs_0=a_cs_0, d=d)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1.483483  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_upper_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the printed upper bound governs."""
+        # Example values, with a shear span long enough for the expression to exceed 2.7 times tau_rdc_0
+        formula = Form8Dot35MaximumShearStressResistance(tau_rdc_0=0.585935, a_cs_0=2500.0, d=500.0)
+
+        # Expected result, manually calculated: 2.7 * 0.585935
+        manually_calculated_result = 1.582025  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("tau_rdc_0", "a_cs_0", "d"),
+        [
+            (-0.585935, 1333.333333, 500.0),  # tau_rdc_0 is negative
+            (0.585935, -1333.333333, 500.0),  # a_cs_0 is negative
+            (0.585935, 1333.333333, -500.0),  # d is negative
+            (0.585935, 1333.333333, 0.0),  # d is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, tau_rdc_0: float, a_cs_0: float, d: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot35MaximumShearStressResistance(tau_rdc_0=tau_rdc_0, a_cs_0=a_cs_0, d=d)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Rdc,max} = \min\left(2.15 \cdot \tau_{Rdc,0} \cdot \left(\frac{a_{cs,0}}{d}\right)^{\frac{1}{6}}, "
+                r"2.7 \cdot \tau_{Rdc,0}\right) = \min\left(2.15 \cdot 0.586 \cdot "
+                r"\left(\frac{1333.333}{500.000}\right)^{\frac{1}{6}}, 2.7 \cdot 0.586\right) = 1.483 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Rdc,max} = \min\left(2.15 \cdot \tau_{Rdc,0} \cdot \left(\frac{a_{cs,0}}{d}\right)^{\frac{1}{6}}, "
+                r"2.7 \cdot \tau_{Rdc,0}\right) = \min\left(2.15 \cdot 0.586 \ MPa \cdot "
+                r"\left(\frac{1333.333 \ mm}{500.000 \ mm}\right)^{\frac{1}{6}}, 2.7 \cdot 0.586 \ MPa\right) = 1.483 \ MPa",
+            ),
+            ("short", r"\tau_{Rdc,max} = 1.483 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        tau_rdc_0 = 0.585935
+        a_cs_0 = 1333.333333
+        d = 500.0
+
+        # Object to test
+        latex = Form8Dot35MaximumShearStressResistance(tau_rdc_0=tau_rdc_0, a_cs_0=a_cs_0, d=d).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_35.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_35.py
@@ -39,16 +39,21 @@ class TestForm8Dot35MaximumShearStressResistance:
     @pytest.mark.parametrize(
         ("tau_rdc_0", "a_cs_0", "d"),
         [
-            (-0.585935, 1333.333333, 500.0),  # tau_rdc_0 is negative
             (0.585935, -1333.333333, 500.0),  # a_cs_0 is negative
+            (0.585935, 0.0, 500.0),  # a_cs_0 is zero, which Formula (8.34) also refuses
             (0.585935, 1333.333333, -500.0),  # d is negative
             (0.585935, 1333.333333, 0.0),  # d is zero
         ],
     )
-    def test_raise_error_when_invalid_values_are_given(self, tau_rdc_0: float, a_cs_0: float, d: float) -> None:
-        """Test invalid values."""
-        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+    def test_raise_error_when_less_or_equal_to_zero(self, tau_rdc_0: float, a_cs_0: float, d: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
             Form8Dot35MaximumShearStressResistance(tau_rdc_0=tau_rdc_0, a_cs_0=a_cs_0, d=d)
+
+    def test_raise_error_when_negative_values_are_given(self) -> None:
+        """The shear stress resistance it scales is the one quantity here that may be zero."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot35MaximumShearStressResistance(tau_rdc_0=-0.585935, a_cs_0=1333.333333, d=500.0)
 
     @pytest.mark.parametrize(
         ("representation", "expected"),


### PR DESCRIPTION
## Description

Implements Formulas (8.33), (8.34) and (8.35) of clause 8.2.2(5), the three quantities that Formula (8.32) combines for the approach that considers the effect of compressive normal forces:

- `Form8Dot33ShearStressResistanceWithoutAxialForce` for (8.33), the shear stress resistance before the axial force term.
- `Form8Dot34FactorK1` for (8.34), the factor by which the normal stress is weighted.
- `Form8Dot35MaximumShearStressResistance` for (8.35), the upper bound used in (8.32).

Formula (8.32) itself follows in a separate pull request, once these three exist to refer to.

Points worth a reviewer's attention:

- **The upper bound in (8.34) is not a plain 0.18.** It carries the same `A_c / (b_w * z)` factor as the expression, so for the geometry used in the tests the bound is 0.24, not 0.18. Clipping at 0.18 would look reasonable and be wrong; there is a test for the case where the bound governs.
- **`e_p` is signed and may be negative.** The standard defines it as positive towards the tensile side, so an eccentricity on the compression side is a valid input. It has no sign guard. The standard also prints no lower bound on `k_1`, so an eccentricity below `-d/3` yields a negative factor. Both are tested rather than suppressed.
- (8.33) is the expression of (8.27) without its lower bound. It is implemented separately rather than shared, because (8.27) is still in review in #1088. Once that lands, folding (8.27) into `max(Form8Dot33(...), tau_rdc_min)` would remove the duplication, and I am happy to do that as a follow up if the reviewer prefers it.
- Both printed bounds are implemented as a minimum, matching the treatment of (8.27) and (8.30).
- The class name for (8.33) deserves a second opinion. The standard calls `tau_Rdc,0` simply "the design value of the shear stress resistance", but that name is already taken by (8.27), so a qualifier was needed. If `WithoutAxialForce` reads wrong, say so and I will rename it.

Contributes to #1083

## Formulas as implemented

**Formula (8.33)**, `Form8Dot33ShearStressResistanceWithoutAxialForce`

`equation`

$$
\tau_{Rdc,0} = \frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d}\right)^{\frac{1}{3}}
$$

`complete`

$$
\tau_{Rdc,0} = \frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d}\right)^{\frac{1}{3}} = \frac{0.66}{1.400} \cdot \left(100 \cdot 0.010 \cdot 30.000 \cdot \frac{32.000}{500.000}\right)^{\frac{1}{3}} = 0.586 \ MPa
$$

`complete_with_units`

$$
\tau_{Rdc,0} = \frac{0.66}{\gamma_V} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d}\right)^{\frac{1}{3}} = \frac{0.66}{1.400} \cdot \left(100 \cdot 0.010 \cdot 30.000 \ MPa \cdot \frac{32.000 \ mm}{500.000 \ mm}\right)^{\frac{1}{3}} = 0.586 \ MPa
$$

**Formula (8.34)**, `Form8Dot34FactorK1`

`equation`

$$
k_1 = \min\left(\frac{0.5}{a_{cs,0}} \cdot \left(e_p + \frac{d}{3}\right) \cdot \frac{A_c}{b_w \cdot z}, 0.18 \cdot \frac{A_c}{b_w \cdot z}\right)
$$

`complete`

$$
k_1 = \min\left(\frac{0.5}{a_{cs,0}} \cdot \left(e_p + \frac{d}{3}\right) \cdot \frac{A_c}{b_w \cdot z}, 0.18 \cdot \frac{A_c}{b_w \cdot z}\right) = \min\left(\frac{0.5}{1333.333} \cdot \left(100.000 + \frac{500.000}{3}\right) \cdot \frac{180000.000}{300.000 \cdot 450.000}, 0.18 \cdot \frac{180000.000}{300.000 \cdot 450.000}\right) = 0.133 \ -
$$

`complete_with_units`

$$
k_1 = \min\left(\frac{0.5}{a_{cs,0}} \cdot \left(e_p + \frac{d}{3}\right) \cdot \frac{A_c}{b_w \cdot z}, 0.18 \cdot \frac{A_c}{b_w \cdot z}\right) = \min\left(\frac{0.5}{1333.333 \ mm} \cdot \left(100.000 \ mm + \frac{500.000 \ mm}{3}\right) \cdot \frac{180000.000 \ mm^2}{300.000 \ mm \cdot 450.000 \ mm}, 0.18 \cdot \frac{180000.000 \ mm^2}{300.000 \ mm \cdot 450.000 \ mm}\right) = 0.133 \ -
$$

**Formula (8.35)**, `Form8Dot35MaximumShearStressResistance`

`equation`

$$
\tau_{Rdc,max} = \min\left(2.15 \cdot \tau_{Rdc,0} \cdot \left(\frac{a_{cs,0}}{d}\right)^{\frac{1}{6}}, 2.7 \cdot \tau_{Rdc,0}\right)
$$

`complete`

$$
\tau_{Rdc,max} = \min\left(2.15 \cdot \tau_{Rdc,0} \cdot \left(\frac{a_{cs,0}}{d}\right)^{\frac{1}{6}}, 2.7 \cdot \tau_{Rdc,0}\right) = \min\left(2.15 \cdot 0.586 \cdot \left(\frac{1333.333}{500.000}\right)^{\frac{1}{6}}, 2.7 \cdot 0.586\right) = 1.483 \ MPa
$$

`complete_with_units`

$$
\tau_{Rdc,max} = \min\left(2.15 \cdot \tau_{Rdc,0} \cdot \left(\frac{a_{cs,0}}{d}\right)^{\frac{1}{6}}, 2.7 \cdot \tau_{Rdc,0}\right) = \min\left(2.15 \cdot 0.586 \ MPa \cdot \left(\frac{1333.333 \ mm}{500.000 \ mm}\right)^{\frac{1}{6}}, 2.7 \cdot 0.586 \ MPa\right) = 1.483 \ MPa
$$

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Tests for both governing branches of (8.34) and (8.35), for a negative eccentricity, for a negative factor, and every raise
- [x] Docstrings added, with variable descriptions taken from the standard
- [x] Documentation table updated with the class names
- [x] `blueprints check` passes: lint, format, type check, and 100% coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented Eurocode FprEN 1992-1-1:2023 formulas **8.33–8.35** for shear stress resistance and related factors, including input validation and accurate result capping where applicable.
  * Added **symbolic, numeric, and unit-aware LaTeX** rendering for formulas **8.33–8.35**.
* **Documentation**
  * Updated the Eurocode formula guide to mark **8.33–8.35** as completed and filled in the associated entries.
* **Tests**
  * Added automated tests covering evaluation, error handling, and LaTeX output for **8.33–8.35**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->