### PR TITLE
feat: add formula 8.32 from FprEN 1992-1-1:2023 clause 8.2.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_32.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_32.py
@@ -82,6 +82,17 @@ class Form8Dot32DesignShearStressResistanceWithNormalForce(Formula):
         """Evaluates the formula, for more information see the __init__ method."""
         raise_if_negative(tau_rdc_0=tau_rdc_0, tau_rdc_min=tau_rdc_min, tau_rdc_max=tau_rdc_max)
 
+        # The two bounds come from different formulas, (8.20) and (8.35), and nothing ties them together.
+        # (8.20) does not depend on the reinforcement ratio while (8.35) does, so for a lightly reinforced
+        # member the maximum can fall below the minimum and the printed chain has no solution at all. Clamping
+        # anyway would return one of the two bounds and quietly break the relation this formula prints, so the
+        # combination is refused instead. The standard says nothing about it; this is a decision taken here.
+        if tau_rdc_min > tau_rdc_max:
+            raise ValueError(
+                f"The minimum shear stress resistance of {tau_rdc_min} MPa exceeds the maximum of {tau_rdc_max} MPa, "
+                f"so no value can satisfy Formula (8.32). Check the inputs of Formulas (8.20) and (8.35)."
+            )
+
         return min(max(tau_rdc_0 - k_1 * sigma_cp, tau_rdc_min), tau_rdc_max)
 
     def latex(self, n: int = 3) -> LatexFormula:

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_32.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_32.py
@@ -42,10 +42,21 @@ class Form8Dot32DesignShearStressResistanceWithNormalForce(Formula):
             normal forces according to Formula (8.33), see Form8Dot33ShearStressResistanceWithoutAxialForce [$MPa$].
         k_1 : DIMENSIONLESS
             [$k_1$] Factor according to Formula (8.34), see Form8Dot34FactorK1, unless the National Annex gives
-            another value. The standard prints no lower bound on it, so a negative value is valid [$-$].
+            another value. It is not required to be positive and is not guarded here: Formula (8.34) prints only
+            an upper bound, and its eccentricity [$e_p$] is defined as positive towards the tensile side, so a
+            tendon eccentric towards the compression side gives a negative [$e_p$] and can drive [$k_1$] below
+            zero [$-$].
         sigma_cp : MPA
             [$\sigma_{cp}$] Normal stress, defined by the standard as [$N_{Ed} / A_c$] with [$A_c$] the area of
-            the concrete cross-section. Its sign carries meaning and is used as given [$MPa$].
+            the concrete cross-section. **Compression is negative.** The standard does not say so anywhere near
+            this formula, but the printed minus sign settles it: compression has to raise the shear stress
+            resistance, and with a positive [$k_1$] the term [$- k_1 \cdot \sigma_{cp}$] only does that for a
+            negative [$\sigma_{cp}$]. It also follows from [$N_{Ed}$] itself, which this clause treats as
+            positive in tension, as Formula (8.31) does.
+
+            Note that the sign of this term flipped between the two generations of the code. EN 1992-1-1:2004
+            prints [$+ k_1 \cdot \sigma_{cp}$] with compression positive, so a value carried over from a
+            calculation to that code has the wrong sign here [$MPa$].
         tau_rdc_min : MPA
             [$\tau_{Rdc,min}$] Minimum shear stress resistance according to Formula (8.20), see
             Form8Dot20MinimumShearStressResistance [$MPa$].
@@ -81,7 +92,7 @@ class Form8Dot32DesignShearStressResistanceWithNormalForce(Formula):
             replacements={
                 r"\tau_{Rdc,0}": f"{self.tau_rdc_0:.{n}f}",
                 r"k_1": f"{self.k_1:.{n}f}",
-                r"\sigma_{cp}": f"{self.sigma_cp:.{n}f}",
+                r"\sigma_{cp}": r"\left(" + f"{self.sigma_cp:.{n}f}" + r"\right)",
                 r"\tau_{Rdc,min}": f"{self.tau_rdc_min:.{n}f}",
                 r"\tau_{Rdc,max}": f"{self.tau_rdc_max:.{n}f}",
             },
