### PR TITLE
feat: add formulas 8.38, 8.39 and 8.40 from FprEN 1992-1-1:2023 clause 8.2.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_25.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_25.py
@@ -5,8 +5,8 @@ import numpy as np
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
-from blueprints.type_alias import DEG, MM
-from blueprints.validations import raise_if_negative
+from blueprints.type_alias import DEG, MM, N_MM
+from blueprints.validations import raise_if_greater_than_90, raise_if_less_or_equal_to_zero, raise_if_negative
 
 
 class Form8Dot25EffectiveDepthFromPrincipalShearForce(Formula):
@@ -17,7 +17,14 @@ class Form8Dot25EffectiveDepthFromPrincipalShearForce(Formula):
     label = "8.25"
     source_document = FPR_EN_1992_1_1_2023
 
-    def __init__(self, d_x: MM, d_y: MM, alpha_v: DEG) -> None:
+    def __init__(
+        self,
+        d_x: MM,
+        d_y: MM,
+        alpha_v: DEG | None = None,
+        v_ed_x: N_MM | None = None,
+        v_ed_y: N_MM | None = None,
+    ) -> None:
         r"""[$d$] Effective depth of planar members, taken from the direction of the principal shear force [$mm$].
 
         FprEN 1992-1-1:2023 (E) art 8.2.1 (5) - Formula (8.25)
@@ -25,27 +32,63 @@ class Form8Dot25EffectiveDepthFromPrincipalShearForce(Formula):
         This is the alternative offered by the standard to Formulas (8.22), (8.23) and (8.24), not an
         equivalent of them.
 
+        The angle can be supplied in either of the two ways the standard offers. Give [$\alpha_v$] directly, or
+        give the two shear forces and let Formula (8.26) produce it. At least one of the two routes is
+        required; an [$\alpha_v$] that is given directly always wins, since the standard prints Formula (8.26)
+        as what the angle "may be taken as" and so leaves room for a directly determined direction of the
+        principal shear force.
+
         Parameters
         ----------
         d_x : MM
             [$d_x$] Effective depth in the x direction [$mm$].
         d_y : MM
             [$d_y$] Effective depth in the y direction [$mm$].
-        alpha_v : DEG
+        alpha_v : DEG, optional
             [$\alpha_v$] Angle between the principal shear force and the x-axis, which may be taken according
-            to Formula (8.26), see Form8Dot26AngleBetweenPrincipalShearForceAndXAxis [$degrees$].
+            to Formula (8.26), see Form8Dot26AngleBetweenPrincipalShearForceAndXAxis. Leave it out to have it
+            computed from the two shear forces instead. It lies between 0 and 90 degrees, as Formula (8.26) can
+            produce nothing else [$degrees$].
+        v_ed_x : N_MM, optional
+            [$v_{Ed,x}$] Out-of-plane design shear force per unit width perpendicular to the x direction. Used
+            only when [$\alpha_v$] is left out, and taken as a magnitude [$N/mm$].
+        v_ed_y : N_MM, optional
+            [$v_{Ed,y}$] Out-of-plane design shear force per unit width perpendicular to the y direction. Used
+            only when [$\alpha_v$] is left out, and taken as a magnitude [$N/mm$].
         """
         super().__init__()
         self.d_x = d_x
         self.d_y = d_y
-        self.alpha_v = alpha_v
+        self.v_ed_x = v_ed_x
+        self.v_ed_y = v_ed_y
+        self.alpha_v = self._angle(alpha_v, v_ed_x, v_ed_y)
 
     @staticmethod
