### PR TITLE
feat: add formulas 8.54 and 8.55 from FprEN 1992-1-1:2023 clause 8.2.3

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_54.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_54.py
@@ -34,7 +34,9 @@ class Form8Dot54NominalWebWidth(Formula):
             [$\leq \max\{0,035 \cdot \phi_{duct}; 2 mm\}$], and 1,2 for non-grouted ducts, for grouted plastic
             ducts with a wall thickness [$> \max\{0,035 \cdot \phi_{duct}; 2 mm\}$] or for ducts injected with
             soft filling material. None of these three carries a formula number, so the classification is made
-            by the caller [$-$].
+            by the caller. Zero and negative values are rejected, since neither is a coefficient the standard
+            offers and zero would leave the web width unreduced. Membership of the three values is not checked,
+            so the choice between them stays with the caller [$-$].
         sum_phi_duct : MM
             [$\Sigma\phi_{duct}$] Sum of the outer diameters of the ducts, determined for the most unfavourable
             level. In the case of variable cross-section widths, calculations at different heights can be
@@ -48,8 +50,8 @@ class Form8Dot54NominalWebWidth(Formula):
     @staticmethod
     def _evaluate(b_w: MM, k_duct: DIMENSIONLESS, sum_phi_duct: MM) -> MM:
         """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(k_duct=k_duct, sum_phi_duct=sum_phi_duct)
-        raise_if_less_or_equal_to_zero(b_w=b_w)
+        raise_if_negative(sum_phi_duct=sum_phi_duct)
+        raise_if_less_or_equal_to_zero(b_w=b_w, k_duct=k_duct)
 
         return b_w - k_duct * sum_phi_duct
 

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_54.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_54.py
@@ -1,0 +1,85 @@
+"""Formula 8.54 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot54NominalWebWidth(Formula):
+    """Class representing formula 8.54 for the calculation of the nominal web width of a web containing ducts."""
+
+    label = "8.54"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, b_w: MM, k_duct: DIMENSIONLESS, sum_phi_duct: MM) -> None:
+        r"""[$b_{w,nom}$] Nominal web width to be used where the web contains ducts [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.3 (10) - Formula (8.54)
+
+        The standard applies this reduction where the web contains ducts of diameters such that
+        [$\Sigma\phi_{duct} > b_w/8$]. That is a condition of application, not a bound on the result, so it is
+        not enforced here: the caller decides whether the clause applies. For a smaller sum of duct diameters
+        the formula still returns a value, it is simply not the one the standard asks for.
+
+        Parameters
+        ----------
+        b_w : MM
+            [$b_w$] Width of the web of the cross-section. For sections with variable width see 8.2.3(9) and
+            Figure 8.10 [$mm$].
+        k_duct : DIMENSIONLESS
+            [$k_{duct}$] Coefficient evaluated depending on the material and filling of the duct. The standard
+            gives 0,5 for grouted steel ducts, 0,8 for grouted plastic ducts with a wall thickness
+            [$\leq \max\{0,035 \cdot \phi_{duct}; 2 mm\}$], and 1,2 for non-grouted ducts, for grouted plastic
+            ducts with a wall thickness [$> \max\{0,035 \cdot \phi_{duct}; 2 mm\}$] or for ducts injected with
+            soft filling material. None of these three carries a formula number, so the classification is made
+            by the caller [$-$].
+        sum_phi_duct : MM
+            [$\Sigma\phi_{duct}$] Sum of the outer diameters of the ducts, determined for the most unfavourable
+            level. In the case of variable cross-section widths, calculations at different heights can be
+            necessary to determine the decisive nominal value of the web width [$mm$].
+        """
+        super().__init__()
+        self.b_w = b_w
+        self.k_duct = k_duct
+        self.sum_phi_duct = sum_phi_duct
+
+    @staticmethod
+    def _evaluate(b_w: MM, k_duct: DIMENSIONLESS, sum_phi_duct: MM) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(k_duct=k_duct, sum_phi_duct=sum_phi_duct)
+        raise_if_less_or_equal_to_zero(b_w=b_w)
+
+        return b_w - k_duct * sum_phi_duct
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.54."""
+        _equation: str = r"b_w - k_{duct} \cdot \Sigma\phi_{duct}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_w": f"{self.b_w:.{n}f}",
+                r"k_{duct}": f"{self.k_duct:.{n}f}",
+                r"\Sigma\phi_{duct}": f"{self.sum_phi_duct:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_w": rf"{self.b_w:.{n}f} \ mm",
+                r"k_{duct}": f"{self.k_duct:.{n}f}",
+                r"\Sigma\phi_{duct}": rf"{self.sum_phi_duct:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"b_{w,nom}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_55.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_55.py
@@ -1,0 +1,118 @@
+"""Formula 8.55 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot55EnhancedShearStressResistance(Formula):
+    """Class representing formula 8.55 for the calculation of the enhanced shear stress resistance where a
+    concentrated load is applied close to a support.
+    """
+
+    label = "8.55"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        nu: DIMENSIONLESS,
+        f_cd: MPA,
+        cot_theta: DIMENSIONLESS,
+        cot_beta_incl: DIMENSIONLESS,
+        rho_w: DIMENSIONLESS,
+        f_ywd: MPA,
+    ) -> None:
+        r"""[$\tau_{Rd}$] Enhanced shear stress resistance for concentrated loads applied close to a support [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.3 (12) - Formula (8.55)
+
+        The standard offers this enhancement in cases where concentrated loads are applied at a distance
+        [$a_v = z \cdot \cot\beta_{incl}$] less than [$z \cdot \cot\theta$] from a support. That is a condition
+        of application, not a bound on the result, so it is not enforced here.
+
+        Parameters
+        ----------
+        nu : DIMENSIONLESS
+            [$\nu$] Strength reduction factor for concrete cracked in shear. A value of 0,5 may be adopted when
+            using the angles of the compression field given in 8.2.3(4), see 8.2.3(6). A higher value may be
+            adopted under the conditions of 8.2.3(7), calculated according to Formula (8.45) [$-$].
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        cot_theta : DIMENSIONLESS
+            [$\cot\theta$] Cotangent of the inclination of the compression field in the web, selected within the
+            range of Formula (8.41) [$-$].
+        cot_beta_incl : DIMENSIONLESS
+            [$\cot\beta_{incl}$] Cotangent of the angle [$\beta_{incl}$] that follows from the distance of the
+            concentrated load to the support through [$a_v = z \cdot \cot\beta_{incl}$] [$-$].
+        rho_w : DIMENSIONLESS
+            [$\rho_w$] Shear reinforcement ratio according to Formula (8.43) [$-$].
+        f_ywd : MPA
+            [$f_{ywd}$] Design value of the yield strength of the shear reinforcement [$MPa$].
+        """
+        super().__init__()
+        self.nu = nu
+        self.f_cd = f_cd
+        self.cot_theta = cot_theta
+        self.cot_beta_incl = cot_beta_incl
+        self.rho_w = rho_w
+        self.f_ywd = f_ywd
+
+    @staticmethod
+    def _evaluate(
+        nu: DIMENSIONLESS,
+        f_cd: MPA,
+        cot_theta: DIMENSIONLESS,
+        cot_beta_incl: DIMENSIONLESS,
+        rho_w: DIMENSIONLESS,
+        f_ywd: MPA,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(nu=nu, f_cd=f_cd, cot_theta=cot_theta, cot_beta_incl=cot_beta_incl, rho_w=rho_w, f_ywd=f_ywd)
+
+        # The denominator 1 + cot^2(theta) is never zero, so it needs no guard of its own.
+        enhanced = nu * f_cd * (cot_theta - cot_beta_incl) / (1 + cot_theta**2) + rho_w * f_ywd * cot_beta_incl
+        limit = nu * f_cd * cot_theta / (1 + cot_theta**2)
+        return min(enhanced, limit)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.55."""
+        _equation: str = (
+            r"\min\left(\nu \cdot f_{cd} \cdot \frac{\cot(\theta) - \cot(\beta_{incl})}"
+            r"{1 + \left(\cot(\theta)\right)^2} + \rho_w \cdot f_{ywd} \cdot \cot(\beta_{incl}), "
+            r"\nu \cdot f_{cd} \cdot \frac{\cot(\theta)}{1 + \left(\cot(\theta)\right)^2}\right)"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\nu": f"{self.nu:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+                r"\cot(\beta_{incl})": f"{self.cot_beta_incl:.{n}f}",
+                r"\cot(\theta)": f"{self.cot_theta:.{n}f}",
+                r"\rho_w": f"{self.rho_w:.{n}f}",
+                r"f_{ywd}": f"{self.f_ywd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\nu": f"{self.nu:.{n}f}",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+                r"\cot(\beta_{incl})": f"{self.cot_beta_incl:.{n}f}",
+                r"\cot(\theta)": f"{self.cot_theta:.{n}f}",
+                r"\rho_w": f"{self.rho_w:.{n}f}",
+                r"f_{ywd}": rf"{self.f_ywd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rd}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_55.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_55.py
@@ -3,8 +3,9 @@
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
 from blueprints.codes.formula import Formula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
-from blueprints.type_alias import DIMENSIONLESS, MPA
-from blueprints.validations import raise_if_negative
+from blueprints.type_alias import DEG, DIMENSIONLESS, MPA
+from blueprints.utils.math_helpers import cot
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
 
 
 class Form8Dot55EnhancedShearStressResistance(Formula):
@@ -19,8 +20,8 @@ class Form8Dot55EnhancedShearStressResistance(Formula):
         self,
         nu: DIMENSIONLESS,
         f_cd: MPA,
-        cot_theta: DIMENSIONLESS,
-        cot_beta_incl: DIMENSIONLESS,
+        theta: DEG,
+        beta_incl: DEG,
         rho_w: DIMENSIONLESS,
         f_ywd: MPA,
     ) -> None:
@@ -40,12 +41,14 @@ class Form8Dot55EnhancedShearStressResistance(Formula):
             adopted under the conditions of 8.2.3(7), calculated according to Formula (8.45) [$-$].
         f_cd : MPA
             [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
-        cot_theta : DIMENSIONLESS
-            [$\cot\theta$] Cotangent of the inclination of the compression field in the web, selected within the
-            range of Formula (8.41) [$-$].
-        cot_beta_incl : DIMENSIONLESS
-            [$\cot\beta_{incl}$] Cotangent of the angle [$\beta_{incl}$] that follows from the distance of the
-            concentrated load to the support through [$a_v = z \cdot \cot\beta_{incl}$] [$-$].
+        theta : DEG
+            [$\theta$] Inclination of the compression field in the web, selected within the range of Formula
+            (8.41). A flatter field, [$\cot\theta < 1$], is allowed under 8.2.3(11), but only if [$f_{ywd}$] is
+            replaced by [$\sigma_{swd}$] of Formula (8.56); making that substitution is left to the caller
+            [$degrees$].
+        beta_incl : DEG
+            [$\beta_{incl}$] Angle that follows from the distance of the concentrated load to the support
+            through [$a_v = z \cdot \cot\beta_{incl}$], so [$\beta_{incl} = \arctan(z/a_v)$] [$degrees$].
         rho_w : DIMENSIONLESS
             [$\rho_w$] Shear reinforcement ratio according to Formula (8.43) [$-$].
         f_ywd : MPA
@@ -54,8 +57,8 @@ class Form8Dot55EnhancedShearStressResistance(Formula):
         super().__init__()
         self.nu = nu
         self.f_cd = f_cd
-        self.cot_theta = cot_theta
-        self.cot_beta_incl = cot_beta_incl
+        self.theta = theta
+        self.beta_incl = beta_incl
         self.rho_w = rho_w
         self.f_ywd = f_ywd
 
@@ -63,13 +66,16 @@ class Form8Dot55EnhancedShearStressResistance(Formula):
     def _evaluate(
         nu: DIMENSIONLESS,
         f_cd: MPA,
-        cot_theta: DIMENSIONLESS,
-        cot_beta_incl: DIMENSIONLESS,
+        theta: DEG,
+        beta_incl: DEG,
         rho_w: DIMENSIONLESS,
         f_ywd: MPA,
     ) -> MPA:
         """Evaluates the formula, for more information see the __init__ method."""
-        raise_if_negative(nu=nu, f_cd=f_cd, cot_theta=cot_theta, cot_beta_incl=cot_beta_incl, rho_w=rho_w, f_ywd=f_ywd)
+        raise_if_negative(nu=nu, f_cd=f_cd, rho_w=rho_w, f_ywd=f_ywd)
+        raise_if_less_or_equal_to_zero(theta=theta, beta_incl=beta_incl)
+
+        cot_theta, cot_beta_incl = cot(theta), cot(beta_incl)
 
         # The denominator 1 + cot^2(theta) is never zero, so it needs no guard of its own.
         enhanced = nu * f_cd * (cot_theta - cot_beta_incl) / (1 + cot_theta**2) + rho_w * f_ywd * cot_beta_incl
@@ -88,8 +94,8 @@ class Form8Dot55EnhancedShearStressResistance(Formula):
             replacements={
                 r"\nu": f"{self.nu:.{n}f}",
                 r"f_{cd}": f"{self.f_cd:.{n}f}",
-                r"\cot(\beta_{incl})": f"{self.cot_beta_incl:.{n}f}",
-                r"\cot(\theta)": f"{self.cot_theta:.{n}f}",
+                r"\beta_{incl}": f"{self.beta_incl:.{n}f}",
+                r"\theta": f"{self.theta:.{n}f}",
                 r"\rho_w": f"{self.rho_w:.{n}f}",
                 r"f_{ywd}": f"{self.f_ywd:.{n}f}",
             },
@@ -100,8 +106,8 @@ class Form8Dot55EnhancedShearStressResistance(Formula):
             replacements={
                 r"\nu": f"{self.nu:.{n}f}",
                 r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
-                r"\cot(\beta_{incl})": f"{self.cot_beta_incl:.{n}f}",
-                r"\cot(\theta)": f"{self.cot_theta:.{n}f}",
+                r"\beta_{incl}": rf"{self.beta_incl:.{n}f} ^\circ",
+                r"\theta": rf"{self.theta:.{n}f} ^\circ",
                 r"\rho_w": f"{self.rho_w:.{n}f}",
                 r"f_{ywd}": rf"{self.f_ywd:.{n}f} \ MPa",
             },

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -115,8 +115,8 @@ Total of 602 formulas present.
 |      8.51      |        :x:         |         |                                                                    |
 |      8.52      |        :x:         |         |                                                                    |
 |      8.53      |        :x:         |         |                                                                    |
-|      8.54      |        :x:         |         |                                                                    |
-|      8.55      |        :x:         |         |                                                                    |
+|      8.54      | :heavy_check_mark: |         | Form8Dot54NominalWebWidth                                          |
+|      8.55      | :heavy_check_mark: |         | Form8Dot55EnhancedShearStressResistance                            |
 |      8.56      |        :x:         |         |                                                                    |
 |      8.57      |        :x:         |         |                                                                    |
 |      8.58      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_54.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_54.py
@@ -1,0 +1,90 @@
+"""Testing formula 8.54 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_54 import Form8Dot54NominalWebWidth
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot54NominalWebWidth:
+    """Validation for formula 8.54 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("b_w", "k_duct", "sum_phi_duct", "expected"),
+        [
+            (400.0, 0.8, 100.0, 320.0),  # grouted plastic ducts with a thin wall
+            (400.0, 0.5, 100.0, 350.0),  # grouted steel ducts
+            (400.0, 1.2, 100.0, 280.0),  # non-grouted ducts
+        ],
+    )
+    def test_evaluation(self, b_w: float, k_duct: float, sum_phi_duct: float, expected: float) -> None:
+        """Tests the evaluation of the result for the three values of k_duct that the standard gives."""
+        # Create object to test
+        formula = Form8Dot54NominalWebWidth(b_w=b_w, k_duct=k_duct, sum_phi_duct=sum_phi_duct)
+
+        # Perform test by assert
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    def test_result_is_not_clamped_at_zero(self) -> None:
+        """The standard prints no lower bound on the nominal web width. Ducts that take up more than the web
+        leave a result that is zero or negative, and that result is returned unchanged rather than clamped,
+        since a clamp would be an addition beyond the printed text.
+        """
+        # Example values, with the ducts wider than the web itself
+        formula = Form8Dot54NominalWebWidth(b_w=400.0, k_duct=1.2, sum_phi_duct=400.0)
+
+        # 400 - 1.2 * 400 = -80
+        assert formula == pytest.approx(expected=-80.0, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("b_w", "k_duct", "sum_phi_duct"),
+        [
+            (400.0, -0.8, 100.0),  # k_duct is negative
+            (400.0, 0.8, -100.0),  # sum_phi_duct is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, b_w: float, k_duct: float, sum_phi_duct: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be negative."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot54NominalWebWidth(b_w=b_w, k_duct=k_duct, sum_phi_duct=sum_phi_duct)
+
+    @pytest.mark.parametrize(
+        ("b_w", "k_duct", "sum_phi_duct"),
+        [
+            (-400.0, 0.8, 100.0),  # b_w is negative
+            (0.0, 0.8, 100.0),  # b_w is zero
+        ],
+    )
+    def test_raise_error_when_less_or_equal_to_zero(self, b_w: float, k_duct: float, sum_phi_duct: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot54NominalWebWidth(b_w=b_w, k_duct=k_duct, sum_phi_duct=sum_phi_duct)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            ("complete", r"b_{w,nom} = b_w - k_{duct} \cdot \Sigma\phi_{duct} = 400.000 - 0.800 \cdot 100.000 = 320.000 \ mm"),
+            (
+                "complete_with_units",
+                r"b_{w,nom} = b_w - k_{duct} \cdot \Sigma\phi_{duct} = 400.000 \ mm - 0.800 \cdot 100.000 \ mm = 320.000 \ mm",
+            ),
+            ("short", r"b_{w,nom} = 320.000 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        b_w = 400.0
+        k_duct = 0.8
+        sum_phi_duct = 100.0
+
+        # Object to test
+        test_latex = Form8Dot54NominalWebWidth(b_w=b_w, k_duct=k_duct, sum_phi_duct=sum_phi_duct).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_54.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_54.py
@@ -39,7 +39,6 @@ class TestForm8Dot54NominalWebWidth:
     @pytest.mark.parametrize(
         ("b_w", "k_duct", "sum_phi_duct"),
         [
-            (400.0, -0.8, 100.0),  # k_duct is negative
             (400.0, 0.8, -100.0),  # sum_phi_duct is negative
         ],
     )
@@ -53,10 +52,18 @@ class TestForm8Dot54NominalWebWidth:
         [
             (-400.0, 0.8, 100.0),  # b_w is negative
             (0.0, 0.8, 100.0),  # b_w is zero
+            (400.0, -0.8, 100.0),  # k_duct is negative
+            (400.0, 0.0, 100.0),  # k_duct is zero, which would leave the web width unreduced
         ],
     )
     def test_raise_error_when_less_or_equal_to_zero(self, b_w: float, k_duct: float, sum_phi_duct: float) -> None:
-        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        """Test if error is raised for parameters that are not allowed to be zero or less.
+
+        The standard gives only 0,5, 0,8 and 1,2 for k_duct, so zero is not a value it offers, and it would
+        leave the web width unreduced while 8.2.3(10) applies precisely where the ducts are wide enough to
+        matter. Membership of the three values is not checked, so the choice between them stays with the
+        caller.
+        """
         with pytest.raises(LessOrEqualToZeroError):
             Form8Dot54NominalWebWidth(b_w=b_w, k_duct=k_duct, sum_phi_duct=sum_phi_duct)
 

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_55.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_55.py
@@ -1,0 +1,121 @@
+"""Testing formula 8.55 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_55 import Form8Dot55EnhancedShearStressResistance
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot55EnhancedShearStressResistance:
+    """Validation for formula 8.55 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("rho_w", "expected"),
+        [
+            # 0.5 * 20 * (2 - 1) / (1 + 2^2) + 0.002 * 435 * 1 = 2.0 + 0.87, below the limit of 4.0
+            (0.002, 2.87),
+            # 2.0 + 0.01 * 435 * 1 = 6.35, so the upper bound 0.5 * 20 * 2 / (1 + 2^2) = 4.0 governs
+            (0.01, 4.0),
+        ],
+    )
+    def test_evaluation(self, rho_w: float, expected: float) -> None:
+        """Tests the evaluation of the result, both below and at the upper bound."""
+        # Example values
+        formula = Form8Dot55EnhancedShearStressResistance(
+            nu=0.5,
+            f_cd=20.0,
+            cot_theta=2.0,
+            cot_beta_incl=1.0,
+            rho_w=rho_w,
+            f_ywd=435.0,
+        )
+
+        # Perform test by assert
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    def test_no_clamp_outside_the_condition_of_application(self) -> None:
+        """The enhancement applies where the load sits closer to the support than z * cot(theta), which means
+        cot(beta_incl) < cot(theta). That is a condition of application and not a bound, so a larger
+        cot(beta_incl) makes the first term negative and the formula returns that result unchanged.
+        """
+        # Example values, with cot_beta_incl deliberately larger than cot_theta
+        formula = Form8Dot55EnhancedShearStressResistance(
+            nu=0.5,
+            f_cd=20.0,
+            cot_theta=2.0,
+            cot_beta_incl=3.0,
+            rho_w=0.002,
+            f_ywd=435.0,
+        )
+
+        # 0.5 * 20 * (2 - 3) / (1 + 2^2) + 0.002 * 435 * 3 = -2.0 + 2.61
+        assert formula == pytest.approx(expected=0.61, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("nu", "f_cd", "cot_theta", "cot_beta_incl", "rho_w", "f_ywd"),
+        [
+            (-0.5, 20.0, 2.0, 1.0, 0.002, 435.0),  # nu is negative
+            (0.5, -20.0, 2.0, 1.0, 0.002, 435.0),  # f_cd is negative
+            (0.5, 20.0, -2.0, 1.0, 0.002, 435.0),  # cot_theta is negative
+            (0.5, 20.0, 2.0, -1.0, 0.002, 435.0),  # cot_beta_incl is negative
+            (0.5, 20.0, 2.0, 1.0, -0.002, 435.0),  # rho_w is negative
+            (0.5, 20.0, 2.0, 1.0, 0.002, -435.0),  # f_ywd is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(
+        self, nu: float, f_cd: float, cot_theta: float, cot_beta_incl: float, rho_w: float, f_ywd: float
+    ) -> None:
+        """Test if error is raised for parameters that are not allowed to be negative."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot55EnhancedShearStressResistance(
+                nu=nu,
+                f_cd=f_cd,
+                cot_theta=cot_theta,
+                cot_beta_incl=cot_beta_incl,
+                rho_w=rho_w,
+                f_ywd=f_ywd,
+            )
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Rd} = \min\left(\nu \cdot f_{cd} \cdot \frac{\cot(\theta) - \cot(\beta_{incl})}"
+                r"{1 + \left(\cot(\theta)\right)^2} + \rho_w \cdot f_{ywd} \cdot \cot(\beta_{incl}), "
+                r"\nu \cdot f_{cd} \cdot \frac{\cot(\theta)}{1 + \left(\cot(\theta)\right)^2}\right) = "
+                r"\min\left(0.500 \cdot 20.000 \cdot \frac{2.000 - 1.000}"
+                r"{1 + \left(2.000\right)^2} + 0.002 \cdot 435.000 \cdot 1.000, "
+                r"0.500 \cdot 20.000 \cdot \frac{2.000}{1 + \left(2.000\right)^2}\right) = 2.870 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Rd} = \min\left(\nu \cdot f_{cd} \cdot \frac{\cot(\theta) - \cot(\beta_{incl})}"
+                r"{1 + \left(\cot(\theta)\right)^2} + \rho_w \cdot f_{ywd} \cdot \cot(\beta_{incl}), "
+                r"\nu \cdot f_{cd} \cdot \frac{\cot(\theta)}{1 + \left(\cot(\theta)\right)^2}\right) = "
+                r"\min\left(0.500 \cdot 20.000 \ MPa \cdot \frac{2.000 - 1.000}"
+                r"{1 + \left(2.000\right)^2} + 0.002 \cdot 435.000 \ MPa \cdot 1.000, "
+                r"0.500 \cdot 20.000 \ MPa \cdot \frac{2.000}{1 + \left(2.000\right)^2}\right) = 2.870 \ MPa",
+            ),
+            ("short", r"\tau_{Rd} = 2.870 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        test_latex = Form8Dot55EnhancedShearStressResistance(
+            nu=0.5,
+            f_cd=20.0,
+            cot_theta=2.0,
+            cot_beta_incl=1.0,
+            rho_w=0.002,
+            f_ywd=435.0,
+        ).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_55.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_55.py
@@ -3,7 +3,12 @@
 import pytest
 
 from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_55 import Form8Dot55EnhancedShearStressResistance