@@ -92,15 +103,20 @@ class Form8Dot32DesignShearStressResistanceWithNormalForce(Formula):
             replacements={
                 r"\tau_{Rdc,0}": rf"{self.tau_rdc_0:.{n}f} \ MPa",
                 r"k_1": f"{self.k_1:.{n}f}",
-                r"\sigma_{cp}": rf"{self.sigma_cp:.{n}f} \ MPa",
+                r"\sigma_{cp}": r"\left(" + rf"{self.sigma_cp:.{n}f} \ MPa" + r"\right)",
                 r"\tau_{Rdc,min}": rf"{self.tau_rdc_min:.{n}f} \ MPa",
                 r"\tau_{Rdc,max}": rf"{self.tau_rdc_max:.{n}f} \ MPa",
             },
             unique_symbol_check=False,
         )
+        # The value of the expression before the two bounds are applied. The line above already shows the
+        # arithmetic, so what this adds is whether a bound was active: it differs from the result exactly then.
+        _intermediate: str = f"{self.tau_rdc_0 - self.k_1 * self.sigma_cp:.{n}f}"
+
         return LatexFormula(
             return_symbol=r"\tau_{Rd,c}",
             result=f"{self:.{n}f}",
+            intermediate_result=_intermediate,
             equation=_equation,
             numeric_equation=_numeric_equation,
             numeric_equation_with_units=_numeric_equation_with_units,

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_32.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_32.py
@@ -1,0 +1,109 @@
+"""Formula 8.32 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot32DesignShearStressResistanceWithNormalForce(Formula):
+    """Class representing formula 8.32 for the calculation of the design value of the shear stress resistance
+    of members without shear reinforcement, considering the effect of compressive normal forces.
+    """
+
+    label = "8.32"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        tau_rdc_0: MPA,
+        k_1: DIMENSIONLESS,
+        sigma_cp: MPA,
+        tau_rdc_min: MPA,
+        tau_rdc_max: MPA,
+    ) -> None:
+        r"""[$\tau_{Rd,c}$] Design value of the shear stress resistance, considering the effect of compressive
+        normal forces [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (5) - Formula (8.32)
+
+        The standard offers this as an alternative to Formula (8.27) in combination with Formula (8.31). It is
+        printed as a single expression enclosed by a lower and an upper bound, which is implemented as a
+        maximum against [$\tau_{Rdc,min}$] followed by a minimum against [$\tau_{Rdc,max}$]. That order only
+        matters for the degenerate input where the lower bound exceeds the upper one, in which case the
+        upper bound wins. The standard assumes this cannot happen and prints no rule for it, so it is
+        defined here rather than rejected.
+
+        Parameters
+        ----------
+        tau_rdc_0 : MPA
+            [$\tau_{Rdc,0}$] Design value of the shear stress resistance without the effect of compressive
+            normal forces according to Formula (8.33), see Form8Dot33ShearStressResistanceWithoutAxialForce [$MPa$].
+        k_1 : DIMENSIONLESS
+            [$k_1$] Factor according to Formula (8.34), see Form8Dot34FactorK1, unless the National Annex gives
+            another value. The standard prints no lower bound on it, so a negative value is valid [$-$].
+        sigma_cp : MPA
+            [$\sigma_{cp}$] Normal stress, defined by the standard as [$N_{Ed} / A_c$] with [$A_c$] the area of
+            the concrete cross-section. Its sign carries meaning and is used as given [$MPa$].
+        tau_rdc_min : MPA
+            [$\tau_{Rdc,min}$] Minimum shear stress resistance according to Formula (8.20), see
+            Form8Dot20MinimumShearStressResistance [$MPa$].
+        tau_rdc_max : MPA
+            [$\tau_{Rdc,max}$] Maximum shear stress resistance according to Formula (8.35), see
+            Form8Dot35MaximumShearStressResistance [$MPa$].
+        """
+        super().__init__()
+        self.tau_rdc_0 = tau_rdc_0
+        self.k_1 = k_1
+        self.sigma_cp = sigma_cp
+        self.tau_rdc_min = tau_rdc_min
+        self.tau_rdc_max = tau_rdc_max
+
+    @staticmethod
+    def _evaluate(
+        tau_rdc_0: MPA,
+        k_1: DIMENSIONLESS,
+        sigma_cp: MPA,
+        tau_rdc_min: MPA,
+        tau_rdc_max: MPA,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(tau_rdc_0=tau_rdc_0, tau_rdc_min=tau_rdc_min, tau_rdc_max=tau_rdc_max)
+
+        return min(max(tau_rdc_0 - k_1 * sigma_cp, tau_rdc_min), tau_rdc_max)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.32."""
+        _equation: str = r"\min\left(\max\left(\tau_{Rdc,0} - k_1 \cdot \sigma_{cp}, \tau_{Rdc,min}\right), \tau_{Rdc,max}\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Rdc,0}": f"{self.tau_rdc_0:.{n}f}",
+                r"k_1": f"{self.k_1:.{n}f}",
+                r"\sigma_{cp}": f"{self.sigma_cp:.{n}f}",
+                r"\tau_{Rdc,min}": f"{self.tau_rdc_min:.{n}f}",
+                r"\tau_{Rdc,max}": f"{self.tau_rdc_max:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Rdc,0}": rf"{self.tau_rdc_0:.{n}f} \ MPa",
+                r"k_1": f"{self.k_1:.{n}f}",
+                r"\sigma_{cp}": rf"{self.sigma_cp:.{n}f} \ MPa",
+                r"\tau_{Rdc,min}": rf"{self.tau_rdc_min:.{n}f} \ MPa",
+                r"\tau_{Rdc,max}": rf"{self.tau_rdc_max:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rd,c}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -93,7 +93,7 @@ Total of 602 formulas present.
 |      8.29      |        :x:         |         |                                                                    |
 |      8.30      |        :x:         |         |                                                                    |
 |      8.31      |        :x:         |         |                                                                    |
-|      8.32      |        :x:         |         |                                                                    |
+|      8.32      | :heavy_check_mark: |         | Form8Dot32DesignShearStressResistanceWithNormalForce               |
 |      8.33      |        :x:         |         |                                                                    |
 |      8.34      |        :x:         |         |                                                                    |
 |      8.35      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_32.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_32.py
@@ -57,6 +57,11 @@ class TestForm8Dot32DesignShearStressResistanceWithNormalForce:
     def test_evaluation_with_a_negative_factor(self) -> None:
         """Tests that a negative factor, which Formula (8.34) can produce, is accepted and used as such.
 
+        Formula (8.34) prints only an upper bound on the factor, and its eccentricity is defined as positive
+        towards the tensile side, so a tendon eccentric towards the compression side gives a negative
+        eccentricity and can drive the factor below zero. Requiring it to be non-negative here would refuse
+        input that the sibling formula in the same clause can legitimately produce.
+
         The inputs are chosen so the result stays between both bounds, otherwise the clamping would hide
         whether the sign of the factor was handled at all.
         """
@@ -92,14 +97,14 @@ class TestForm8Dot32DesignShearStressResistanceWithNormalForce:
             (
                 "complete",
                 r"\tau_{Rd,c} = \min\left(\max\left(\tau_{Rdc,0} - k_1 \cdot \sigma_{cp}, \tau_{Rdc,min}\right), "
-                r"\tau_{Rdc,max}\right) = \min\left(\max\left(0.586 - 0.133 \cdot -2.000, 0.522\right), "
-                r"1.483\right) = 0.853 \ MPa",
+                r"\tau_{Rdc,max}\right) = \min\left(\max\left(0.586 - 0.133 \cdot \left(-2.000\right), 0.522\right), "
+                r"1.483\right) = 0.853 = 0.853 \ MPa",
             ),
             (
                 "complete_with_units",
                 r"\tau_{Rd,c} = \min\left(\max\left(\tau_{Rdc,0} - k_1 \cdot \sigma_{cp}, \tau_{Rdc,min}\right), "
-                r"\tau_{Rdc,max}\right) = \min\left(\max\left(0.586 \ MPa - 0.133 \cdot -2.000 \ MPa, "
-                r"0.522 \ MPa\right), 1.483 \ MPa\right) = 0.853 \ MPa",
+                r"\tau_{Rdc,max}\right) = \min\left(\max\left(0.586 \ MPa - 0.133 \cdot \left(-2.000 \ MPa\right), "
+                r"0.522 \ MPa\right), 1.483 \ MPa\right) = 0.853 = 0.853 \ MPa",
             ),
             ("short", r"\tau_{Rd,c} = 0.853 \ MPa"),
         ],
@@ -125,3 +130,22 @@ class TestForm8Dot32DesignShearStressResistanceWithNormalForce:
         }
 
         assert expected == actual[representation], f"{representation} representation failed."
