### PR TITLE
feat: add formula 8.41 from FprEN 1992-1-1:2023 clause 8.2.3

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_41.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_41.py
@@ -1,0 +1,193 @@
+"""Formula 8.41 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import operator
+from collections.abc import Callable, Sequence
+from typing import Self
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import AggregatedComparisonFormula, ComparisonFormula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS
+
+
+class SubForm8Dot41LowerBound(ComparisonFormula):
+    r"""Class representing the lower bound of formula 8.41, [$1 \leq \cot\theta$]."""
+
+    label = "8.41"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, cot_theta: DIMENSIONLESS) -> None:
+        r"""Check the selected inclination of the compression field against its lower bound.
+
+        FprEN 1992-1-1:2023 (E) art 8.2.3 (4) - Formula (8.41)
+
+        Parameters
+        ----------
+        cot_theta : DIMENSIONLESS
+            [$\cot\theta$] Cotangent of the selected inclination of the compression field [$-$].
+        """
+        super().__init__()
+        self.cot_theta = cot_theta
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(*_args, **_kwargs) -> float:
+        """Evaluates the lower bound, which the standard prints as the constant 1."""
+        return 1.0
+
+    @staticmethod
+    def _evaluate_rhs(cot_theta: DIMENSIONLESS, *_args, **_kwargs) -> float:
+        """Evaluates the value under check, for more information see the __init__ method."""
+        return float(cot_theta)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for the lower bound of formula 8.41."""
+        _equation: str = r"1 \leq \cot(\theta)"
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=latex_replace_symbols(
+                template=_equation,
+                replacements={r"\cot(\theta)": f"{self.cot_theta:.{n}f}"},
+                unique_symbol_check=False,
+            ),
+            comparison_operator_label=r"\to",
+            unit="",
+        )
+
+
+class SubForm8Dot41UpperBound(ComparisonFormula):
+    r"""Class representing the upper bound of formula 8.41, [$\cot\theta \leq \cot\theta_{min}$]."""
+
+    label = "8.41"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, cot_theta: DIMENSIONLESS, cot_theta_min: DIMENSIONLESS) -> None:
+        r"""Check the selected inclination of the compression field against its upper bound.
+
+        FprEN 1992-1-1:2023 (E) art 8.2.3 (4) - Formula (8.41)
+
+        Parameters
+        ----------
+        cot_theta : DIMENSIONLESS
+            [$\cot\theta$] Cotangent of the selected inclination of the compression field [$-$].
+        cot_theta_min : DIMENSIONLESS
+            [$\cot\theta_{min}$] Cotangent of the minimal inclination of the compression field [$-$].
+        """
+        super().__init__()
+        self.cot_theta = cot_theta
+        self.cot_theta_min = cot_theta_min
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(cot_theta: DIMENSIONLESS, *_args, **_kwargs) -> float:
+        """Evaluates the value under check, for more information see the __init__ method."""
+        return float(cot_theta)
+
+    @staticmethod
+    def _evaluate_rhs(cot_theta_min: DIMENSIONLESS, *_args, **_kwargs) -> float:
+        """Evaluates the upper bound, for more information see the __init__ method."""
+        return float(cot_theta_min)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for the upper bound of formula 8.41."""
+        _equation: str = r"\cot(\theta) \leq \cot(\theta_{min})"
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=latex_replace_symbols(
+                template=_equation,
+                replacements={
+                    r"\cot(\theta_{min})": f"{self.cot_theta_min:.{n}f}",
+                    r"\cot(\theta)": f"{self.cot_theta:.{n}f}",
+                },
+                unique_symbol_check=False,
+            ),
+            comparison_operator_label=r"\to",
+            unit="",
+        )
+
+
+class Form8Dot41CheckCotangentCompressionFieldAngle(AggregatedComparisonFormula):
+    r"""Class representing formula 8.41 for the check of the cotangent of the inclination of the compression
+    field in the web carrying shear.
+
+    The check is on [$\cot\theta$] and not on [$\theta$]. Since the cotangent decreases over the range of
+    angles that apply here, the same check written in angles reverses direction, so the two are not
+    interchangeable.
+
+    The printed range is one relation, but it is modelled as two comparisons joined with ``all`` so that each
+    bound carries its own unity check. Those two are available through ``comparison_formulas``, and
+    ``unity_check`` on this class is the larger of the two, so it exceeds 1 as soon as either bound is violated.
+    """
+
+    label = "8.41"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __new__(cls, cot_theta: DIMENSIONLESS, cot_theta_min: DIMENSIONLESS) -> Self:
+        """Translates the arguments of this formula into the aggregation the base class evaluates."""
+        return super().__new__(cls, aggregation=all, comparison_formulas=cls._bounds(cot_theta, cot_theta_min))
+
+    def __init__(self, cot_theta: DIMENSIONLESS, cot_theta_min: DIMENSIONLESS) -> None:
+        r"""Check whether the selected inclination of the compression field lies within the permitted range.
+
+        FprEN 1992-1-1:2023 (E) art 8.2.3 (4) - Formula (8.41)
+
+        The standard lets the designer select the inclination, so this is a verification of that choice and
+        not a value to be calculated. Both bounds are inclusive as printed.
+
+        Parameters
+        ----------
+        cot_theta : DIMENSIONLESS
+            [$\cot\theta$] Cotangent of the selected inclination of the compression field in the web
+            carrying shear [$-$].
+        cot_theta_min : DIMENSIONLESS
+            [$\cot\theta_{min}$] Cotangent of the minimal inclination of the compression field. For shear
+            reinforcement of ductility class B or C the standard gives 2,5 for ordinary reinforced members
+            without axial force, 3,0 for members subjected to significant axial compressive force under the
+            conditions of 8.2.3(4), with interpolation between 2,5 and 3,0 for intermediate cases, and
+            [$2,5 - 0,1 \cdot N_{Ed}/|V_{Ed}| \geq 1,0$] for members subjected to axial tension. For ductility
+            class A it shall be reduced by 20 %. None of these three values carries a formula number, so they
+            are an input here rather than a separate class [$-$].
+        """
+        super().__init__(aggregation=all, comparison_formulas=self._bounds(cot_theta, cot_theta_min))
+        self.cot_theta = cot_theta
+        self.cot_theta_min = cot_theta_min
+
+    @staticmethod
+    def _bounds(cot_theta: DIMENSIONLESS, cot_theta_min: DIMENSIONLESS) -> Sequence[ComparisonFormula]:
+        """Builds the two halves of the printed range."""
+        return (
+            SubForm8Dot41LowerBound(cot_theta=cot_theta),
+            SubForm8Dot41UpperBound(cot_theta=cot_theta, cot_theta_min=cot_theta_min),
+        )
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.41."""
+        _equation: str = r"1 \leq \cot(\theta) \leq \cot(\theta_{min})"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\cot(\theta_{min})": f"{self.cot_theta_min:.{n}f}",
+                r"\cot(\theta)": f"{self.cot_theta:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            # Both bounds and the value under check are dimensionless, so the representation with units is the same one.
+            numeric_equation_with_units=_numeric_equation,
+            comparison_operator_label=r"\to",
+            unit="",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -102,7 +102,7 @@ Total of 602 formulas present.
 |      8.38      |        :x:         |         |                                                                    |
 |      8.39      |        :x:         |         |                                                                    |
 |      8.40      |        :x:         |         |                                                                    |