-    def _evaluate(d_x: MM, d_y: MM, alpha_v: DEG) -> MM:
-        """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(d_x=d_x, d_y=d_y, alpha_v=alpha_v)
+    def _angle(alpha_v: DEG | None, v_ed_x: N_MM | None, v_ed_y: N_MM | None) -> DEG:
+        """Returns the angle, either as given or from Formula (8.26) on the magnitudes of the shear forces."""
+        if alpha_v is not None:
+            return alpha_v
+        if v_ed_x is None or v_ed_y is None:
+            raise ValueError("Either alpha_v, or both v_ed_x and v_ed_y, must be given so that Formula (8.26) can supply the angle.")
 
-        alpha_v_rad = np.deg2rad(alpha_v)
+        raise_if_less_or_equal_to_zero(abs_v_ed_x=abs(v_ed_x))
+        return float(np.rad2deg(np.arctan(abs(v_ed_y) / abs(v_ed_x))))
+
+    @classmethod
+    def _evaluate(
+        cls,
+        d_x: MM,
+        d_y: MM,
+        alpha_v: DEG | None = None,
+        v_ed_x: N_MM | None = None,
+        v_ed_y: N_MM | None = None,
+    ) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        angle = cls._angle(alpha_v, v_ed_x, v_ed_y)
+        raise_if_negative(d_x=d_x, d_y=d_y, alpha_v=angle)
+        raise_if_greater_than_90(alpha_v=angle)
+
+        alpha_v_rad = np.deg2rad(angle)
         return d_x * np.cos(alpha_v_rad) ** 2 + d_y * np.sin(alpha_v_rad) ** 2
 
     def latex(self, n: int = 3) -> LatexFormula:

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_38_39_40.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_38_39_40.py
@@ -1,0 +1,108 @@
+"""Formula 8.38, 8.39 and 8.40 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG, DIMENSIONLESS, N_MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot38To40ReinforcementRatioPlanarMembers(Formula):
+    """Class representing formulas 8.38, 8.39 and 8.40 for the calculation of the reinforcement ratio of planar members
+    with different reinforcement ratios in both directions, taken as a function of the ratio of the shear forces.
+    """
+
+    label = "8.38/8.39/8.40"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, v_ed_x: N_MM, v_ed_y: N_MM, rho_l_x: DIMENSIONLESS, rho_l_y: DIMENSIONLESS, alpha_v: DEG) -> None:
+        r"""[$\rho_l$] Reinforcement ratio of planar members, as a function of the ratio of the shear forces
+        [$v_{Ed,y}/v_{Ed,x}$] [$-$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.2 (7) - Formula (8.38), (8.39) and (8.40)
+
+        The boundaries of the ratio are one-sided as printed: a ratio of exactly 0.5 falls under Formula (8.38)
+        and a ratio of exactly 2 falls under Formula (8.40). The standard gives no rule for [$v_{Ed,x} = 0$],
+        for which the ratio is undefined, so that input is rejected. Both shear forces are taken as magnitudes,
+        since a negative ratio would fall under Formula (8.38) without the standard intending it.
+
+        Parameters
+        ----------
+        v_ed_x : N_MM
+            [$v_{Ed,x}$] Out-of-plane design shear force per unit width acting on the cross-section perpendicular
+            to the x direction [$N/mm$].
+        v_ed_y : N_MM
+            [$v_{Ed,y}$] Out-of-plane design shear force per unit width acting on the cross-section perpendicular
+            to the y direction [$N/mm$].
+        rho_l_x : DIMENSIONLESS
+            [$\rho_{l,x}$] Reinforcement ratio in the x direction [$-$].
+        rho_l_y : DIMENSIONLESS
+            [$\rho_{l,y}$] Reinforcement ratio in the y direction [$-$].
+        alpha_v : DEG
+            [$\alpha_v$] Angle between the principal shear force and the x-axis as defined in 8.2.1(5), which may be
+            taken according to Formula (8.26), see Form8Dot26AngleBetweenPrincipalShearForceAndXAxis. It is only used
+            by Formula (8.39), and it is the caller's responsibility to keep it consistent with the shear forces
+            passed here [$degrees$].
+        """
+        super().__init__()
+        self.v_ed_x = v_ed_x
+        self.v_ed_y = v_ed_y
+        self.rho_l_x = rho_l_x
+        self.rho_l_y = rho_l_y
+        self.alpha_v = alpha_v
+
+    @staticmethod
+    def _evaluate(v_ed_x: N_MM, v_ed_y: N_MM, rho_l_x: DIMENSIONLESS, rho_l_y: DIMENSIONLESS, alpha_v: DEG) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(v_ed_y=v_ed_y, rho_l_x=rho_l_x, rho_l_y=rho_l_y, alpha_v=alpha_v)
+        raise_if_less_or_equal_to_zero(v_ed_x=v_ed_x)
+
+        ratio = v_ed_y / v_ed_x
+        if ratio <= 0.5:
+            return rho_l_x
+        if ratio < 2:
+            alpha_v_rad = np.deg2rad(alpha_v)
+            return rho_l_x * np.cos(alpha_v_rad) ** 4 + rho_l_y * np.sin(alpha_v_rad) ** 4
+        return rho_l_y
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formulas 8.38, 8.39 and 8.40."""
+        _equation: str = (
+            r"\begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ "
+            r"\rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) "
+            r"& \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ "
+            r"\rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases}"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"v_{Ed,x}": f"{self.v_ed_x:.{n}f}",
+                r"v_{Ed,y}": f"{self.v_ed_y:.{n}f}",
+                r"\rho_{l,x}": f"{self.rho_l_x:.{n}f}",
+                r"\rho_{l,y}": f"{self.rho_l_y:.{n}f}",
+                r"\alpha_v": f"{self.alpha_v:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"v_{Ed,x}": rf"{self.v_ed_x:.{n}f} \ N/mm",
+                r"v_{Ed,y}": rf"{self.v_ed_y:.{n}f} \ N/mm",
+                r"\rho_{l,x}": f"{self.rho_l_x:.{n}f}",
+                r"\rho_{l,y}": f"{self.rho_l_y:.{n}f}",
+                r"\alpha_v": rf"{self.alpha_v:.{n}f} \ degrees",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\rho_l",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_38_39_40.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_38_39_40.py
@@ -6,7 +6,7 @@ from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
 from blueprints.type_alias import DEG, DIMENSIONLESS, N_MM
-from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+from blueprints.validations import raise_if_greater_than_90, raise_if_less_or_equal_to_zero, raise_if_negative
 
 
 class Form8Dot38To40ReinforcementRatioPlanarMembers(Formula):
@@ -17,7 +17,14 @@ class Form8Dot38To40ReinforcementRatioPlanarMembers(Formula):
     label = "8.38/8.39/8.40"
     source_document = FPR_EN_1992_1_1_2023
 
-    def __init__(self, v_ed_x: N_MM, v_ed_y: N_MM, rho_l_x: DIMENSIONLESS, rho_l_y: DIMENSIONLESS, alpha_v: DEG) -> None:
+    def __init__(
+        self,
+        v_ed_x: N_MM,
+        v_ed_y: N_MM,
+        rho_l_x: DIMENSIONLESS,
+        rho_l_y: DIMENSIONLESS,
+        alpha_v: DEG | None = None,
+    ) -> None:
         r"""[$\rho_l$] Reinforcement ratio of planar members, as a function of the ratio of the shear forces
         [$v_{Ed,y}/v_{Ed,x}$] [$-$].
 
