### PR TITLE
feat: add formulas 8.65 and 8.66 from FprEN 1992-1-1:2023 clause 8.2.5

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_65.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_65.py
@@ -1,0 +1,87 @@
+"""Formula 8.65 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MPA, N
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot65LongitudinalShearStressFlangeWebJunction(Formula):
+    """Class representing formula 8.65 for the calculation of the longitudinal shear stress at the junction
+    between one side of a flange and the web.
+    """
+
+    label = "8.65"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, delta_f_d: N, h_f: MM, delta_x: MM) -> None:
+        r"""[$\tau_{Ed}$] Longitudinal shear stress at the junction between one side of a flange and the
+        web [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art 8.2.5 (1) - Formula (8.65)
+
+        The standard limits the length under consideration: the maximum value that may be assumed for
+        [$\Delta x$] is half the distance between the section where the moment is 0 and the section where it is
+        maximum, and where point loads are applied it should not exceed the distance between point loads. Those
+        are conditions on how the caller chooses the length, not bounds on the result, so they are not enforced
+        here.
+
+        Parameters
+        ----------
+        delta_f_d : N
+            [$\Delta F_d$] Change of the axial force in the flange over the length [$\Delta x$], see
+            Figure 8.13 [$N$].
+        h_f : MM
+            [$h_f$] Thickness of the flange at the junctions [$mm$].
+        delta_x : MM
+            [$\Delta x$] Length under consideration, see Figure 8.13 [$mm$].
+        """
+        super().__init__()
+        self.delta_f_d = delta_f_d
+        self.h_f = h_f
+        self.delta_x = delta_x
+
+    @staticmethod
+    def _evaluate(delta_f_d: N, h_f: MM, delta_x: MM) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        # The standard prints no sign requirement on the change of the axial force and no absolute value
+        # bars, so rejecting a negative one is a decision taken here and not a reading of the standard. It is
+        # preferred over passing the sign through, because a negative shear stress would satisfy the check of
+        # Formula (8.66) for a load case that is just as onerous as its mirror image. Taking the magnitude
+        # instead would also close that path, but it would silently accept either sign convention.
+        raise_if_negative(delta_f_d=delta_f_d)
+        raise_if_less_or_equal_to_zero(h_f=h_f, delta_x=delta_x)
+
+        return delta_f_d / (h_f * delta_x)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.65."""
+        _equation: str = r"\frac{\Delta F_d}{h_f \cdot \Delta x}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Delta F_d": f"{self.delta_f_d:.{n}f}",
+                r"h_f": f"{self.h_f:.{n}f}",
+                r"\Delta x": f"{self.delta_x:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Delta F_d": rf"{self.delta_f_d:.{n}f} \ N",
+                r"h_f": rf"{self.h_f:.{n}f} \ mm",
+                r"\Delta x": rf"{self.delta_x:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Ed}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_66.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_66.py
@@ -1,0 +1,106 @@
+"""Formula 8.66 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import operator
+from collections.abc import Callable
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import ComparisonFormula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot66CheckOmissionOfShearVerification(ComparisonFormula):
+    r"""Class representing formula 8.66 for the check that determines whether the verification of the shear
+    between web and flanges may be omitted.
+
+    A satisfied check does not mean the connection has been verified. It means the standard permits the
+    verification to be skipped and requires no extra reinforcement above that for transverse bending. A check
+    that is not satisfied does not mean the connection fails either; it means 8.2.5(3) and (4) have to be
+    worked through, starting from Formula (8.69).
+    """
+
+    label = "8.66"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, tau_ed: MPA, a_st_min: MM2, s_f: MM, h_f: MM, f_yd: MPA) -> None:
+        r"""Check whether further verification of the shear between web and flanges may be omitted.
+
+        FprEN 1992-1-1:2023 (E) art 8.2.5 (2) - Formula (8.66)
+
+        Parameters
+        ----------
+        tau_ed : MPA
+            [$\tau_{Ed}$] Longitudinal shear stress at the junction between one side of a flange and the web
+            according to Formula (8.65), see Form8Dot65LongitudinalShearStressFlangeWebJunction [$MPa$].
+        a_st_min : MM2
+            [$A_{st,min}$] Minimum transverse reinforcement according to Table 12.1 (NDP) [$mm^2$].
+        s_f : MM
+            [$s_f$] Spacing of the transverse reinforcement in the flange. The standard does not define it in
+            words; it appears only as a dimension in Figure 8.13, between the transverse bars along
+            [$\Delta x$] [$mm$].
+        h_f : MM
+            [$h_f$] Thickness of the flange at the junctions [$mm$].
+        f_yd : MPA
+            [$f_{yd}$] Design value of the yield strength of the transverse reinforcement [$MPa$].
+        """
+        super().__init__()
+        self.tau_ed = tau_ed
+        self.a_st_min = a_st_min
+        self.s_f = s_f
+        self.h_f = h_f
+        self.f_yd = f_yd
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(tau_ed: MPA, *_args, **_kwargs) -> float:
+        """Evaluates the longitudinal shear stress, for more information see the __init__ method."""
+        raise_if_negative(tau_ed=tau_ed)
+
+        return float(tau_ed)
+
+    @staticmethod
+    def _evaluate_rhs(a_st_min: MM2, s_f: MM, h_f: MM, f_yd: MPA, *_args, **_kwargs) -> float:
+        """Evaluates the stress that the minimum transverse reinforcement already carries."""
+        raise_if_negative(a_st_min=a_st_min, f_yd=f_yd)
+        raise_if_less_or_equal_to_zero(s_f=s_f, h_f=h_f)
+
+        return float(a_st_min / (s_f * h_f) * f_yd)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.66."""
+        _equation: str = r"\tau_{Ed} \leq \frac{A_{st,min}}{s_f \cdot h_f} \cdot f_{yd}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Ed}": f"{self.tau_ed:.{n}f}",
+                r"A_{st,min}": f"{self.a_st_min:.{n}f}",
+                r"s_f": f"{self.s_f:.{n}f}",
+                r"h_f": f"{self.h_f:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Ed}": rf"{self.tau_ed:.{n}f} \ MPa",
+                r"A_{st,min}": rf"{self.a_st_min:.{n}f} \ mm^2",
+                r"s_f": rf"{self.s_f:.{n}f} \ mm",
+                r"h_f": rf"{self.h_f:.{n}f} \ mm",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label=r"\to",
+            unit="",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -126,8 +126,8 @@ Total of 602 formulas present.
 |      8.62      |        :x:         |         |                                                                    |
 |      8.63      |        :x:         |         |                                                                    |
 |      8.64      |        :x:         |         |                                                                    |
-|      8.65      |        :x:         |         |                                                                    |
-|      8.66      |        :x:         |         |                                                                    |
+|      8.65      | :heavy_check_mark: |         | Form8Dot65LongitudinalShearStressFlangeWebJunction                 |
+|      8.66      | :heavy_check_mark: |         | Form8Dot66CheckOmissionOfShearVerification                         |
 |      8.67      |        :x:         |         |                                                                    |
 |      8.68      |        :x:         |         |                                                                    |
 |      8.69      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_65.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_65.py
@@ -1,0 +1,75 @@
+"""Testing formula 8.65 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_65 import (
+    Form8Dot65LongitudinalShearStressFlangeWebJunction,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot65LongitudinalShearStressFlangeWebJunction:
+    """Validation for formula 8.65 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("delta_f_d", "h_f", "delta_x", "expected"),
+        [
+            (200000.0, 200.0, 2000.0, 0.5),  # 200000 over an area of 200 by 2000
+            (0.0, 200.0, 2000.0, 0.0),  # no change of axial force over the length considered
+            (200000.0, 100.0, 2000.0, 1.0),  # halving the flange thickness doubles the stress
+        ],
+    )
+    def test_evaluation(self, delta_f_d: float, h_f: float, delta_x: float, expected: float) -> None:
+        """Tests the evaluation of the result."""
+        # Create object to test
+        formula = Form8Dot65LongitudinalShearStressFlangeWebJunction(delta_f_d=delta_f_d, h_f=h_f, delta_x=delta_x)
+
+        # Perform test by assert
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    def test_raise_error_when_negative_values_are_given(self) -> None:
+        """Test if error is raised for a change of axial force that is not allowed to be negative."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot65LongitudinalShearStressFlangeWebJunction(delta_f_d=-200000.0, h_f=200.0, delta_x=2000.0)
+
+    @pytest.mark.parametrize(
+        ("delta_f_d", "h_f", "delta_x"),
+        [
+            (200000.0, -200.0, 2000.0),  # h_f is negative
+            (200000.0, 0.0, 2000.0),  # h_f is zero
+            (200000.0, 200.0, -2000.0),  # delta_x is negative
+            (200000.0, 200.0, 0.0),  # delta_x is zero
+        ],
+    )
+    def test_raise_error_when_less_or_equal_to_zero(self, delta_f_d: float, h_f: float, delta_x: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot65LongitudinalShearStressFlangeWebJunction(delta_f_d=delta_f_d, h_f=h_f, delta_x=delta_x)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Ed} = \frac{\Delta F_d}{h_f \cdot \Delta x} = \frac{200000.000}{200.000 \cdot 2000.000} = 0.500 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Ed} = \frac{\Delta F_d}{h_f \cdot \Delta x} = "
+                r"\frac{200000.000 \ N}{200.000 \ mm \cdot 2000.000 \ mm} = 0.500 \ MPa",
+            ),
+            ("short", r"\tau_{Ed} = 0.500 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        test_latex = Form8Dot65LongitudinalShearStressFlangeWebJunction(delta_f_d=200000.0, h_f=200.0, delta_x=2000.0).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_66.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_66.py
@@ -1,0 +1,118 @@
+"""Testing formula 8.66 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_66 import (
+    Form8Dot66CheckOmissionOfShearVerification,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot66CheckOmissionOfShearVerification:
+    """Validation for formula 8.66 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("tau_ed", "expected", "expected_unity_check"),
+        [
+            # the minimum transverse reinforcement carries 400 / (200 * 200) * 435 = 4.35 MPa
+            (0.5, True, 0.11494252873563217),
+            (5.0, False, 1.1494252873563218),
+        ],
+    )
+    def test_evaluation(self, tau_ed: float, expected: bool, expected_unity_check: float) -> None:
+        """Tests the verdict and the unity check that it is based on."""
+        # Create object to test
+        formula = Form8Dot66CheckOmissionOfShearVerification(tau_ed=tau_ed, a_st_min=400.0, s_f=200.0, h_f=200.0, f_yd=435.0)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+        assert formula.unity_check == pytest.approx(expected=expected_unity_check, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("tau_ed", "expected"),
+        [
+            (4.0, True),  # exactly on the limit, which is inclusive as printed
+            (4.000001, False),  # just above it
+        ],
+    )
+    def test_bound_is_inclusive(self, tau_ed: float, expected: bool) -> None:
+        """The bound is printed with a less than or equal sign, so a shear stress exactly on it passes.
+
+        The values are chosen so that 400 / (200 * 200) * 400 is exactly 4.0 in floating point. With the 435
+        of the other tests the limit comes out as 4.3500000000000005, and a case sitting on it would pass by
+        rounding rather than by the printed inequality, which would prove nothing about inclusivity.
+        """
+        # Create object to test
+        formula = Form8Dot66CheckOmissionOfShearVerification(tau_ed=tau_ed, a_st_min=400.0, s_f=200.0, h_f=200.0, f_yd=400.0)
+
+        # Perform test by assert
+        assert formula.rhs == 4.0
+        assert bool(formula) is expected
+
+    def test_both_sides_are_exposed(self) -> None:
+        """The shear stress and the stress the minimum reinforcement carries are both available."""
+        # Example values
+        formula = Form8Dot66CheckOmissionOfShearVerification(tau_ed=0.5, a_st_min=400.0, s_f=200.0, h_f=200.0, f_yd=435.0)
+
+        # Perform test by assert
+        assert formula.lhs == pytest.approx(expected=0.5, rel=1e-4)
+        assert formula.rhs == pytest.approx(expected=4.35, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("tau_ed", "a_st_min", "f_yd"),
+        [
+            (-0.5, 400.0, 435.0),  # tau_ed is negative
+            (0.5, -400.0, 435.0),  # a_st_min is negative
+            (0.5, 400.0, -435.0),  # f_yd is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, tau_ed: float, a_st_min: float, f_yd: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be negative."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot66CheckOmissionOfShearVerification(tau_ed=tau_ed, a_st_min=a_st_min, s_f=200.0, h_f=200.0, f_yd=f_yd)
+
+    @pytest.mark.parametrize(
+        ("s_f", "h_f"),
+        [
+            (-200.0, 200.0),  # s_f is negative
+            (0.0, 200.0),  # s_f is zero
+            (200.0, -200.0),  # h_f is negative
+            (200.0, 0.0),  # h_f is zero
+        ],
+    )
+    def test_raise_error_when_less_or_equal_to_zero(self, s_f: float, h_f: float) -> None:
+        """Test if error is raised for parameters that are not allowed to be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot66CheckOmissionOfShearVerification(tau_ed=0.5, a_st_min=400.0, s_f=s_f, h_f=h_f, f_yd=435.0)
+
+    @pytest.mark.parametrize(
+        ("tau_ed", "representation", "expected"),
+        [
+            (
+                0.5,
+                "complete",
+                r"CHECK \to \tau_{Ed} \leq \frac{A_{st,min}}{s_f \cdot h_f} \cdot f_{yd} \to "
+                r"0.500 \leq \frac{400.000}{200.000 \cdot 200.000} \cdot 435.000 \to OK",
+            ),
+            (
+                0.5,
+                "complete_with_units",
+                r"CHECK \to \tau_{Ed} \leq \frac{A_{st,min}}{s_f \cdot h_f} \cdot f_{yd} \to "
+                r"0.500 \ MPa \leq \frac{400.000 \ mm^2}{200.000 \ mm \cdot 200.000 \ mm} \cdot 435.000 \ MPa \to OK",
+            ),
+            (0.5, "short", r"CHECK \to OK"),
+            (5.0, "short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex(self, tau_ed: float, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        test_latex = Form8Dot66CheckOmissionOfShearVerification(tau_ed=tau_ed, a_st_min=400.0, s_f=200.0, h_f=200.0, f_yd=435.0).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]


### PR DESCRIPTION
Implements formulas (8.65) and (8.66) of FprEN 1992-1-1:2023 (E), clause 8.2.5, paragraphs (1) and (2), pages 128 and 129. This opens clause 8.2.5, shear between web and flanges.

Contributes to #1083.

## A passing check here does not mean the connection is safe

(8.66) is a `ComparisonFormula`, but its meaning is unlike the checks in the earlier pull requests of this series. The standard introduces it with: "In case the following condition is satisfied, further verification of the shear between web and flanges may be omitted and no extra reinforcement above that for transverse bending is required".

So a satisfied check means the designer may skip the work of 8.2.5(3) and (4), not that the junction has been verified. And a failing check does not mean the junction is inadequate: 8.2.5(3) then says the shear strength of the flange "may be calculated by considering the flange as a system of compression fields combined with ties", which routes the design through (8.67) to (8.71) and may well pass.

Both readings are in the class docstring, because `OK` on a check that is really a permission to stop checking is exactly the kind of thing that gets misread downstream. The blind verifier was asked what a satisfied check means before seeing any of this and reached the same two-sided reading from the printed sentences.

## Decisions

- **(8.65) rejects a negative change of axial force, and that is a decision taken here rather than a reading of the standard.** The standard defines `dF_d` only as "the change of the axial force in the flange over the length dx". It prints no sign requirement and no absolute value bars. Letting the sign through would be worse than rejecting: a negative shear stress satisfies (8.66) trivially, for a load case that is just as onerous as its mirror image. Taking the magnitude would also close that path but would silently accept either sign convention. The code comment says all of this, and the verifier independently identified the same failure mode and the same two candidate treatments.
- The limits the standard sets on `dx`, half the distance between the section of zero moment and the section of maximum moment, and no more than the distance between point loads, are conditions on how the caller picks the length. They are not bounds on the result and are not enforced.
- `s_f` is documented as the standard leaves it. The verifier pointed out that neither page defines it in words: it appears only as a dimension in Figure 8.13, between the transverse bars along `dx`. The docstring now says so rather than asserting a definition of its own.

## A boundary test that passed by rounding luck

The first version of the inclusive-bound test used `tau_ed = 4.35` against `400 / (200 * 200) * 435`. That expression evaluates to `4.3500000000000005` while the literal `4.35` is `4.34999999999999964`, so the case passed on rounding rather than on the printed `<=`. It proved nothing about inclusivity.

The verifier flagged it: "Set B is a floating-point knife-edge ... flagging it rather than trusting it." The test now uses `f_yd = 400`, for which `400 / (200 * 200) * 400` is exactly `4.0`, asserts that the right-hand side really is `4.0`, and checks both `4.0` and a value just above it. The realistic `435` stays in the other cases.

## Verification

Both formulas were blindly verified against the rendered pages 128 and 129 of the standard, one agent per formula, neither of which saw the implementation or the tests.

**(8.65): verdict OK.** Same result for all three input sets. It confirmed the unit by working through the dimensions, and that the fraction bar spans both factors of the denominator. On the sign question it was explicit that rejecting a negative value is an addition to the standard and must be documented as the implementer's choice, which is what the code comment now does.

**(8.66): verdict OK.** Same right-hand side and the same verdict for all three input sets, with its arithmetic shown. It quoted the sentence that fixes what a satisfied check means, confirmed the bound is inclusive, and confirmed that `f_yd` multiplies the whole fraction and is not under the bar. Its two remarks, on `s_f` being undefined in words and on the knife-edge boundary case, both changed this pull request.

## Formulas as implemented

**Formula (8.65)**, `Form8Dot65LongitudinalShearStressFlangeWebJunction`

`equation`

$$
\tau_{Ed} = \frac{\Delta F_d}{h_f \cdot \Delta x}
$$

`complete`

$$
\tau_{Ed} = \frac{\Delta F_d}{h_f \cdot \Delta x} = \frac{200000.000}{200.000 \cdot 2000.000} = 0.500 \ MPa
$$

`complete_with_units`

$$
\tau_{Ed} = \frac{\Delta F_d}{h_f \cdot \Delta x} = \frac{200000.000 \ N}{200.000 \ mm \cdot 2000.000 \ mm} = 0.500 \ MPa
$$

**Formula (8.66)**, `Form8Dot66CheckOmissionOfShearVerification`

`equation`

$$
CHECK \to \tau_{Ed} \leq \frac{A_{st,min}}{s_f \cdot h_f} \cdot f_{yd}
$$

`complete`

$$
CHECK \to \tau_{Ed} \leq \frac{A_{st,min}}{s_f \cdot h_f} \cdot f_{yd} \to 0.500 \leq \frac{400.000}{200.000 \cdot 200.000} \cdot 435.000 \to OK
$$

`complete_with_units`

$$
CHECK \to \tau_{Ed} \leq \frac{A_{st,min}}{s_f \cdot h_f} \cdot f_{yd} \to 0.500 \ MPa \leq \frac{400.000 \ mm^2}{200.000 \ mm \cdot 200.000 \ mm} \cdot 435.000 \ MPa \to OK
$$


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2:2023 Formula 8.65 for calculating longitudinal shear stress at a flange–web junction.
  * Added Formula 8.66 to verify when shear verification may be omitted based on reinforcement and stress limits.
  * Both formulas support validation, numerical results, and LaTeX representations with units.

* **Documentation**
  * Updated the Eurocode formula status table to mark Formulas 8.65 and 8.66 as complete.

* **Tests**
  * Added coverage for calculations, validation, threshold behavior, comparison results, and LaTeX output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->