-|      8.41      |        :x:         |         |                                                                    |
+|      8.41      | :heavy_check_mark: |         | Form8Dot41CheckCotangentCompressionFieldAngle                      |
 |      8.42      |        :x:         |         |                                                                    |
 |      8.43      |        :x:         |         |                                                                    |
 |      8.44      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_41.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_41.py
@@ -1,0 +1,121 @@
+"""Testing formula 8.41 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_41 import (
+    Form8Dot41CheckCotangentCompressionFieldAngle,
+    SubForm8Dot41LowerBound,
+    SubForm8Dot41UpperBound,
+)
+
+
+class TestForm8Dot41CheckCotangentCompressionFieldAngle:
+    """Validation for formula 8.41 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("cot_theta", "cot_theta_min", "expected"),
+        [
+            (2.0, 2.5, True),  # inside the range
+            (1.0, 2.5, True),  # at the lower bound, which is inclusive
+            (2.5, 2.5, True),  # at the upper bound, which is inclusive
+            (0.8, 2.5, False),  # below the lower bound
+            (3.0, 2.5, False),  # above the upper bound
+            (2.8, 3.0, True),  # a member with significant axial compressive force
+            (1.5, 1.4, False),  # a member in axial tension, where the upper bound approaches the lower one
+            (1.0, 0.9, False),  # an upper bound below 1 leaves an empty range, so no selected inclination can pass
+        ],
+    )
+    def test_evaluation(self, cot_theta: float, cot_theta_min: float, expected: bool) -> None:
+        """Tests the evaluation of the result."""
+        # Create object to test
+        formula = Form8Dot41CheckCotangentCompressionFieldAngle(cot_theta=cot_theta, cot_theta_min=cot_theta_min)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+
+    @pytest.mark.parametrize(
+        ("cot_theta", "expected_unity_check"),
+        [
+            (2.0, 0.8),  # the upper bound governs: 2.0 / 2.5
+            (0.8, 1.25),  # the lower bound governs: 1 / 0.8
+            (3.0, 1.2),  # the upper bound governs and is violated: 3.0 / 2.5
+        ],
+    )
+    def test_unity_check_is_the_governing_bound(self, cot_theta: float, expected_unity_check: float) -> None:
+        """Aggregating with all takes the largest unity check, so the governing bound is the one reported."""
+        # Create object to test
+        formula = Form8Dot41CheckCotangentCompressionFieldAngle(cot_theta=cot_theta, cot_theta_min=2.5)
+
+        # Perform test by assert
+        assert formula.unity_check == pytest.approx(expected=expected_unity_check, rel=1e-4)
+
+    def test_both_bounds_are_exposed_separately(self) -> None:
+        """Each half of the printed range keeps its own left-hand side, right-hand side and unity check."""
+        # Example values
+        formula = Form8Dot41CheckCotangentCompressionFieldAngle(cot_theta=2.0, cot_theta_min=2.5)
+        lower, upper = formula.comparison_formulas
+
+        # Perform test by assert
+        assert lower.lhs == pytest.approx(expected=1.0, rel=1e-4)
+        assert lower.rhs == pytest.approx(expected=2.0, rel=1e-4)
+        assert upper.lhs == pytest.approx(expected=2.0, rel=1e-4)
+        assert upper.rhs == pytest.approx(expected=2.5, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("cot_theta", "representation", "expected"),
+        [
+            (2.0, "complete", r"CHECK \to 1 \leq \cot(\theta) \leq \cot(\theta_{min}) \to 1 \leq 2.000 \leq 2.500 \to OK"),
+            (2.0, "complete_with_units", r"CHECK \to 1 \leq \cot(\theta) \leq \cot(\theta_{min}) \to 1 \leq 2.000 \leq 2.500 \to OK"),
+            (2.0, "short", r"CHECK \to OK"),
+            (3.0, "complete", r"CHECK \to 1 \leq \cot(\theta) \leq \cot(\theta_{min}) \to 1 \leq 3.000 \leq 2.500 \to \text{Not OK}"),
+            (3.0, "short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex(self, cot_theta: float, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        test_latex = Form8Dot41CheckCotangentCompressionFieldAngle(cot_theta=cot_theta, cot_theta_min=2.5).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]
+
+
+class TestSubForm8Dot41Bounds:
+    """Validation for the two halves of formula 8.41 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("cot_theta", "expected", "expected_latex"),
+        [
+            (2.0, True, r"CHECK \to 1 \leq \cot(\theta) \to 1 \leq 2.000 \to OK"),
+            (0.8, False, r"CHECK \to 1 \leq \cot(\theta) \to 1 \leq 0.800 \to \text{Not OK}"),
+        ],
+    )
+    def test_lower_bound(self, cot_theta: float, expected: bool, expected_latex: str) -> None:
+        """Tests the lower bound on its own."""
+        # Create object to test
+        formula = SubForm8Dot41LowerBound(cot_theta=cot_theta)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+        assert formula.latex().complete == expected_latex
+
+    @pytest.mark.parametrize(
+        ("cot_theta", "expected", "expected_latex"),
+        [
+            (2.0, True, r"CHECK \to \cot(\theta) \leq \cot(\theta_{min}) \to 2.000 \leq 2.500 \to OK"),
+            (3.0, False, r"CHECK \to \cot(\theta) \leq \cot(\theta_{min}) \to 3.000 \leq 2.500 \to \text{Not OK}"),
+        ],
+    )
+    def test_upper_bound(self, cot_theta: float, expected: bool, expected_latex: str) -> None:
+        """Tests the upper bound on its own."""
+        # Create object to test
+        formula = SubForm8Dot41UpperBound(cot_theta=cot_theta, cot_theta_min=2.5)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+        assert formula.latex().complete == expected_latex


### PR DESCRIPTION
Implements formula (8.41) of FprEN 1992-1-1:2023 (E), clause 8.2.3(4), page 122. This opens clause 8.2.3, members with shear reinforcement.

Contributes to #1083.

## A two-sided check built as an aggregation

The standard prints `1 <= cot(theta) <= cot(theta_min)` and introduces it with: "The inclination of the compression field in the web carrying shear may be selected within the following range". The designer selects `cot(theta)`; the formula says whether that selection is admissible. There is no expression on the right of an equals sign, so nothing is being assigned. That is a check, not a value, and it is why (8.32), (8.34) and (8.35) in the earlier pull requests are plain `Formula` instead: those print an assignment with bounds, so they clamp a computed value.

`DoubleComparisonFormula` is on its way out, so the range is built with `AggregatedComparisonFormula`. The one printed relation becomes two comparisons, `SubForm8Dot41LowerBound` and `SubForm8Dot41UpperBound`, joined with `all`.

That gives each bound its own unity check, and the aggregate reports the larger of the two, so the governing bound is visible:

| `cot(theta)` against `cot(theta_min) = 2,5` | verdict | `unity_check` | governed by |
|---|---|---|---|
| 2,0 | OK | 0,80 | upper bound |
| 0,8 | Not OK | 1,25 | lower bound |
| 3,0 | Not OK | 1,20 | upper bound |

Two consequences worth knowing before this pattern spreads through the rest of the standard:

- `lhs` and `rhs` raise `NotImplementedError` on the aggregate by design, so the two halves are reached through `comparison_formulas`. A test pins down all four values.
- `__new__` has to translate the two arguments of this formula into the `aggregation` and `comparison_formulas` pair the base class evaluates. Overriding `_evaluate` instead does not work: its signature is fixed by the base class and `ty` rejects the narrowed override. Every two-sided range in the standard will have to repeat that translation, so a constructor on the base class for this shape would be worth considering.

## Decisions

- Both bounds are inclusive as printed, and both have their own test.
- `cot(theta_min)` is an input, not a separate class. The standard gives three rules for it, 2,5 for ordinary reinforced members, 3,0 under significant axial compression, and `2,5 - 0,1 * N_Ed / |V_Ed| >= 1,0` under axial tension, plus a 20 % reduction for ductility class A. None of the three carries a formula number, so none of them gets a numbered formula class.
- No input validation. The check itself is the answer for any input: a `cot(theta)` below 1 or above `cot(theta_min)` reports Not OK, which is the correct report rather than an error. A `cot(theta_min)` below 1 leaves an empty range, so every selection reports Not OK; there is a test for that. The alternative reading, that such an input should raise, is defensible and a reviewer who prefers it should say so.
- The name says cotangent on purpose. What is checked is `cot(theta)` and not `theta`. The cotangent decreases over the angles that apply here, so the same check written in angles reverses direction. The class docstring says this as well.
- The standard prints `cot(theta)` bare; the LaTeX writes `\cot(\theta)` with parentheses. Without them the substitution key `\cot\theta` is a prefix of `\cot\theta_{min}` and the two would only stay apart by dictionary ordering.

## Verification

Blindly verified against the rendered page 122 of the standard by a second agent that never saw the implementation or the tests.

Verdict **OK**. It independently derived clause 8.2.3(4), both bounds inclusive, the same assignment of the three printed terms to lower bound, value under check and upper bound, and the same boolean for all seven test input sets. It confirmed the check reading over the assignment reading and quoted the sentence that decides it. Two points it raised are both addressed above: it suggested the class name should say cotangent rather than angle, which is why the class carries that name, and it suggested rejecting `cot(theta_min) < 1`, which is the open decision listed above.

Note that the verification ran against the earlier `DoubleComparisonFormula` version. The arithmetic and the boundaries are unchanged by the move to `AggregatedComparisonFormula`; only the base class and the way the two bounds are exposed changed, and the test suite for both was extended rather than replaced.

## Formulas as implemented

**Formula (8.41)**, `Form8Dot41CheckCotangentCompressionFieldAngle`

`equation`

$$
CHECK \to 1 \leq \cot(\theta) \leq \cot(\theta_{min})
$$

`complete`, with `cot_theta = 2,0` and `cot_theta_min = 2,5`

$$
CHECK \to 1 \leq \cot(\theta) \leq \cot(\theta_{min}) \to 1 \leq 2.000 \leq 2.500 \to OK
$$

`complete_with_units`

$$
CHECK \to 1 \leq \cot(\theta) \leq \cot(\theta_{min}) \to 1 \leq 2.000 \leq 2.500 \to OK
$$

Every term here is dimensionless, so `complete_with_units` is deliberately the same string as `complete` rather than being left empty.

And the failing case, with `cot_theta = 3,0` against the same upper bound:

$$
CHECK \to 1 \leq \cot(\theta) \leq \cot(\theta_{min}) \to 1 \leq 3.000 \leq 2.500 \to \text{Not OK}
$$