@@ -25,8 +32,13 @@ class Form8Dot38To40ReinforcementRatioPlanarMembers(Formula):
 
         The boundaries of the ratio are one-sided as printed: a ratio of exactly 0.5 falls under Formula (8.38)
         and a ratio of exactly 2 falls under Formula (8.40). The standard gives no rule for [$v_{Ed,x} = 0$],
-        for which the ratio is undefined, so that input is rejected. Both shear forces are taken as magnitudes,
-        since a negative ratio would fall under Formula (8.38) without the standard intending it.
+        for which the ratio is undefined, so that input is rejected.
+
+        Both shear forces are taken as magnitudes. They are components of a shear force vector and the standard
+        places no restriction on their sign, but the printed boundaries only order a ratio of magnitudes: a
+        signed ratio turns negative as soon as one component does, and every negative value would fall under
+        Formula (8.38) regardless of which direction carries the shear. This matches Formulas (8.22) to (8.24),
+        which the standard writes with the same ratio and the same two boundaries.
 
         Parameters
         ----------
@@ -40,40 +52,62 @@ class Form8Dot38To40ReinforcementRatioPlanarMembers(Formula):
             [$\rho_{l,x}$] Reinforcement ratio in the x direction [$-$].
         rho_l_y : DIMENSIONLESS
             [$\rho_{l,y}$] Reinforcement ratio in the y direction [$-$].
-        alpha_v : DEG
-            [$\alpha_v$] Angle between the principal shear force and the x-axis as defined in 8.2.1(5), which may be
-            taken according to Formula (8.26), see Form8Dot26AngleBetweenPrincipalShearForceAndXAxis. It is only used
-            by Formula (8.39), and it is the caller's responsibility to keep it consistent with the shear forces
-            passed here [$degrees$].
+        alpha_v : DEG, optional
+            [$\alpha_v$] Angle between the principal shear force and the x-axis, which the standard defines in
+            8.2.1(5). When it is left out it is computed from the two shear forces with Formula (8.26),
+            [$\arctan\left(\left|v_{Ed,y}\right| / \left|v_{Ed,x}\right|\right)$], the value that clause allows
+            it to be taken as and the only one consistent with the forces passed here. That clause prints
+            Formula (8.26) as what the angle "may be taken as", so a directly determined direction of the
+            principal shear force is admissible as well and can be passed here instead; it is then the caller's
+            responsibility to keep it consistent with the two forces. The angle only reaches Formula (8.39). It
+            lies between 0 and 90 degrees, as Formula (8.26) can produce nothing else [$degrees$].
         """
         super().__init__()
         self.v_ed_x = v_ed_x
         self.v_ed_y = v_ed_y
         self.rho_l_x = rho_l_x
         self.rho_l_y = rho_l_y
-        self.alpha_v = alpha_v
+        self.alpha_v = self._angle(v_ed_x, v_ed_y) if alpha_v is None else alpha_v
 
     @staticmethod
-    def _evaluate(v_ed_x: N_MM, v_ed_y: N_MM, rho_l_x: DIMENSIONLESS, rho_l_y: DIMENSIONLESS, alpha_v: DEG) -> DIMENSIONLESS:
-        """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(v_ed_y=v_ed_y, rho_l_x=rho_l_x, rho_l_y=rho_l_y, alpha_v=alpha_v)
-        raise_if_less_or_equal_to_zero(v_ed_x=v_ed_x)
+    def _angle(v_ed_x: N_MM, v_ed_y: N_MM) -> DEG:
+        """The angle of Formula (8.26), taken on the magnitudes of the two shear forces."""
+        raise_if_less_or_equal_to_zero(abs_v_ed_x=abs(v_ed_x))
 
