### PR TITLE
fix: derive the boolean of a comparison formula from its operator instead of its unity check

### DIFF
--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -211,21 +211,28 @@ class ComparisonFormula(Formula, ABC):
     def __bool__(self) -> bool:
         """Return whether the comparison condition is satisfied.
 
-        Returns True if the unity check is less than or equal to 1.0, indicating the condition is satisfied.
-        This allows ComparisonFormula instances to be used directly in boolean contexts.
+        The comparison operator is applied to the two sides directly, so that this agrees with
+        :meth:`_evaluate` and therefore with ``float(self)`` for every input.
+
+        It deliberately does not go through :attr:`unity_check`. That ratio only orders the two sides
+        correctly while both have the same sign. Where they do not, ``lhs / rhs`` turns negative and a
+        negative value is below 1, so a condition that is in fact violated would be reported as satisfied;
+        a right-hand side of zero would raise :class:`ZeroDivisionError` instead of answering. Both are
+        reachable whenever a lower bound is written as ``constant <= value``, which puts the value under
+        check on the right-hand side.
 
         Examples
         --------
         formula = SomeComparisonFormula(...)
-        if formula:  # Equivalent to: if formula.unity_check <= 1.0
+        if formula:  # Equivalent to: if formula.lhs <= formula.rhs, for the le operator
             print("Condition satisfied")
 
         Returns
         -------
         bool
-            True if unity_check <= 1.0 (condition is satisfied), False otherwise.
+            True if the comparison holds, False otherwise.
         """
-        return self.unity_check <= 1.0
+        return bool(self._comparison_operator()(self.lhs, self.rhs))
 
     @classmethod
     def _evaluate(cls, *args, **kwargs) -> bool:
@@ -325,6 +332,25 @@ class AggregatedComparisonFormula(ComparisonFormula):
             if self.aggregation is all
             else min(formula.unity_check for formula in self.comparison_formulas)
         )
+
+    def __bool__(self) -> bool:
+        """Return whether the aggregated condition is satisfied.
+
+        The aggregation function is applied to the results of the individual comparison formulas, so that
+        this agrees with :meth:`_evaluate` and therefore with ``float(self)``.
+
+        It cannot use the inherited implementation, because this class disables the comparison operator and
+        the two sides it works on. It deliberately does not go through :attr:`unity_check` either: for an
+        ``any`` aggregation the smallest ratio decides, which is not the same question as whether any of the
+        conditions holds, and the ratios of the members carry the sign problem described on
+        :meth:`ComparisonFormula.__bool__`.
+
+        Returns
+        -------
+        bool
+            True if the aggregated condition holds, False otherwise.
+        """
+        return bool(self.aggregation(bool(formula) for formula in self.comparison_formulas))
 
     @classmethod
     def _evaluate(

--- a/tests/codes/test_formula.py
+++ b/tests/codes/test_formula.py
@@ -849,3 +849,59 @@ class TestAggregatedComparisonFormula:
         outer = AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[inner_any, inner_all])
         assert not outer
         assert bool(outer) is False