+
+    def test_intermediate_result_shows_whether_a_bound_was_active(self) -> None:
+        """The intermediate result is the expression before clamping, so it differs from the result exactly
+        when one of the two bounds bit.
+        """
+        # A compressive normal stress raises the resistance and leaves both bounds inactive
+        free = Form8Dot32DesignShearStressResistanceWithNormalForce(
+            tau_rdc_0=0.585935, k_1=0.133333, sigma_cp=-2.0, tau_rdc_min=0.522, tau_rdc_max=1.483483
+        ).latex()
+
+        # A tensile normal stress lowers it below the minimum, so the lower bound governs
+        clamped = Form8Dot32DesignShearStressResistanceWithNormalForce(
+            tau_rdc_0=0.585935, k_1=0.133333, sigma_cp=2.0, tau_rdc_min=0.522, tau_rdc_max=1.483483
+        ).latex()
+
+        assert free.intermediate_result == "0.853"
+        assert free.result == "0.853"
+        assert clamped.intermediate_result == "0.319"
+        assert clamped.result == "0.522"

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_32.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_32.py
@@ -149,3 +149,19 @@ class TestForm8Dot32DesignShearStressResistanceWithNormalForce:
         assert free.result == "0.853"
         assert clamped.intermediate_result == "0.319"
         assert clamped.result == "0.522"
