### PR TITLE
feat: add formula 8.64 from FprEN 1992-1-1:2023 clause 8.2.4

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_64.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_64.py
@@ -1,0 +1,95 @@
+"""Formula 8.64 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MPA, NMM_MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot64ShearStressResistanceWithTransverseBending(Formula):
+    """Class representing formula 8.64 for the calculation of the shear stress resistance reduced by the
+    influence of transverse bending.
+    """
+
+    label = "8.64"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, tau_rd: MPA, m_ed: NMM_MM, m_rd: NMM_MM) -> None:
+        r"""[$\tau_{Rdm}$] Shear stress resistance reduced by the influence of transverse bending [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.4 (2) - Formula (8.64)
+
+        The standard offers this in case of shear reinforcement perpendicular to the longitudinal axis of the
+        member and symmetric to the web middle plane, and states that Annex G may be used as an alternative.
+        It also allows the interaction to be disregarded altogether where
+        [$\tau_{Ed}/\tau_{Rd} < 0,2$] or [$m_{Ed}/m_{Rd} < 0,1$], see 8.2.4(1). Those are conditions of
+        application rather than bounds on the result, so none of them is enforced here.
+
+        Parameters
+        ----------
+        tau_rd : MPA
+            [$\tau_{Rd}$] Shear resistance according to the formula in 8.2.3(5), NOTE 1 [$MPa$].
+        m_ed : NMM_MM
+            [$m_{Ed}$] Transverse bending moment per unit width of the web, see Figure 8.12. The standard
+            prints no unit for it; the lower case m marks it as a moment per unit width rather than a sectional
+            moment, which is also what makes it commensurable with the shear stress it interacts with. Only its
+            ratio to [$m_{Rd}$] enters the formula, so the two only have to be expressed in the same unit, but
+            they do have to be the same kind of quantity [$Nmm/mm$].
+        m_rd : NMM_MM
+            [$m_{Rd}$] Bending resistance without interaction with shear, per unit width of the web. Only the
+            ratio of [$m_{Ed}$] to this value enters the formula [$Nmm/mm$].
+        """
+        super().__init__()
+        self.tau_rd = tau_rd
+        self.m_ed = m_ed
+        self.m_rd = m_rd
+
+    @staticmethod
+    def _evaluate(tau_rd: MPA, m_ed: NMM_MM, m_rd: NMM_MM) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(tau_rd=tau_rd, m_ed=m_ed)
+        raise_if_less_or_equal_to_zero(m_rd=m_rd)
+
+        # A transverse bending moment above the bending resistance leaves no real square root. The standard
+        # prints nothing at all about that case, so rejecting it is a decision taken here and not a reading of
+        # the standard. It is preferred over returning zero or a nan, either of which would hide that the
+        # bending resistance is already exhausted. Note that m_ed equal to m_rd is inside the formula and
+        # returns zero rather than raising.
+        radicand = 1 - m_ed / m_rd
+        raise_if_negative(one_minus_m_ed_over_m_rd=radicand)
+
+        return tau_rd * np.sqrt(radicand)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.64."""
+        _equation: str = r"\tau_{Rd} \cdot \sqrt{1 - \frac{m_{Ed}}{m_{Rd}}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Rd}": f"{self.tau_rd:.{n}f}",
+                r"m_{Ed}": f"{self.m_ed:.{n}f}",
+                r"m_{Rd}": f"{self.m_rd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Rd}": rf"{self.tau_rd:.{n}f} \ MPa",
+                r"m_{Ed}": rf"{self.m_ed:.{n}f} \ Nmm/mm",
+                r"m_{Rd}": rf"{self.m_rd:.{n}f} \ Nmm/mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rdm}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/type_alias.py
+++ b/blueprints/type_alias.py
@@ -61,6 +61,12 @@ KNM = float
 """Kilonewton-meters (kNm), represented as a float."""
 # </editor-fold>
 
+# <editor-fold desc="MOMENT PER UNIT LENGTH">
+NMM_MM = float
+"""Newton-millimeters per millimeter (Nmm/mm), represented as a float. Used for the bending moment per unit
+width of a planar member, which the codes write with a lower case m to distinguish it from a sectional moment."""
+# </editor-fold>
+
 # <editor-fold desc="STRESSES">
 KPA = float
 """Kilopascals (KPa), represented as a float."""

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -125,7 +125,7 @@ Total of 602 formulas present.
 |      8.61      |        :x:         |         |                                                                    |
 |      8.62      |        :x:         |         |                                                                    |
 |      8.63      |        :x:         |         |                                                                    |
-|      8.64      |        :x:         |         |                                                                    |
+|      8.64      | :heavy_check_mark: |         | Form8Dot64ShearStressResistanceWithTransverseBending               |
 |      8.65      |        :x:         |         |                                                                    |
 |      8.66      |        :x:         |         |                                                                    |
 |      8.67      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_64.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_64.py
@@ -1,0 +1,88 @@
+"""Testing formula 8.64 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_64 import (
+    Form8Dot64ShearStressResistanceWithTransverseBending,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot64ShearStressResistanceWithTransverseBending:
+    """Validation for formula 8.64 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("m_ed", "expected"),
+        [
+            # a quarter of the bending resistance, so tau_rd times the root of three quarters
+            (25000.0, 2.598076211353316),
+            # three quarters of it, where the reduction is already a halving
+            (75000.0, 1.5),
+            # without transverse bending the resistance is untouched
+            (0.0, 3.0),
+            # at the bending resistance the root vanishes and no shear resistance is left
+            (100000.0, 0.0),
+        ],
+    )
+    def test_evaluation(self, m_ed: float, expected: float) -> None:
+        """Tests the evaluation of the result, including both ends of the range of the root."""
+        # Create object to test
+        formula = Form8Dot64ShearStressResistanceWithTransverseBending(tau_rd=3.0, m_ed=m_ed, m_rd=100000.0)
+
+        # Perform test by assert
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("tau_rd", "m_ed", "m_rd"),
+        [
+            (-3.0, 25000.0, 100000.0),  # tau_rd is negative
+            (3.0, -25000.0, 100000.0),  # m_ed is negative
+            # a transverse bending moment above the bending resistance leaves no real square root
+            (3.0, 150000.0, 100000.0),
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, tau_rd: float, m_ed: float, m_rd: float) -> None:
+        """Test if error is raised for parameters, or a radicand, that are not allowed to be negative."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot64ShearStressResistanceWithTransverseBending(tau_rd=tau_rd, m_ed=m_ed, m_rd=m_rd)
+
+    @pytest.mark.parametrize(
+        ("tau_rd", "m_ed", "m_rd"),
+        [
+            (3.0, 25000.0, -100000.0),  # m_rd is negative
+            (3.0, 25000.0, 0.0),  # m_rd is zero
+        ],
+    )
+    def test_raise_error_when_less_or_equal_to_zero(self, tau_rd: float, m_ed: float, m_rd: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot64ShearStressResistanceWithTransverseBending(tau_rd=tau_rd, m_ed=m_ed, m_rd=m_rd)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Rdm} = \tau_{Rd} \cdot \sqrt{1 - \frac{m_{Ed}}{m_{Rd}}} = "
+                r"3.000 \cdot \sqrt{1 - \frac{25000.000}{100000.000}} = 2.598 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Rdm} = \tau_{Rd} \cdot \sqrt{1 - \frac{m_{Ed}}{m_{Rd}}} = "
+                r"3.000 \ MPa \cdot \sqrt{1 - \frac{25000.000 \ Nmm/mm}{100000.000 \ Nmm/mm}} = 2.598 \ MPa",
+            ),
+            ("short", r"\tau_{Rdm} = 2.598 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        test_latex = Form8Dot64ShearStressResistanceWithTransverseBending(tau_rd=3.0, m_ed=25000.0, m_rd=100000.0).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]


### PR DESCRIPTION
Implements formula (8.64) of FprEN 1992-1-1:2023 (E), clause 8.2.4(2), page 127.

This completes clause 8.2.4, In-plane shear and transverse bending. It is the only numbered formula in it: 8.2.4(1) prints a condition under which the interaction may be disregarded, but no numbered formula, and 8.2.5 begins on page 128 with (8.65).

Contributes to #1083.

## This pull request adds a type alias

`blueprints/type_alias.py` gains `NMM_MM`, newton-millimetres per millimetre, for the bending moment per unit width of a planar member. That is a change to a shared file in an otherwise ordinary formula pull request, so it should be looked at deliberately rather than waved through.

The reason is `m_Ed` and `m_Rd` in (8.64). The standard prints no unit for either, anywhere on the page. The lower case `m` is the signal: the codes reserve it for a moment per unit width and use upper case `M` for a sectional moment, and here that is also what makes the quantity commensurable with the shear stress `tau_Ed` it interacts with. Figure 8.12 shows both acting on the same strip of web.

The blind verifier was asked for an independent reading before any alias existed, and reached the same conclusion from the clause title, the figure and the surrounding notation. On typing both as a plain `NMM` it said: dimensionally defensible, since only the ratio enters and any unit cancels, but "the annotation NMM asserts a unit the standard does not print and which I believe is the wrong one, and it invites a caller to pass a total moment for `m_Ed` and a per-unit-width resistance for `m_Rd`, which silently gives a wrong answer".

That is the failure this alias is meant to prevent. If a reviewer would rather keep the alias list closed, the alternative is `NMM` on both arguments plus the warning in the docstring; the arithmetic is identical either way.

## Decisions

- The square root spans the whole difference, `sqrt(1 - m_Ed/m_Rd)`, not `sqrt(1) - m_Ed/m_Rd` and not `1 - sqrt(m_Ed/m_Rd)`. The verifier confirmed the vinculum runs over the stacked fraction as well.
- **A transverse bending moment above the bending resistance is rejected, and that is a decision taken here rather than a reading of the standard.** The standard prints nothing about that case: no note, no lower bound on `tau_Rdm`, no statement that the member fails. The square root simply has no real value there. Returning zero would claim a result the formula does not give, and returning a nan would hide the problem, so the class raises. The verifier reached the same preference and was explicit that it must be documented as an implementation decision and not attributed to FprEN 1992-1-1; the code comment says exactly that. Note that `m_Ed` equal to `m_Rd` is inside the formula and returns 0,0 rather than raising, and has its own test.
- The conditions in 8.2.4 are conditions of application and are not enforced. 8.2.4(1) allows the interaction to be disregarded where `tau_Ed/tau_Rd < 0,2` or `m_Ed/m_Rd < 0,1`; that is permission to skip the check, not a validity range. 8.2.4(2) applies to shear reinforcement perpendicular to the member axis and symmetric to the web middle plane, and offers Annex G as an alternative. None of those is a numeric bound. A test with `m_Ed = 0` confirms that an input well inside the disregard region still returns `tau_Rd` unchanged.
- `tau_Ed` is not a parameter. It appears only in the disregard condition of 8.2.4(1), not in (8.64).

## Verification

Blindly verified against the rendered pages 127 and 128 of the standard by a second agent that never saw the implementation or the tests.

Verdict **OK**. It independently derived clause 8.2.4(2), confirmed (8.64) is the only numbered formula in the clause, gave the same result for all four input sets with its arithmetic shown, and settled the scope of the square root from the image. Its two substantive points, the unit of the bending quantities and the status of the `m_Ed > m_Rd` case, are both handled above, and both changed the code.

## Formulas as implemented

**Formula (8.64)**, `Form8Dot64ShearStressResistanceWithTransverseBending`

`equation`

$$
\tau_{Rdm} = \tau_{Rd} \cdot \sqrt{1 - \frac{m_{Ed}}{m_{Rd}}}
$$

`complete`

$$
\tau_{Rdm} = \tau_{Rd} \cdot \sqrt{1 - \frac{m_{Ed}}{m_{Rd}}} = 3.000 \cdot \sqrt{1 - \frac{25000.000}{100000.000}} = 2.598 \ MPa
$$

`complete_with_units`

$$
\tau_{Rdm} = \tau_{Rd} \cdot \sqrt{1 - \frac{m_{Ed}}{m_{Rd}}} = 3.000 \ MPa \cdot \sqrt{1 - \frac{25000.000 \ Nmm/mm}{100000.000 \ Nmm/mm}} = 2.598 \ MPa
$$


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2 (2023) Formula 8.64 for calculating shear stress resistance reduced by transverse bending.
  * Added support for moment-per-unit-length values in Nmm/mm.
  * Added formatted formula output with optional units.
  * Added validation for invalid stress and bending inputs.

* **Documentation**
  * Marked Formula 8.64 as implemented in the Eurocode formula tracker.

* **Tests**
  * Added coverage for calculations, invalid inputs, boundary conditions, and formula formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->