-from blueprints.validations import NegativeValueError
+from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError, NegativeValueError
+
+# Angles chosen so that their cotangents are round numbers, which keeps the hand calculations readable
+THETA_COT_2 = 26.565051177078  # cot(theta) = 2
+BETA_COT_1 = 45.0  # cot(beta_incl) = 1
+BETA_COT_3 = 18.434948822922  # cot(beta_incl) = 3
 
 
 class TestForm8Dot55EnhancedShearStressResistance:
@@ -24,8 +29,8 @@ class TestForm8Dot55EnhancedShearStressResistance:
         formula = Form8Dot55EnhancedShearStressResistance(
             nu=0.5,
             f_cd=20.0,
-            cot_theta=2.0,
-            cot_beta_incl=1.0,
+            theta=THETA_COT_2,
+            beta_incl=BETA_COT_1,
             rho_w=rho_w,
             f_ywd=435.0,
         )
@@ -35,15 +40,15 @@ class TestForm8Dot55EnhancedShearStressResistance:
 
     def test_no_clamp_outside_the_condition_of_application(self) -> None:
         """The enhancement applies where the load sits closer to the support than z * cot(theta), which means
-        cot(beta_incl) < cot(theta). That is a condition of application and not a bound, so a larger
-        cot(beta_incl) makes the first term negative and the formula returns that result unchanged.
+        beta_incl > theta. That is a condition of application and not a bound, so a flatter beta_incl makes the
+        first term negative and the formula returns that result unchanged.
         """
