### PR TITLE
feat: add formulas 8.36 and 8.37 from FprEN 1992-1-1:2023 clause 8.2.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_36.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_36.py
@@ -1,0 +1,86 @@
+"""Formula 8.36 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot36EffectiveDepthPrestressedMembers(Formula):
+    """Class representing formula 8.36 for the calculation of the effective depth of prestressed members
+    with bonded tendons.
+    """
+
+    label = "8.36"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, d_s: MM, a_s: MM2, d_p: MM, a_p: MM2) -> None:
+        r"""[$d$] Effective depth of prestressed members with bonded tendons [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (6) - Formula (8.36)
+
+        The area of prestressed reinforcement [$A_p$] may be omitted if including it reduces the shear
+        resistance through the reduced effective depth, provided the longitudinal tension reinforcement
+        [$A_s$] is sufficient to carry [$M_{Ed}$] and [$N_{Ed}$] taking into account the effect of
+        prestressing. Passing [$A_p = 0$] returns [$d_s$], which is that omission.
+
+        Parameters
+        ----------
+        d_s : MM
+            [$d_s$] Effective depth of the longitudinal tension reinforcement [$mm$].
+        a_s : MM2
+            [$A_s$] Area of the longitudinal tension reinforcement [$mm^2$].
+        d_p : MM
+            [$d_p$] Effective depth of the prestressed reinforcement [$mm$].
+        a_p : MM2
+            [$A_p$] Area of the prestressed reinforcement [$mm^2$].
+        """
+        super().__init__()
+        self.d_s = d_s
+        self.a_s = a_s
+        self.d_p = d_p
+        self.a_p = a_p
+
+    @staticmethod
+    def _evaluate(d_s: MM, a_s: MM2, d_p: MM, a_p: MM2) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(d_s=d_s, a_s=a_s, d_p=d_p, a_p=a_p)
+
+        denominator = d_s * a_s + d_p * a_p
+        raise_if_less_or_equal_to_zero(denominator=denominator)
+
+        return (d_s**2 * a_s + d_p**2 * a_p) / denominator
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.36."""
+        _equation: str = r"\frac{\left(d_s\right)^2 \cdot A_s + \left(d_p\right)^2 \cdot A_p}{d_s \cdot A_s + d_p \cdot A_p}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"d_s": f"{self.d_s:.{n}f}",
+                r"A_s": f"{self.a_s:.{n}f}",
+                r"d_p": f"{self.d_p:.{n}f}",
+                r"A_p": f"{self.a_p:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"d_s": rf"{self.d_s:.{n}f} \ mm",
+                r"A_s": rf"{self.a_s:.{n}f} \ mm^2",
+                r"d_p": rf"{self.d_p:.{n}f} \ mm",
+                r"A_p": rf"{self.a_p:.{n}f} \ mm^2",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"d",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_37.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_37.py
@@ -1,0 +1,95 @@
+"""Formula 8.37 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MM2
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot37ReinforcementRatioPrestressedMembers(Formula):
+    """Class representing formula 8.37 for the calculation of the reinforcement ratio of prestressed members
+    with bonded tendons.
+    """
+
+    label = "8.37"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, d_s: MM, a_s: MM2, d_p: MM, a_p: MM2, b_w: MM, d: MM) -> None:
+        r"""[$\rho_l$] Reinforcement ratio of prestressed members with bonded tendons [$-$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (6) - Formula (8.37)
+
+        The area of prestressed reinforcement [$A_p$] may be omitted under the conditions given in 8.2.2(6).
+        With [$A_p = 0$] and [$d = d_s$] this formula reduces to Formula (8.28).
+
+        Parameters
+        ----------
+        d_s : MM
+            [$d_s$] Effective depth of the longitudinal tension reinforcement [$mm$].
+        a_s : MM2
+            [$A_s$] Area of the longitudinal tension reinforcement [$mm^2$].
+        d_p : MM
+            [$d_p$] Effective depth of the prestressed reinforcement [$mm$].
+        a_p : MM2
+            [$A_p$] Area of the prestressed reinforcement [$mm^2$].
+        b_w : MM
+            [$b_w$] Width of the cross-section of linear members [$mm$].
+        d : MM
+            [$d$] Effective depth according to Formula (8.36), see Form8Dot36EffectiveDepthPrestressedMembers [$mm$].
+            Within this clause it is not a free value: for the same member it follows from the four
+            reinforcement quantities above. Passing anything else yields a ratio that is silently
+            inconsistent with the section it claims to describe.
+        """
+        super().__init__()
+        self.d_s = d_s
+        self.a_s = a_s
+        self.d_p = d_p
+        self.a_p = a_p
+        self.b_w = b_w
+        self.d = d
+
+    @staticmethod
+    def _evaluate(d_s: MM, a_s: MM2, d_p: MM, a_p: MM2, b_w: MM, d: MM) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(d_s=d_s, a_s=a_s, d_p=d_p, a_p=a_p)
+        raise_if_less_or_equal_to_zero(b_w=b_w, d=d)
+
+        return (d_s * a_s + d_p * a_p) / (b_w * d**2)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.37."""
+        _equation: str = r"\frac{d_s \cdot A_s + d_p \cdot A_p}{b_w \cdot \left(d\right)^2}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"d_s": f"{self.d_s:.{n}f}",
+                r"A_s": f"{self.a_s:.{n}f}",
+                r"d_p": f"{self.d_p:.{n}f}",
+                r"A_p": f"{self.a_p:.{n}f}",
+                r"b_w": f"{self.b_w:.{n}f}",
+                r"\left(d\right)": rf"\left({self.d:.{n}f}\right)",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"d_s": rf"{self.d_s:.{n}f} \ mm",
+                r"A_s": rf"{self.a_s:.{n}f} \ mm^2",
+                r"d_p": rf"{self.d_p:.{n}f} \ mm",
+                r"A_p": rf"{self.a_p:.{n}f} \ mm^2",
+                r"b_w": rf"{self.b_w:.{n}f} \ mm",
+                r"\left(d\right)": rf"\left({self.d:.{n}f} \ mm\right)",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\rho_l",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -97,8 +97,8 @@ Total of 602 formulas present.
 |      8.33      |        :x:         |         |                                                                    |
 |      8.34      |        :x:         |         |                                                                    |
 |      8.35      |        :x:         |         |                                                                    |
-|      8.36      |        :x:         |         |                                                                    |
-|      8.37      |        :x:         |         |                                                                    |
+|      8.36      | :heavy_check_mark: |         | Form8Dot36EffectiveDepthPrestressedMembers                         |
+|      8.37      | :heavy_check_mark: |         | Form8Dot37ReinforcementRatioPrestressedMembers                     |
 |      8.38      |        :x:         |         |                                                                    |
 |      8.39      |        :x:         |         |                                                                    |
 |      8.40      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_36.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_36.py
@@ -1,0 +1,88 @@
+"""Testing formula 8.36 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_36 import (
+    Form8Dot36EffectiveDepthPrestressedMembers,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot36EffectiveDepthPrestressedMembers:
+    """Validation for formula 8.36 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        d_s = 500.0
+        a_s = 1500.0
+        d_p = 450.0
+        a_p = 800.0
+
+        # Object to test
+        formula = Form8Dot36EffectiveDepthPrestressedMembers(d_s=d_s, a_s=a_s, d_p=d_p, a_p=a_p)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 483.783784  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_prestressed_reinforcement_is_omitted(self) -> None:
+        """Tests the omission of the prestressed reinforcement allowed by 8.2.2(6), which returns the effective depth
+        of the longitudinal tension reinforcement.
+        """
+        formula = Form8Dot36EffectiveDepthPrestressedMembers(d_s=500.0, a_s=1500.0, d_p=450.0, a_p=0.0)
+
+        assert formula == pytest.approx(expected=500.0, rel=1e-9)
+
+    @pytest.mark.parametrize(
+        ("d_s", "a_s", "d_p", "a_p"),
+        [
+            (-500.0, 1500.0, 450.0, 800.0),  # d_s is negative
+            (500.0, -1500.0, 450.0, 800.0),  # a_s is negative
+            (500.0, 1500.0, -450.0, 800.0),  # d_p is negative
+            (500.0, 1500.0, 450.0, -800.0),  # a_p is negative
+            (500.0, 0.0, 450.0, 0.0),  # no reinforcement at all, so the denominator is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, d_s: float, a_s: float, d_p: float, a_p: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot36EffectiveDepthPrestressedMembers(d_s=d_s, a_s=a_s, d_p=d_p, a_p=a_p)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"d = \frac{\left(d_s\right)^2 \cdot A_s + \left(d_p\right)^2 \cdot A_p}{d_s \cdot A_s + d_p \cdot A_p} = "
+                r"\frac{\left(500.000\right)^2 \cdot 1500.000 + \left(450.000\right)^2 \cdot 800.000}"
+                r"{500.000 \cdot 1500.000 + 450.000 \cdot 800.000} = 483.784 \ mm",
+            ),
+            (
+                "complete_with_units",
+                r"d = \frac{\left(d_s\right)^2 \cdot A_s + \left(d_p\right)^2 \cdot A_p}{d_s \cdot A_s + d_p \cdot A_p} = "
+                r"\frac{\left(500.000 \ mm\right)^2 \cdot 1500.000 \ mm^2 + \left(450.000 \ mm\right)^2 \cdot 800.000 \ mm^2}"
+                r"{500.000 \ mm \cdot 1500.000 \ mm^2 + 450.000 \ mm \cdot 800.000 \ mm^2} = 483.784 \ mm",
+            ),
+            ("short", r"d = 483.784 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        d_s = 500.0
+        a_s = 1500.0
+        d_p = 450.0
+        a_p = 800.0
+
+        # Object to test
+        latex = Form8Dot36EffectiveDepthPrestressedMembers(d_s=d_s, a_s=a_s, d_p=d_p, a_p=a_p).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_36.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_36.py
@@ -28,12 +28,16 @@ class TestForm8Dot36EffectiveDepthPrestressedMembers:
         assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
 
     def test_evaluation_when_the_prestressed_reinforcement_is_omitted(self) -> None:
-        """Tests the omission of the prestressed reinforcement allowed by 8.2.2(6), which returns the effective depth
-        of the longitudinal tension reinforcement.
+        r"""Tests the omission of the prestressed reinforcement allowed by 8.2.2(6), which returns the effective
+        depth of the longitudinal tension reinforcement.
+
+        With [$A_p = 0$] the formula reduces to [$d_s^2 \cdot A_s / (d_s \cdot A_s)$], which is [$d_s$]. The
+        assertion is on exact equality rather than on a tolerance, because that reduction is exact and a
+        tolerance would only hide it if it ever stopped being.
         """
         formula = Form8Dot36EffectiveDepthPrestressedMembers(d_s=500.0, a_s=1500.0, d_p=450.0, a_p=0.0)
 
-        assert formula == pytest.approx(expected=500.0, rel=1e-9)
+        assert float(formula) == 500.0
 
     @pytest.mark.parametrize(
         ("d_s", "a_s", "d_p", "a_p"),

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_37.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_37.py
@@ -1,0 +1,97 @@
+"""Testing formula 8.37 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_37 import (
+    Form8Dot37ReinforcementRatioPrestressedMembers,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot37ReinforcementRatioPrestressedMembers:
+    """Validation for formula 8.37 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        d_s = 500.0
+        a_s = 1500.0
+        d_p = 450.0
+        a_p = 800.0
+        b_w = 300.0
+        d = 483.783784  # from formula 8.36 for the same reinforcement
+
+        # Object to test
+        formula = Form8Dot37ReinforcementRatioPrestressedMembers(d_s=d_s, a_s=a_s, d_p=d_p, a_p=a_p, b_w=b_w, d=d)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.015809  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_reduces_to_formula_8_28_without_prestressing(self) -> None:
+        """Tests that omitting the prestressed reinforcement reproduces Formula (8.28).
+
+        With a_p = 0 the formula becomes d_s * A_s / (b_w * d_s^2), which is A_s / (b_w * d_s), the
+        reinforcement ratio of Formula (8.28) for the same section.
+        """
+        formula = Form8Dot37ReinforcementRatioPrestressedMembers(d_s=500.0, a_s=1500.0, d_p=450.0, a_p=0.0, b_w=300.0, d=500.0)
+
+        # 1500 / (300 * 500), the value Formula (8.28) gives for the same section
+        assert formula == pytest.approx(expected=0.01, rel=1e-9)
+
+    @pytest.mark.parametrize(
+        ("d_s", "a_s", "d_p", "a_p", "b_w", "d"),
+        [
+            (-500.0, 1500.0, 450.0, 800.0, 300.0, 483.783784),  # d_s is negative
+            (500.0, -1500.0, 450.0, 800.0, 300.0, 483.783784),  # a_s is negative
+            (500.0, 1500.0, -450.0, 800.0, 300.0, 483.783784),  # d_p is negative
+            (500.0, 1500.0, 450.0, -800.0, 300.0, 483.783784),  # a_p is negative
+            (500.0, 1500.0, 450.0, 800.0, -300.0, 483.783784),  # b_w is negative
+            (500.0, 1500.0, 450.0, 800.0, 0.0, 483.783784),  # b_w is zero
+            (500.0, 1500.0, 450.0, 800.0, 300.0, -483.783784),  # d is negative
+            (500.0, 1500.0, 450.0, 800.0, 300.0, 0.0),  # d is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, d_s: float, a_s: float, d_p: float, a_p: float, b_w: float, d: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot37ReinforcementRatioPrestressedMembers(d_s=d_s, a_s=a_s, d_p=d_p, a_p=a_p, b_w=b_w, d=d)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\rho_l = \frac{d_s \cdot A_s + d_p \cdot A_p}{b_w \cdot \left(d\right)^2} = "
+                r"\frac{500.000 \cdot 1500.000 + 450.000 \cdot 800.000}{300.000 \cdot \left(483.784\right)^2} = 0.016 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"\rho_l = \frac{d_s \cdot A_s + d_p \cdot A_p}{b_w \cdot \left(d\right)^2} = "
+                r"\frac{500.000 \ mm \cdot 1500.000 \ mm^2 + 450.000 \ mm \cdot 800.000 \ mm^2}"
+                r"{300.000 \ mm \cdot \left(483.784 \ mm\right)^2} = 0.016 \ -",
+            ),
+            ("short", r"\rho_l = 0.016 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        d_s = 500.0
+        a_s = 1500.0
+        d_p = 450.0
+        a_p = 800.0
+        b_w = 300.0
+        d = 483.783784
+
+        # Object to test
+        latex = Form8Dot37ReinforcementRatioPrestressedMembers(d_s=d_s, a_s=a_s, d_p=d_p, a_p=a_p, b_w=b_w, d=d).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_37.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_37.py
@@ -33,12 +33,14 @@ class TestForm8Dot37ReinforcementRatioPrestressedMembers:
         """Tests that omitting the prestressed reinforcement reproduces Formula (8.28).
 
         With a_p = 0 the formula becomes d_s * A_s / (b_w * d_s^2), which is A_s / (b_w * d_s), the
-        reinforcement ratio of Formula (8.28) for the same section.
+        reinforcement ratio of Formula (8.28) for the same section. The assertion is on exact equality rather
+        than on a tolerance, because that reduction is exact and a tolerance would only hide it if it ever
+        stopped being.
         """
         formula = Form8Dot37ReinforcementRatioPrestressedMembers(d_s=500.0, a_s=1500.0, d_p=450.0, a_p=0.0, b_w=300.0, d=500.0)
 
         # 1500 / (300 * 500), the value Formula (8.28) gives for the same section
-        assert formula == pytest.approx(expected=0.01, rel=1e-9)
+        assert float(formula) == 0.01
 
     @pytest.mark.parametrize(
         ("d_s", "a_s", "d_p", "a_p", "b_w", "d"),


### PR DESCRIPTION
## Description

Implements Formulas (8.36) and (8.37) of clause 8.2.2(6), the effective depth and the reinforcement ratio for prestressed members with bonded tendons:

- `Form8Dot36EffectiveDepthPrestressedMembers` for (8.36).
- `Form8Dot37ReinforcementRatioPrestressedMembers` for (8.37).

With this, clause 8.2.2 is complete up to and including paragraph (6).

Points worth a reviewer's attention:

- **Only the depths are squared, and only in the numerator of (8.36).** The areas are never squared, the denominator is linear in the depths, and in (8.37) the single squared quantity is `d` in the denominator. Carrying the squares of (8.36) into (8.37) is the plausible misreading here.
- **The omission allowed by 8.2.2(6) is expressed by passing `a_p = 0`.** The standard permits leaving out the prestressed reinforcement if including it lowers the shear resistance through the reduced effective depth. With `a_p = 0`, (8.36) returns `d_s`, and (8.37) reduces to `A_s / (b_w * d_s)`, which is exactly Formula (8.28) for the same section. There is a test for that identity, which cross-checks the two clauses against each other.
- **`d` in (8.37) is redundant but kept as an input.** Within this clause it is not free: for the same member it follows from (8.36) using the four reinforcement quantities that are already in the signature, so a caller passing something else gets a silently inconsistent ratio. It is kept as a parameter for consistency with the rest of this clause, where derived quantities are passed in rather than computed internally, and the constraint is spelled out in the docstring. Deriving it inside (8.37) and dropping the parameter is the alternative; say the word and I will change it.
- The denominator of (8.36) is guarded as a whole rather than per term, since it is the product sum that must be non-zero. A section with neither ordinary nor prestressed reinforcement raises rather than dividing by zero.

Contributes to #1083

## Formulas as implemented

**Formula (8.36)**, `Form8Dot36EffectiveDepthPrestressedMembers`

`equation`

$$
d = \frac{\left(d_s\right)^2 \cdot A_s + \left(d_p\right)^2 \cdot A_p}{d_s \cdot A_s + d_p \cdot A_p}
$$

`complete`

$$
d = \frac{\left(d_s\right)^2 \cdot A_s + \left(d_p\right)^2 \cdot A_p}{d_s \cdot A_s + d_p \cdot A_p} = \frac{\left(500.000\right)^2 \cdot 1500.000 + \left(450.000\right)^2 \cdot 800.000}{500.000 \cdot 1500.000 + 450.000 \cdot 800.000} = 483.784 \ mm
$$

`complete_with_units`

$$
d = \frac{\left(d_s\right)^2 \cdot A_s + \left(d_p\right)^2 \cdot A_p}{d_s \cdot A_s + d_p \cdot A_p} = \frac{\left(500.000 \ mm\right)^2 \cdot 1500.000 \ mm^2 + \left(450.000 \ mm\right)^2 \cdot 800.000 \ mm^2}{500.000 \ mm \cdot 1500.000 \ mm^2 + 450.000 \ mm \cdot 800.000 \ mm^2} = 483.784 \ mm
$$

**Formula (8.37)**, `Form8Dot37ReinforcementRatioPrestressedMembers`

`equation`

$$
\rho_l = \frac{d_s \cdot A_s + d_p \cdot A_p}{b_w \cdot \left(d\right)^2}
$$

`complete`

$$
\rho_l = \frac{d_s \cdot A_s + d_p \cdot A_p}{b_w \cdot \left(d\right)^2} = \frac{500.000 \cdot 1500.000 + 450.000 \cdot 800.000}{300.000 \cdot \left(483.784\right)^2} = 0.016 \ -
$$

`complete_with_units`

$$
\rho_l = \frac{d_s \cdot A_s + d_p \cdot A_p}{b_w \cdot \left(d\right)^2} = \frac{500.000 \ mm \cdot 1500.000 \ mm^2 + 450.000 \ mm \cdot 800.000 \ mm^2}{300.000 \ mm \cdot \left(483.784 \ mm\right)^2} = 0.016 \ -
$$

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Tests for the general case, the omission of the prestressed reinforcement, the identity with Formula (8.28), and every raise
- [x] Docstrings added, with variable descriptions taken from the standard
- [x] Documentation table updated with the class names
- [x] `blueprints check` passes: lint, format, type check, and 100% coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2 (2023) Formula **8.36** for effective depth of prestressed members with bonded tendons.
  * Added Eurocode 2 (2023) Formula **8.37** for reinforcement ratio of prestressed members, including input validation and correct reductions when prestressing is omitted.
  * Added symbolic and numeric **LaTeX** outputs (with and without units) for both formulas.
* **Documentation**
  * Updated the Eurocode formula guide to mark **8.36** and **8.37** as completed and link the corresponding formula names.
* **Tests**
  * Added tests covering calculations, validation/edge cases, and LaTeX formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->