+
+
+class TestComparisonFormulaBooleanAgreesWithEvaluate:
+    """The boolean of a comparison must agree with the comparison itself, whatever the signs of the two sides.
+
+    Deriving it from the unity check does not: that ratio only orders the two sides correctly while both have
+    the same sign. These cases are reachable in practice whenever a lower bound is written as
+    ``constant <= value``, which puts the value under check on the right-hand side of the comparison.
+
+    ``ComparisonFormulaTestLessOrEqual`` has ``lhs = a + b`` and ``rhs = c / 2`` with the ``le`` operator.
+    """
+
+    @pytest.mark.parametrize(
+        ("a", "b", "c", "expected"),
+        [
+            (1, 1, 10, True),  # lhs = 2, rhs = 5, both positive
+            (4, 1, 4, False),  # lhs = 5, rhs = 2, both positive
+            (1, 1, -4, False),  # lhs = 2, rhs = -2, so the ratio is -1 and would report a satisfied condition
+            (-1, -1, 4, True),  # lhs = -2, rhs = 2, so the ratio is -1 as well, and here it is satisfied
+            # lhs = -2, rhs = -1, both negative, so the ratio is 2 and would report a violated condition
+            (-1, -1, -2, True),
+            (1, 1, 0, False),  # lhs = 2, rhs = 0, where the ratio does not exist at all
+        ],
+    )
+    def test_bool_matches_the_operator(self, a: float, b: float, c: float, expected: bool) -> None:
+        """The boolean follows the operator applied to the two sides."""
+        formula = ComparisonFormulaTestLessOrEqual(a=a, b=b, c=c)
+
+        assert bool(formula) is expected
+        assert bool(formula) == bool(float(formula)), "bool() and float() must not disagree"
+
+    @pytest.mark.parametrize(
+        ("a", "b", "c"),
+        [
+            (1, 1, -4),  # lhs = 2, rhs = -2
+            (1, 1, 0),  # lhs = 2, rhs = 0
+        ],
+    )
+    def test_aggregation_of_a_sign_crossing_member(self, a: float, b: float, c: float) -> None:
+        """An aggregate follows its members, including where their two sides straddle zero.
+
+        The aggregate cannot reuse the inherited boolean, because it disables the comparison operator and the
+        two sides. It aggregates the results of its members instead, which is what its own ``_evaluate``
+        already does.
+        """
+        crossing = ComparisonFormulaTestLessOrEqual(a=a, b=b, c=c)
+        passing = ComparisonFormulaTestLessOrEqual(a=1, b=1, c=10)
+
+        aggregate_all = AggregatedComparisonFormulaTest(aggregation=all, comparison_formulas=[passing, crossing])
+        aggregate_any = AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[passing, crossing])
+
+        assert bool(crossing) is False
+        assert bool(aggregate_all) is False
+        assert bool(aggregate_any) is True
+        assert bool(aggregate_all) == bool(float(aggregate_all))
+        assert bool(aggregate_any) == bool(float(aggregate_any))


### PR DESCRIPTION
`ComparisonFormula.__bool__` derived its answer from `unity_check`, the ratio of the two sides. That ratio only orders them correctly while both have the same sign, so a comparison whose sides straddle zero was reported wrongly, and one with a right-hand side of zero raised instead of answering.

`ComparisonFormula._evaluate` never had the problem: it applies the operator. So `float(formula)` was right while `bool(formula)` was wrong, and the two disagreed silently.

## What was wrong

With `lhs = 2`, `rhs = -2` and the `le` operator, `2 <= -2` is false, but `2 / -2 = -1` and `-1 <= 1` is true, so the check reported satisfied. With `lhs = -2`, `rhs = -1` it went the other way: `-2 <= -1` is true, but the ratio is `2` and the check reported violated. With `rhs = 0` there is no ratio at all and it raised `ZeroDivisionError`.

This is reachable in ordinary use. A lower bound has to be written as `constant <= value`, which puts the value under check on the right-hand side. Three range checks from the FprEN 1992-1-1:2023 series are built that way and all three were affected:

```
8.41  cot_theta = -1.0                 -> reported OK,  while 1 <= -1.0 <= 2.5 is false
8.58  cot_theta = -1.0, alpha_w = 60   -> reported OK,  while 0.577 <= -1.0 <= 2.5 is false
8.67  cot_theta_f = -1.0, compression  -> reported OK,  while 1 <= -1.0 <= 3.0 is false
all three, cot = 0.0                   -> ZeroDivisionError
```

`AggregatedComparisonFormula` inherited the same `__bool__` while disabling the comparison operator and both sides, so it could not be corrected by the same change alone. Its own `_evaluate` aggregates over `bool(member)` and was therefore correct all along, which is the second disagreement this fixes.

## The fix

Two methods, no change to any signature or to `unity_check`:

- `ComparisonFormula.__bool__` applies the comparison operator to the two sides.
- `AggregatedComparisonFormula.__bool__` applies the aggregation function to the results of its members, which is exactly what its `_evaluate` already did.

After this, `bool(formula)` and `float(formula)` agree by construction in both classes.

## Evidence

The whole suite passes: **6760 tests, no regressions**. That covers the 24 comparison formulas already in the repository, none of which changed behaviour, because their two sides are same-signed in every case they are tested with.

Six new cases in `tests/codes/test_formula.py` pin the behaviour down, covering both signs on either side, the zero right-hand side, and the two aggregations. Each of them also asserts that `bool()` and `float()` agree, which is the invariant that was broken.

## What this does not change

`unity_check` is left as it is. The ratio is still what a reader wants for the ordinary same-signed case, and it is what the aggregations report. It remains ill-defined where the two sides straddle zero, but it no longer decides whether a check passes, which is what made that mattering.

Worth a separate look, not touched here: for an `any` aggregation `unity_check` takes the smallest member ratio, which is not the same question as whether any of the conditions holds. With this fix the boolean no longer depends on it, so the two can now disagree in that case.