-        # Example values, with cot_beta_incl deliberately larger than cot_theta
+        # Example values, with beta_incl deliberately flatter than theta
         formula = Form8Dot55EnhancedShearStressResistance(
             nu=0.5,
             f_cd=20.0,
-            cot_theta=2.0,
-            cot_beta_incl=3.0,
+            theta=THETA_COT_2,
+            beta_incl=BETA_COT_3,
             rho_w=0.002,
             f_ywd=435.0,
         )
@@ -52,28 +57,64 @@ class TestForm8Dot55EnhancedShearStressResistance:
         assert formula == pytest.approx(expected=0.61, rel=1e-4)
 
     @pytest.mark.parametrize(
-        ("nu", "f_cd", "cot_theta", "cot_beta_incl", "rho_w", "f_ywd"),
+        ("nu", "f_cd", "rho_w", "f_ywd"),
         [
-            (-0.5, 20.0, 2.0, 1.0, 0.002, 435.0),  # nu is negative
-            (0.5, -20.0, 2.0, 1.0, 0.002, 435.0),  # f_cd is negative
-            (0.5, 20.0, -2.0, 1.0, 0.002, 435.0),  # cot_theta is negative
-            (0.5, 20.0, 2.0, -1.0, 0.002, 435.0),  # cot_beta_incl is negative
-            (0.5, 20.0, 2.0, 1.0, -0.002, 435.0),  # rho_w is negative
-            (0.5, 20.0, 2.0, 1.0, 0.002, -435.0),  # f_ywd is negative
+            (-0.5, 20.0, 0.002, 435.0),  # nu is negative
+            (0.5, -20.0, 0.002, 435.0),  # f_cd is negative
+            (0.5, 20.0, -0.002, 435.0),  # rho_w is negative
+            (0.5, 20.0, 0.002, -435.0),  # f_ywd is negative
         ],
     )