+
+    def test_raise_error_when_the_bounds_are_inverted(self) -> None:
+        """The two bounds come from different formulas and can cross, which leaves the chain unsatisfiable.
+
+        The minimum of (8.20) does not depend on the reinforcement ratio while the maximum of (8.35) does, so
+        a lightly reinforced member can produce a maximum below the minimum. The values here are the ones that
+        come out of (8.20) and (8.33) to (8.35) for a reinforcement ratio of 0.04 percent, with gamma_v = 1.4,
+        f_ck = 30 MPa, f_yd = 435 MPa, d_dg = 32 mm, d = 500 mm and a_cs_0 = 1333.333 mm.
+
+        Clamping anyway would return 0.5073, which is below the declared minimum of 0.5220 and therefore
+        breaks the relation the formula prints.
+        """
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            Form8Dot32DesignShearStressResistanceWithNormalForce(
+                tau_rdc_0=0.2004, k_1=0.133333, sigma_cp=-2.0, tau_rdc_min=0.5220, tau_rdc_max=0.5073
+            )

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_32.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_32.py
@@ -1,0 +1,127 @@
+"""Testing formula 8.32 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_32 import (
+    Form8Dot32DesignShearStressResistanceWithNormalForce,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot32DesignShearStressResistanceWithNormalForce:
+    """Validation for formula 8.32 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression itself governs."""
+        # Example values
+        tau_rdc_0 = 0.585935
+        k_1 = 0.133333
+        sigma_cp = -2.0
+        tau_rdc_min = 0.522
+        tau_rdc_max = 1.483483
+
+        # Object to test
+        formula = Form8Dot32DesignShearStressResistanceWithNormalForce(
+            tau_rdc_0=tau_rdc_0, k_1=k_1, sigma_cp=sigma_cp, tau_rdc_min=tau_rdc_min, tau_rdc_max=tau_rdc_max
+        )
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.852601  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_lower_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the lower bound governs."""
+        # Example values, with a tensile normal stress that pushes the expression below the lower bound
+        formula = Form8Dot32DesignShearStressResistanceWithNormalForce(
+            tau_rdc_0=0.585935, k_1=0.133333, sigma_cp=1.0, tau_rdc_min=0.522, tau_rdc_max=1.483483
+        )
+
+        # Expected result, manually calculated: the expression yields 0.452602, so the lower bound governs
+        manually_calculated_result = 0.522  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_upper_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the upper bound governs."""
+        # Example values, with a compressive normal stress that pushes the expression above the upper bound
+        formula = Form8Dot32DesignShearStressResistanceWithNormalForce(
+            tau_rdc_0=0.585935, k_1=0.133333, sigma_cp=-10.0, tau_rdc_min=0.522, tau_rdc_max=1.483483
+        )
+
+        # Expected result, manually calculated: the expression yields 1.919265, so the upper bound governs
+        manually_calculated_result = 1.483483  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_with_a_negative_factor(self) -> None:
+        """Tests that a negative factor, which Formula (8.34) can produce, is accepted and used as such.
+
+        The inputs are chosen so the result stays between both bounds, otherwise the clamping would hide
+        whether the sign of the factor was handled at all.
+        """
+        formula = Form8Dot32DesignShearStressResistanceWithNormalForce(
+            tau_rdc_0=0.585935, k_1=-0.066667, sigma_cp=2.0, tau_rdc_min=0.522, tau_rdc_max=1.483483
+        )
+
+        # Expected result, manually calculated: 0.585935 - (-0.066667) * 2.0
+        manually_calculated_result = 0.719269  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("tau_rdc_0", "k_1", "sigma_cp", "tau_rdc_min", "tau_rdc_max"),
+        [
+            (-0.585935, 0.133333, -2.0, 0.522, 1.483483),  # tau_rdc_0 is negative
+            (0.585935, 0.133333, -2.0, -0.522, 1.483483),  # tau_rdc_min is negative
+            (0.585935, 0.133333, -2.0, 0.522, -1.483483),  # tau_rdc_max is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(
+        self, tau_rdc_0: float, k_1: float, sigma_cp: float, tau_rdc_min: float, tau_rdc_max: float
+    ) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot32DesignShearStressResistanceWithNormalForce(
+                tau_rdc_0=tau_rdc_0, k_1=k_1, sigma_cp=sigma_cp, tau_rdc_min=tau_rdc_min, tau_rdc_max=tau_rdc_max
+            )
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Rd,c} = \min\left(\max\left(\tau_{Rdc,0} - k_1 \cdot \sigma_{cp}, \tau_{Rdc,min}\right), "
+                r"\tau_{Rdc,max}\right) = \min\left(\max\left(0.586 - 0.133 \cdot -2.000, 0.522\right), "
+                r"1.483\right) = 0.853 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Rd,c} = \min\left(\max\left(\tau_{Rdc,0} - k_1 \cdot \sigma_{cp}, \tau_{Rdc,min}\right), "
+                r"\tau_{Rdc,max}\right) = \min\left(\max\left(0.586 \ MPa - 0.133 \cdot -2.000 \ MPa, "
+                r"0.522 \ MPa\right), 1.483 \ MPa\right) = 0.853 \ MPa",
+            ),
+            ("short", r"\tau_{Rd,c} = 0.853 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        tau_rdc_0 = 0.585935
+        k_1 = 0.133333
+        sigma_cp = -2.0
+        tau_rdc_min = 0.522
+        tau_rdc_max = 1.483483
+
+        # Object to test
+        latex = Form8Dot32DesignShearStressResistanceWithNormalForce(
+            tau_rdc_0=tau_rdc_0, k_1=k_1, sigma_cp=sigma_cp, tau_rdc_min=tau_rdc_min, tau_rdc_max=tau_rdc_max
+        ).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Description

Implements Formula (8.32) of clause 8.2.2(5) as `Form8Dot32DesignShearStressResistanceWithNormalForce`. This is the assembly that the three quantities of #1090 feed: the design value of the shear stress resistance for the approach that considers the effect of compressive normal forces, offered by the standard as an alternative to Formula (8.27) combined with Formula (8.31).

Points worth a reviewer's attention:

- **The standard prints this as a chained inequality with an embedded equality**, `tau_Rdc,min <= tau_Rd,c = tau_Rdc,0 - k_1 * sigma_cp <= tau_Rdc,max`, so strictly it reads as a verification rather than an assignment. It is implemented as a clamp, first against the lower bound and then against the upper one, which is what the bounds are for and matches the treatment of (8.27) and (8.30). All three outcomes have a test.
- **The operator between the terms is a minus.** With `sigma_cp = N_Ed / A_c` and compression entering negative, compression raises the resistance, which is the point of the clause. Implementing it as a plus while feeding a positive compressive stress produces the same number for compression and the wrong sign for tension.
- **Neither `k_1` nor `sigma_cp` has a sign guard, deliberately.** Formula (8.34) can produce a negative `k_1`, and `sigma_cp` is negative in compression and positive in tension. Restricting either would break the formula.
- The clamping order only matters for the degenerate input where the lower bound exceeds the upper one. The standard prints no rule for that, so the behaviour is documented in the docstring rather than rejected by a guard the standard does not ask for.
- `tau_rdc_0`, `tau_rdc_min` and `tau_rdc_max` come in as parameters rather than being derived internally, following the pattern used throughout this clause. The class therefore cannot check that `tau_Rdc,max <= 2.7 * tau_Rdc,0`, which Formula (8.35) guarantees at its own level.
- Minor rendering observation, not specific to this formula: a negative substituted value renders as `0.133 \cdot -2.000`, a multiplication dot directly followed by a minus sign. Wrapping negative values in parentheses would read better, but that belongs in `latex_replace_symbols` and would affect every formula in the library, so it is left alone here.

The docstring refers to the classes of Formulas (8.33), (8.34) and (8.35), which are in review in #1090. There is no code dependency: this pull request takes their results as parameters and can be merged independently.

Contributes to #1083

## Formulas as implemented

**Formula (8.32)**, `Form8Dot32DesignShearStressResistanceWithNormalForce`

`equation`

$$
\tau_{Rd,c} = \min\left(\max\left(\tau_{Rdc,0} - k_1 \cdot \sigma_{cp}, \tau_{Rdc,min}\right), \tau_{Rdc,max}\right)
$$

`complete`

$$
\tau_{Rd,c} = \min\left(\max\left(\tau_{Rdc,0} - k_1 \cdot \sigma_{cp}, \tau_{Rdc,min}\right), \tau_{Rdc,max}\right) = \min\left(\max\left(0.586 - 0.133 \cdot -2.000, 0.522\right), 1.483\right) = 0.853 \ MPa
$$

`complete_with_units`

$$
\tau_{Rd,c} = \min\left(\max\left(\tau_{Rdc,0} - k_1 \cdot \sigma_{cp}, \tau_{Rdc,min}\right), \tau_{Rdc,max}\right) = \min\left(\max\left(0.586 \ MPa - 0.133 \cdot -2.000 \ MPa, 0.522 \ MPa\right), 1.483 \ MPa\right) = 0.853 \ MPa
$$

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Tests for the unclamped case, both bounds, and a negative factor with a result that stays between the bounds so the clamping cannot hide the sign handling
- [x] Docstrings added, with variable descriptions taken from the standard
- [x] Documentation table updated with the class name
- [x] `blueprints check` passes: lint, format, type check, and 100% coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2 formula **8.32** for design shear stress resistance with compressive normal force.
  * Resistance is clamped between configurable minimum and maximum limits.
  * Supports intermediate (unclamped) and final (clamped) result reporting, plus symbolic/numeric/unit-aware LaTeX output.
* **Documentation**
  * Updated the Eurocode formula guide to mark **8.32** as implemented.
* **Tests**
  * Added automated tests covering evaluation, clamping behavior, validation errors (including inverted bounds), intermediate vs final results, and LaTeX formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->