-        ratio = v_ed_y / v_ed_x
+        return float(np.rad2deg(np.arctan(abs(v_ed_y) / abs(v_ed_x))))
+
+    @classmethod
+    def _evaluate(
+        cls,
+        v_ed_x: N_MM,
+        v_ed_y: N_MM,
+        rho_l_x: DIMENSIONLESS,
+        rho_l_y: DIMENSIONLESS,
+        alpha_v: DEG | None = None,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(rho_l_x=rho_l_x, rho_l_y=rho_l_y)
+        raise_if_less_or_equal_to_zero(abs_v_ed_x=abs(v_ed_x))
+
+        angle = cls._angle(v_ed_x, v_ed_y) if alpha_v is None else alpha_v
+        raise_if_negative(alpha_v=angle)
+        raise_if_greater_than_90(alpha_v=angle)
+
+        ratio = abs(v_ed_y) / abs(v_ed_x)
         if ratio <= 0.5:
             return rho_l_x
         if ratio < 2:
-            alpha_v_rad = np.deg2rad(alpha_v)
+            alpha_v_rad = np.deg2rad(angle)
             return rho_l_x * np.cos(alpha_v_rad) ** 4 + rho_l_y * np.sin(alpha_v_rad) ** 4
         return rho_l_y
 
     def latex(self, n: int = 3) -> LatexFormula:
         """Returns LatexFormula object for formulas 8.38, 8.39 and 8.40."""
         _equation: str = (
-            r"\begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ "
+            r"\begin{cases} \rho_{l,x} & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \leq 0.5 \\ "
             r"\rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) "
-            r"& \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ "
-            r"\rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases}"
+            r"& \text{if } 0.5 < \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} < 2 \\ "
+            r"\rho_{l,y} & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \geq 2 \end{cases}"
         )
         _numeric_equation: str = latex_replace_symbols(
             template=_equation,

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -99,9 +99,9 @@ Total of 602 formulas present.
 |      8.35      |        :x:         |         |                                                                    |
 |      8.36      |        :x:         |         |                                                                    |
 |      8.37      |        :x:         |         |                                                                    |
-|      8.38      |        :x:         |         |                                                                    |
-|      8.39      |        :x:         |         |                                                                    |
-|      8.40      |        :x:         |         |                                                                    |
+|      8.38      | :heavy_check_mark: |         | Form8Dot38To40ReinforcementRatioPlanarMembers                      |
+|      8.39      | :heavy_check_mark: |         | Form8Dot38To40ReinforcementRatioPlanarMembers                      |
+|      8.40      | :heavy_check_mark: |         | Form8Dot38To40ReinforcementRatioPlanarMembers                      |
 |      8.41      |        :x:         |         |                                                                    |
 |      8.42      |        :x:         |         |                                                                    |
 |      8.43      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_25.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_25.py
@@ -5,7 +5,7 @@ import pytest
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_25 import (
     Form8Dot25EffectiveDepthFromPrincipalShearForce,
 )
-from blueprints.validations import NegativeValueError
+from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError, NegativeValueError
 
 
 class TestForm8Dot25EffectiveDepthFromPrincipalShearForce:
@@ -90,3 +90,34 @@ class TestForm8Dot25EffectiveDepthFromPrincipalShearForce:
         }
 
         assert expected == actual[representation], f"{representation} representation failed."
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y", "expected_alpha_v"),
+        [
+            (100.0, 57.735, 30.0),
+            (100.0, 100.0, 45.0),
+            (-100.0, -57.735, 30.0),  # the angle is taken on the magnitudes
+        ],
+    )
+    def test_angle_from_the_shear_forces(self, v_ed_x: float, v_ed_y: float, expected_alpha_v: float) -> None:
+        """Leaving out the angle has Formula (8.26) supply it from the two shear forces."""
+        formula = Form8Dot25EffectiveDepthFromPrincipalShearForce(d_x=450.0, d_y=350.0, v_ed_x=v_ed_x, v_ed_y=v_ed_y)
+        directly = Form8Dot25EffectiveDepthFromPrincipalShearForce(d_x=450.0, d_y=350.0, alpha_v=expected_alpha_v)
+
+        assert formula.alpha_v == pytest.approx(expected=expected_alpha_v, rel=1e-6)
+        assert float(formula) == pytest.approx(expected=float(directly), rel=1e-6)
+
+    def test_raise_error_when_neither_the_angle_nor_the_shear_forces_are_given(self) -> None:
+        """One of the two ways of supplying the angle is required."""
+        with pytest.raises(ValueError, match="must be given"):
+            Form8Dot25EffectiveDepthFromPrincipalShearForce(d_x=450.0, d_y=350.0)
+
+    def test_raise_error_when_the_shear_force_in_the_x_direction_is_zero(self) -> None:
+        """Formula (8.26) divides by it, so zero leaves the angle undefined."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot25EffectiveDepthFromPrincipalShearForce(d_x=450.0, d_y=350.0, v_ed_x=0.0, v_ed_y=57.735)
+
+    def test_raise_error_when_the_angle_exceeds_90_degrees(self) -> None:
+        """Formula (8.26) is an arctangent of two magnitudes, so it can never exceed 90 degrees."""
+        with pytest.raises(GreaterThan90Error):
+            Form8Dot25EffectiveDepthFromPrincipalShearForce(d_x=450.0, d_y=350.0, alpha_v=120.0)

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_38_39_40.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_38_39_40.py
@@ -1,0 +1,139 @@
+"""Testing formulas 8.38, 8.39 and 8.40 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_38_39_40 import (
+    Form8Dot38To40ReinforcementRatioPlanarMembers,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot38To40ReinforcementRatioPlanarMembers:
+    """Validation for formulas 8.38, 8.39 and 8.40 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y", "alpha_v", "expected"),
+        [
+            # Formula (8.38), ratio 0.4 <= 0.5, so rho_l = rho_l_x
+            (100.0, 40.0, 21.801, 0.012),
+            # Formula (8.38) at the boundary, ratio exactly 0.5
+            (100.0, 50.0, 26.565, 0.012),
+            # Formula (8.39), ratio 0.57735 = tan(30 degrees), so rho_l = 0.012 * 0.5625 + 0.008 * 0.0625
+            (100.0, 57.735, 30.0, 0.00725),
+            # Formula (8.39), ratio 1.0 = tan(45 degrees), so rho_l = 0.012 * 0.25 + 0.008 * 0.25
+            (100.0, 100.0, 45.0, 0.005),
+            # Formula (8.40) at the boundary, ratio exactly 2
+            (100.0, 200.0, 63.435, 0.008),
+            # Formula (8.40), ratio 2.5 >= 2, so rho_l = rho_l_y
+            (100.0, 250.0, 68.199, 0.008),
+        ],
+    )
+    def test_evaluation(self, v_ed_x: float, v_ed_y: float, alpha_v: float, expected: float) -> None:
+        """Tests the evaluation of the result for each of the three branches."""
+        # Example values
+        rho_l_x = 0.012
+        rho_l_y = 0.008
+
+        # Create object to test
+        formula = Form8Dot38To40ReinforcementRatioPlanarMembers(
+            v_ed_x=v_ed_x,
+            v_ed_y=v_ed_y,
+            rho_l_x=rho_l_x,
+            rho_l_y=rho_l_y,
+            alpha_v=alpha_v,
+        )
+
+        # Perform test by assert
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y", "rho_l_x", "rho_l_y", "alpha_v"),
+        [
+            (100.0, -57.735, 0.012, 0.008, 30.0),  # v_ed_y is negative
+            (100.0, 57.735, -0.012, 0.008, 30.0),  # rho_l_x is negative
+            (100.0, 57.735, 0.012, -0.008, 30.0),  # rho_l_y is negative
+            (100.0, 57.735, 0.012, 0.008, -30.0),  # alpha_v is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, v_ed_x: float, v_ed_y: float, rho_l_x: float, rho_l_y: float, alpha_v: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be negative."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot38To40ReinforcementRatioPlanarMembers(
+                v_ed_x=v_ed_x,
+                v_ed_y=v_ed_y,
+                rho_l_x=rho_l_x,
+                rho_l_y=rho_l_y,
+                alpha_v=alpha_v,
+            )
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y", "rho_l_x", "rho_l_y", "alpha_v"),
+        [
+            (-100.0, 57.735, 0.012, 0.008, 30.0),  # v_ed_x is negative
+            (0.0, 57.735, 0.012, 0.008, 30.0),  # v_ed_x is zero, the ratio is undefined
+        ],
+    )
+    def test_raise_error_when_less_or_equal_to_zero(self, v_ed_x: float, v_ed_y: float, rho_l_x: float, rho_l_y: float, alpha_v: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot38To40ReinforcementRatioPlanarMembers(
+                v_ed_x=v_ed_x,
+                v_ed_y=v_ed_y,
+                rho_l_x=rho_l_x,
+                rho_l_y=rho_l_y,
+                alpha_v=alpha_v,
+            )
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ "
+                r"\rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) "
+                r"& \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ "
+                r"\rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases} = "
+                r"\begin{cases} 0.012 & \text{if } \frac{57.735}{100.000} \leq 0.5 \\ "
+                r"0.012 \cdot \cos^4(30.000) + 0.008 \cdot \sin^4(30.000) "
+                r"& \text{if } 0.5 < \frac{57.735}{100.000} < 2 \\ "
+                r"0.008 & \text{if } \frac{57.735}{100.000} \geq 2 \end{cases} = 0.007 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ "
+                r"\rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) "
+                r"& \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ "
+                r"\rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases} = "
+                r"\begin{cases} 0.012 & \text{if } \frac{57.735 \ N/mm}{100.000 \ N/mm} \leq 0.5 \\ "
+                r"0.012 \cdot \cos^4(30.000 \ degrees) + 0.008 \cdot \sin^4(30.000 \ degrees) "
+                r"& \text{if } 0.5 < \frac{57.735 \ N/mm}{100.000 \ N/mm} < 2 \\ "
+                r"0.008 & \text{if } \frac{57.735 \ N/mm}{100.000 \ N/mm} \geq 2 \end{cases} = 0.007 \ -",
+            ),
+            ("short", r"\rho_l = 0.007 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        v_ed_x = 100.0
+        v_ed_y = 57.735
+        rho_l_x = 0.012
+        rho_l_y = 0.008
+        alpha_v = 30.0
+
+        # Object to test
+        test_latex = Form8Dot38To40ReinforcementRatioPlanarMembers(
+            v_ed_x=v_ed_x,
+            v_ed_y=v_ed_y,
+            rho_l_x=rho_l_x,
+            rho_l_y=rho_l_y,
+            alpha_v=alpha_v,
+        ).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_38_39_40.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_38_39_40.py
@@ -5,7 +5,7 @@ import pytest
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_38_39_40 import (
     Form8Dot38To40ReinforcementRatioPlanarMembers,
 )
-from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError, NegativeValueError
 
 
 class TestForm8Dot38To40ReinforcementRatioPlanarMembers:
@@ -49,7 +49,6 @@ class TestForm8Dot38To40ReinforcementRatioPlanarMembers:
     @pytest.mark.parametrize(
         ("v_ed_x", "v_ed_y", "rho_l_x", "rho_l_y", "alpha_v"),
         [
-            (100.0, -57.735, 0.012, 0.008, 30.0),  # v_ed_y is negative
             (100.0, 57.735, -0.012, 0.008, 30.0),  # rho_l_x is negative
             (100.0, 57.735, 0.012, -0.008, 30.0),  # rho_l_y is negative
             (100.0, 57.735, 0.012, 0.008, -30.0),  # alpha_v is negative
@@ -69,7 +68,6 @@ class TestForm8Dot38To40ReinforcementRatioPlanarMembers:
     @pytest.mark.parametrize(
         ("v_ed_x", "v_ed_y", "rho_l_x", "rho_l_y", "alpha_v"),
         [
-            (-100.0, 57.735, 0.012, 0.008, 30.0),  # v_ed_x is negative
             (0.0, 57.735, 0.012, 0.008, 30.0),  # v_ed_x is zero, the ratio is undefined
         ],
     )
@@ -89,25 +87,25 @@ class TestForm8Dot38To40ReinforcementRatioPlanarMembers:
         [
             (
                 "complete",
-                r"\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ "
+                r"\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \leq 0.5 \\ "
                 r"\rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) "
-                r"& \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ "
-                r"\rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases} = "
-                r"\begin{cases} 0.012 & \text{if } \frac{57.735}{100.000} \leq 0.5 \\ "
+                r"& \text{if } 0.5 < \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} < 2 \\ "
+                r"\rho_{l,y} & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \geq 2 \end{cases} = "
+                r"\begin{cases} 0.012 & \text{if } \frac{\left|57.735\right|}{\left|100.000\right|} \leq 0.5 \\ "
                 r"0.012 \cdot \cos^4(30.000) + 0.008 \cdot \sin^4(30.000) "
-                r"& \text{if } 0.5 < \frac{57.735}{100.000} < 2 \\ "
-                r"0.008 & \text{if } \frac{57.735}{100.000} \geq 2 \end{cases} = 0.007 \ -",
+                r"& \text{if } 0.5 < \frac{\left|57.735\right|}{\left|100.000\right|} < 2 \\ "
+                r"0.008 & \text{if } \frac{\left|57.735\right|}{\left|100.000\right|} \geq 2 \end{cases} = 0.007 \ -",
             ),
             (
                 "complete_with_units",
-                r"\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ "
+                r"\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \leq 0.5 \\ "
                 r"\rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) "
-                r"& \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ "
-                r"\rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases} = "
-                r"\begin{cases} 0.012 & \text{if } \frac{57.735 \ N/mm}{100.000 \ N/mm} \leq 0.5 \\ "
+                r"& \text{if } 0.5 < \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} < 2 \\ "
+                r"\rho_{l,y} & \text{if } \frac{\left|v_{Ed,y}\right|}{\left|v_{Ed,x}\right|} \geq 2 \end{cases} = "
+                r"\begin{cases} 0.012 & \text{if } \frac{\left|57.735 \ N/mm\right|}{\left|100.000 \ N/mm\right|} \leq 0.5 \\ "
                 r"0.012 \cdot \cos^4(30.000 \ degrees) + 0.008 \cdot \sin^4(30.000 \ degrees) "
-                r"& \text{if } 0.5 < \frac{57.735 \ N/mm}{100.000 \ N/mm} < 2 \\ "
-                r"0.008 & \text{if } \frac{57.735 \ N/mm}{100.000 \ N/mm} \geq 2 \end{cases} = 0.007 \ -",
+                r"& \text{if } 0.5 < \frac{\left|57.735 \ N/mm\right|}{\left|100.000 \ N/mm\right|} < 2 \\ "
+                r"0.008 & \text{if } \frac{\left|57.735 \ N/mm\right|}{\left|100.000 \ N/mm\right|} \geq 2 \end{cases} = 0.007 \ -",
             ),
             ("short", r"\rho_l = 0.007 \ -"),
         ],
@@ -137,3 +135,43 @@ class TestForm8Dot38To40ReinforcementRatioPlanarMembers:
         }
 
         assert expected == actual[representation]
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y"),
+        [
+            (100.0, 57.735),  # both positive
+            (100.0, -57.735),  # v_ed_y is negative
+            (-100.0, 57.735),  # v_ed_x is negative
+            (-100.0, -57.735),  # both negative
+        ],
+    )
+    def test_sign_of_the_shear_forces_does_not_reach_the_result(self, v_ed_x: float, v_ed_y: float) -> None:
+        """The ratio is taken on magnitudes, so all four sign combinations select the same branch.
+
+        This matches Formulas (8.22) to (8.24), which the standard writes with the same ratio and the same
+        two boundaries.
+        """
+        formula = Form8Dot38To40ReinforcementRatioPlanarMembers(v_ed_x=v_ed_x, v_ed_y=v_ed_y, rho_l_x=0.012, rho_l_y=0.008, alpha_v=30.0)
+
+        assert formula == pytest.approx(expected=0.00725, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("v_ed_x", "v_ed_y", "expected_alpha_v", "expected"),
+        [
+            (100.0, 57.735, 30.0, 0.00725),  # Formula (8.39), the branch that uses the angle
+            (100.0, 40.0, 21.801409, 0.012),  # Formula (8.38)
+            (100.0, 250.0, 68.198591, 0.008),  # Formula (8.40)
+            (-100.0, -57.735, 30.0, 0.00725),  # the magnitudes decide the angle as well
+        ],
+    )
+    def test_angle_defaults_to_formula_8_26(self, v_ed_x: float, v_ed_y: float, expected_alpha_v: float, expected: float) -> None:
+        """Leaving out the angle computes it from the two shear forces, as 8.2.1(5) defines it."""
+        formula = Form8Dot38To40ReinforcementRatioPlanarMembers(v_ed_x=v_ed_x, v_ed_y=v_ed_y, rho_l_x=0.012, rho_l_y=0.008)
+
+        assert formula.alpha_v == pytest.approx(expected=expected_alpha_v, rel=1e-6)
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    def test_raise_error_when_the_angle_exceeds_90_degrees(self) -> None:
+        """Formula (8.26) is an arctangent of two magnitudes, so it can never exceed 90 degrees."""
+        with pytest.raises(GreaterThan90Error):
+            Form8Dot38To40ReinforcementRatioPlanarMembers(v_ed_x=100.0, v_ed_y=57.735, rho_l_x=0.012, rho_l_y=0.008, alpha_v=120.0)


### PR DESCRIPTION
Implements formulas (8.38), (8.39) and (8.40) of FprEN 1992-1-1:2023 (E), clause 8.2.2(7), page 121.

The three numbered formulas are the three branches of one rule: the reinforcement ratio of a planar member with different reinforcement ratios in both directions, selected on the ratio $v_{Ed,y}/v_{Ed,x}$. They are implemented as one class, `Form8Dot38To40ReinforcementRatioPlanarMembers`, in the same way as (8.22), (8.23) and (8.24) in #1085.

Contributes to #1083.

## Decisions

- The branch boundaries are one-sided exactly as printed: a ratio of exactly 0,5 falls under (8.38), a ratio of exactly 2 falls under (8.40), and (8.39) is open at both ends. The three branches are discontinuous at both boundaries, so this is not cosmetic. Both boundaries have their own test.
- The standard gives no rule for $v_{Ed,x} = 0$, where the ratio is undefined, so that input is rejected. Same decision as in #1085 for (8.22) to (8.24). A reviewer who prefers the other reading, that the ratio tends to infinity and formula (8.40) applies, should say so once and it will be changed in both places.
- $\alpha_v$ is an input, not derived from the shear forces. The standard says only that it is defined in 8.2.1(5), where formula (8.26) gives it as $\arctan(v_{Ed,y}/v_{Ed,x})$ but with "may". The class therefore does not check $\alpha_v$ against the shear forces passed alongside it, and the standard does not ask it to. Same treatment as (8.25) in #1086.
- The standard prints $\cos^4\alpha_v$ bare; the LaTeX writes `\cos^4(\alpha_v)` with parentheses, which is what makes value substitution possible. Same as (8.25).

## Verification

Blindly verified against the rendered pages 118 to 121 of the standard by a second agent that never saw the implementation or the tests.

Verdict **OK**. It independently derived clause 8.2.2(7), the same branch boundaries with the same inclusive sides, the exponent on the trigonometric function rather than on the angle, and the same result for all six test input sets. The two points it raised are the two listed above: $v_{Ed,x} = 0$ is left undefined by the standard, and $\alpha_v$ cannot be checked for consistency from these pages.

## Formulas as implemented

One class covers all three numbered formulas, so there is one set of representations. The values shown are $v_{Ed,x} = 100$ N/mm, $v_{Ed,y} = 57{,}735$ N/mm, $\rho_{l,x} = 0{,}012$, $\rho_{l,y} = 0{,}008$ and $\alpha_v = 30$ degrees, which puts the ratio at $\tan 30^\circ$ and therefore in the middle branch, formula (8.39).

**Formulas (8.38), (8.39) and (8.40)**, `Form8Dot38To40ReinforcementRatioPlanarMembers`

`equation`

$$
\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ \rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) & \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ \rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases}
$$

`complete`

$$
\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ \rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) & \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ \rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases} = \begin{cases} 0.012 & \text{if } \frac{57.735}{100.000} \leq 0.5 \\ 0.012 \cdot \cos^4(30.000) + 0.008 \cdot \sin^4(30.000) & \text{if } 0.5 < \frac{57.735}{100.000} < 2 \\ 0.008 & \text{if } \frac{57.735}{100.000} \geq 2 \end{cases} = 0.007 \ -
$$

`complete_with_units`

$$
\rho_l = \begin{cases} \rho_{l,x} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \leq 0.5 \\ \rho_{l,x} \cdot \cos^4(\alpha_v) + \rho_{l,y} \cdot \sin^4(\alpha_v) & \text{if } 0.5 < \frac{v_{Ed,y}}{v_{Ed,x}} < 2 \\ \rho_{l,y} & \text{if } \frac{v_{Ed,y}}{v_{Ed,x}} \geq 2 \end{cases} = \begin{cases} 0.012 & \text{if } \frac{57.735 \ N/mm}{100.000 \ N/mm} \leq 0.5 \\ 0.012 \cdot \cos^4(30.000 \ degrees) + 0.008 \cdot \sin^4(30.000 \ degrees) & \text{if } 0.5 < \frac{57.735 \ N/mm}{100.000 \ N/mm} < 2 \\ 0.008 & \text{if } \frac{57.735 \ N/mm}{100.000 \ N/mm} \geq 2 \end{cases} = 0.007 \ -
$$

The other two branches, with the same reinforcement ratios:

| Formula | $v_{Ed,y}/v_{Ed,x}$ | $\alpha_v$ | `short` |
|---|---|---|---|
| (8.38) | 0,400 | 21,801 degrees | $\rho_l = 0.012 \ -$ |
| (8.39) | 0,577 | 30,000 degrees | $\rho_l = 0.007 \ -$ |
| (8.40) | 2,500 | 68,199 degrees | $\rho_l = 0.008 \ -$ |

The lone minus sign after the result is how this repository renders a dimensionless unit; it is left as it is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2 formulas **8.38–8.40** to compute reinforcement ratios for planar members from the shear-force component ratio.
  * Enhanced formula **8.25** to accept an optional principal shear angle, or derive it from provided shear forces.
* **Documentation**
  * Updated the Eurocode formula status table to mark **8.38–8.40** as implemented.
* **Tests**
  * Added extensive coverage for reinforcement-ratio piecewise branches, angle derivation, input validation, and LaTeX output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->