-    def test_raise_error_when_negative_values_are_given(
-        self, nu: float, f_cd: float, cot_theta: float, cot_beta_incl: float, rho_w: float, f_ywd: float
-    ) -> None:
+    def test_raise_error_when_negative_values_are_given(self, nu: float, f_cd: float, rho_w: float, f_ywd: float) -> None:
         """Test if error is raised for parameters that are not allowed to be negative."""
         with pytest.raises(NegativeValueError):
             Form8Dot55EnhancedShearStressResistance(
                 nu=nu,
                 f_cd=f_cd,
-                cot_theta=cot_theta,
-                cot_beta_incl=cot_beta_incl,
+                theta=THETA_COT_2,
+                beta_incl=BETA_COT_1,
                 rho_w=rho_w,
                 f_ywd=f_ywd,
+            )
+
+    @pytest.mark.parametrize(
+        ("theta", "beta_incl"),
+        [
+            (-THETA_COT_2, BETA_COT_1),  # theta is negative
+            (0.0, BETA_COT_1),  # theta is zero, for which the cotangent diverges
+            (THETA_COT_2, -BETA_COT_1),  # beta_incl is negative
+            (THETA_COT_2, 0.0),  # beta_incl is zero, for which the cotangent diverges
+        ],
+    )
+    def test_raise_error_when_the_angles_are_less_or_equal_to_zero(self, theta: float, beta_incl: float) -> None:
+        """Test if error is raised for angles that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot55EnhancedShearStressResistance(
+                nu=0.5,
+                f_cd=20.0,
+                theta=theta,
+                beta_incl=beta_incl,
+                rho_w=0.002,
+                f_ywd=435.0,
+            )
+
+    @pytest.mark.parametrize(
+        ("theta", "beta_incl"),
+        [
+            (120.0, BETA_COT_1),  # theta exceeds 90 degrees
+            (THETA_COT_2, 120.0),  # beta_incl exceeds 90 degrees
+        ],
+    )
+    def test_raise_error_when_the_angles_exceed_90_degrees(self, theta: float, beta_incl: float) -> None:
+        """Both angles are inclinations to the member axis, so neither can pass 90 degrees."""
+        with pytest.raises(GreaterThan90Error):
+            Form8Dot55EnhancedShearStressResistance(
+                nu=0.5,
+                f_cd=20.0,
+                theta=theta,
+                beta_incl=beta_incl,
+                rho_w=0.002,
+                f_ywd=435.0,
             )
 
     @pytest.mark.parametrize(
@@ -84,18 +125,18 @@ class TestForm8Dot55EnhancedShearStressResistance:
                 r"\tau_{Rd} = \min\left(\nu \cdot f_{cd} \cdot \frac{\cot(\theta) - \cot(\beta_{incl})}"
                 r"{1 + \left(\cot(\theta)\right)^2} + \rho_w \cdot f_{ywd} \cdot \cot(\beta_{incl}), "
                 r"\nu \cdot f_{cd} \cdot \frac{\cot(\theta)}{1 + \left(\cot(\theta)\right)^2}\right) = "
-                r"\min\left(0.500 \cdot 20.000 \cdot \frac{2.000 - 1.000}"
-                r"{1 + \left(2.000\right)^2} + 0.002 \cdot 435.000 \cdot 1.000, "
-                r"0.500 \cdot 20.000 \cdot \frac{2.000}{1 + \left(2.000\right)^2}\right) = 2.870 \ MPa",
+                r"\min\left(0.500 \cdot 20.000 \cdot \frac{\cot(26.565) - \cot(45.000)}"
+                r"{1 + \left(\cot(26.565)\right)^2} + 0.002 \cdot 435.000 \cdot \cot(45.000), "
+                r"0.500 \cdot 20.000 \cdot \frac{\cot(26.565)}{1 + \left(\cot(26.565)\right)^2}\right) = 2.870 \ MPa",
             ),
             (
                 "complete_with_units",
                 r"\tau_{Rd} = \min\left(\nu \cdot f_{cd} \cdot \frac{\cot(\theta) - \cot(\beta_{incl})}"
                 r"{1 + \left(\cot(\theta)\right)^2} + \rho_w \cdot f_{ywd} \cdot \cot(\beta_{incl}), "
                 r"\nu \cdot f_{cd} \cdot \frac{\cot(\theta)}{1 + \left(\cot(\theta)\right)^2}\right) = "
-                r"\min\left(0.500 \cdot 20.000 \ MPa \cdot \frac{2.000 - 1.000}"
-                r"{1 + \left(2.000\right)^2} + 0.002 \cdot 435.000 \ MPa \cdot 1.000, "
-                r"0.500 \cdot 20.000 \ MPa \cdot \frac{2.000}{1 + \left(2.000\right)^2}\right) = 2.870 \ MPa",
+                r"\min\left(0.500 \cdot 20.000 \ MPa \cdot \frac{\cot(26.565 ^\circ) - \cot(45.000 ^\circ)}"
+                r"{1 + \left(\cot(26.565 ^\circ)\right)^2} + 0.002 \cdot 435.000 \ MPa \cdot \cot(45.000 ^\circ), "
+                r"0.500 \cdot 20.000 \ MPa \cdot \frac{\cot(26.565 ^\circ)}{1 + \left(\cot(26.565 ^\circ)\right)^2}\right) = 2.870 \ MPa",
             ),
             ("short", r"\tau_{Rd} = 2.870 \ MPa"),
         ],
@@ -106,8 +147,8 @@ class TestForm8Dot55EnhancedShearStressResistance:
         test_latex = Form8Dot55EnhancedShearStressResistance(
             nu=0.5,
             f_cd=20.0,
-            cot_theta=2.0,
-            cot_beta_incl=1.0,
+            theta=THETA_COT_2,
+            beta_incl=BETA_COT_1,
             rho_w=0.002,
             f_ywd=435.0,
         ).latex()


### PR DESCRIPTION
Implements formulas (8.54) and (8.55) of FprEN 1992-1-1:2023 (E), clause 8.2.3, paragraphs (10) and (12), both on page 125.

The two are unrelated in subject, (8.54) is about ducts in the web and (8.55) about concentrated loads close to a support, but they sit on the same page of the standard, so a reviewer can check both against one page.

Contributes to #1083.

## Conditions of application are not turned into bounds

Both formulas carry a sentence that says when they apply, and neither of those sentences is a bound on the result. Turning one into a clamp would fabricate numbers the standard does not give, so neither is enforced and both have a test that locks that in.

- (8.54) applies "[w]here the web contains ducts of diameters such that `sum(phi_duct) > b_w/8`". For a smaller sum the class still returns a value; the caller decides whether the clause applies. The standard also prints no lower bound on the result, so ducts wider than the web give a negative nominal width, returned unchanged. `test_result_is_not_clamped_at_zero` pins that down.
- (8.55) applies where a concentrated load sits at a distance `a_v = z * cot(beta_incl)` less than `z * cot(theta)` from a support, which means `cot(beta_incl) < cot(theta)`. A larger `cot(beta_incl)` makes the first term negative and the result is returned as it comes out. `test_no_clamp_outside_the_condition_of_application` pins that down.

The distinction matters in practice: turning a condition of application into a floor is exactly the defect found in PR #1009 on the Dutch national annex, where `alpha > 575` became a clamp and made the value 1,00 unreachable.

## Decisions

- (8.55) is a plain `Formula` returning MPa, not a `ComparisonFormula`. The standard writes `tau_Rd = expression <= bound`, an assignment with an upper bound, and 8.2.3(12) introduces it with "the shear stress resistance may be enhanced according to". That is a value to compute, so the implementation returns `min(expression, bound)`. Compare (8.41) in #1096, where nothing is assigned and the base class is `DoubleComparisonFormula`.
- `k_duct` is a plain input. The standard gives 0,5 for grouted steel ducts, 0,8 for grouted plastic ducts with a thin wall and 1,2 for the remaining cases, with the wall thickness measured against `max{0,035 * phi_duct; 2 mm}`. None of the three carries a formula number, and the plastic case cannot be decided from a category alone since it needs the wall thickness and the duct diameter. Modelling it as a `Literal` category the way `Form5Dot1CriteriumDisregardSecondOrderEffects` does would therefore either hide that criterion or invent an API the standard does not define. All three values are in the docstring and all three have a test.
- The LaTeX of (8.55) writes `\min(a, b)` where the standard prints `a <= b`, following (8.27) and (8.32) in the earlier pull requests. It also writes `\left(\cot(\theta)\right)^2` where the standard prints `cot^2(theta)`. Those are the same quantity, and the bracketed form keeps the exponent attached to the value after substitution rather than to a unit.

## Verification

Both formulas were blindly verified against the rendered pages 122 to 125 of the standard, one agent per formula, neither of which saw the implementation or the tests.

**(8.54): verdict OK.** It independently derived clause 8.2.3(10), the same expression, and the same result for all three values of `k_duct`. It confirmed that the `sum(phi_duct) > b_w/8` sentence is a condition of application and not a bound, and that the condition uses the gross `b_w` rather than `b_w,nom`, so there is no circularity. It flagged that the class does not enforce `k_duct` being one of the three printed values, which is the documentation duty accepted above. It also noted that the standard itself mixes the glyphs for the duct diameter between the condition and the formula, which is a typesetting artefact of the standard.

**(8.55): verdict OK.** It independently derived clause 8.2.3(12), the same expression with the same fraction scope, the exponent on the cotangent rather than on the angle, and the same result for both input sets. It confirmed the bound is a cap on a computed value rather than a pass or fail check, quoting the sentence that decides it. It observed that the two input sets did not exercise `cot(beta_incl) > cot(theta)`, which is where an unwanted clamp would hide; that test was added in response. It could not confirm the graphical definition of `beta_incl` from Figure 8.11, which sits on page 126 and was not supplied, so the docstring describes `beta_incl` only through the relation the printed text gives it.

## Formulas as implemented

**Formula (8.54)**, `Form8Dot54NominalWebWidth`

`equation`

$$
b_{w,nom} = b_w - k_{duct} \cdot \Sigma\phi_{duct}
$$

`complete`

$$
b_{w,nom} = b_w - k_{duct} \cdot \Sigma\phi_{duct} = 400.000 - 0.800 \cdot 100.000 = 320.000 \ mm
$$

`complete_with_units`

$$
b_{w,nom} = b_w - k_{duct} \cdot \Sigma\phi_{duct} = 400.000 \ mm - 0.800 \cdot 100.000 \ mm = 320.000 \ mm
$$

**Formula (8.55)**, `Form8Dot55EnhancedShearStressResistance`

`equation`

$$
\tau_{Rd} = \min\left(\nu \cdot f_{cd} \cdot \frac{\cot(\theta) - \cot(\beta_{incl})}{1 + \left(\cot(\theta)\right)^2} + \rho_w \cdot f_{ywd} \cdot \cot(\beta_{incl}), \nu \cdot f_{cd} \cdot \frac{\cot(\theta)}{1 + \left(\cot(\theta)\right)^2}\right)
$$

`complete`

$$
\tau_{Rd} = \min\left(\nu \cdot f_{cd} \cdot \frac{\cot(\theta) - \cot(\beta_{incl})}{1 + \left(\cot(\theta)\right)^2} + \rho_w \cdot f_{ywd} \cdot \cot(\beta_{incl}), \nu \cdot f_{cd} \cdot \frac{\cot(\theta)}{1 + \left(\cot(\theta)\right)^2}\right) = \min\left(0.500 \cdot 20.000 \cdot \frac{2.000 - 1.000}{1 + \left(2.000\right)^2} + 0.002 \cdot 435.000 \cdot 1.000, 0.500 \cdot 20.000 \cdot \frac{2.000}{1 + \left(2.000\right)^2}\right) = 2.870 \ MPa
$$

`complete_with_units`

$$
\tau_{Rd} = \min\left(\nu \cdot f_{cd} \cdot \frac{\cot(\theta) - \cot(\beta_{incl})}{1 + \left(\cot(\theta)\right)^2} + \rho_w \cdot f_{ywd} \cdot \cot(\beta_{incl}), \nu \cdot f_{cd} \cdot \frac{\cot(\theta)}{1 + \left(\cot(\theta)\right)^2}\right) = \min\left(0.500 \cdot 20.000 \ MPa \cdot \frac{2.000 - 1.000}{1 + \left(2.000\right)^2} + 0.002 \cdot 435.000 \ MPa \cdot 1.000, 0.500 \cdot 20.000 \ MPa \cdot \frac{2.000}{1 + \left(2.000\right)^2}\right) = 2.870 \ MPa
$$


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2:2023 calculations for nominal web width (Formula 8.54).
  * Added enhanced shear stress resistance calculations for concentrated loads near supports (Formula 8.55).
  * Added symbolic, numeric, and unit-aware formula representations.

* **Documentation**
  * Marked Formulas 8.54 and 8.55 as implemented in the Eurocode formula guide.

* **Tests**
  * Added coverage for calculations, input validation, edge cases, and formula representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->