### PR TITLE
feat: add formulas 8.67 and 8.68 from FprEN 1992-1-1:2023 clause 8.2.5

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_67_68.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_67_68.py
@@ -1,0 +1,222 @@
+"""Formula 8.67 and 8.68 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import operator
+from collections.abc import Callable, Sequence
+from typing import Literal, Self
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import AggregatedComparisonFormula, ComparisonFormula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+FLANGE_TYPE = Literal["compression", "tension"]
+
+
+def _upper_bound(flange_type: FLANGE_TYPE) -> float:
+    """Returns the upper bound on the cotangent, which is 3,0 in compression flanges per Formula (8.67) and
+    1,25 in tension flanges per Formula (8.68).
+    """
+    limits = {"compression": 3.0, "tension": 1.25}
+    limit = limits.get(flange_type.lower())
+    if limit is None:
+        raise ValueError(f"Invalid flange type: {flange_type}. Must be 'compression' or 'tension'.")
+    return limit
+
+
+class SubForm8Dot67To68LowerBound(ComparisonFormula):
+    r"""Class representing the lower bound of formulas 8.67 and 8.68, [$1 \leq \cot\theta_f$].
+
+    The standard prints the same lower bound for both flange types.
+    """
+
+    label = "8.67/8.68"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, cot_theta_f: DIMENSIONLESS) -> None:
+        r"""Check the selected inclination of the compression field in the flange against its lower bound.
+
+        FprEN 1992-1-1:2023 (E) art 8.2.5 (3) - Formula (8.67) and (8.68)
+
+        Parameters
+        ----------
+        cot_theta_f : DIMENSIONLESS
+            [$\cot\theta_f$] Cotangent of the selected inclination of the compression field in the flange
+            with respect to the longitudinal axis [$-$].
+        """
+        super().__init__()
+        self.cot_theta_f = cot_theta_f
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(*_args, **_kwargs) -> float:
+        """Evaluates the lower bound, which the standard prints as the constant 1."""
+        return 1.0
+
+    @staticmethod
+    def _evaluate_rhs(cot_theta_f: DIMENSIONLESS, *_args, **_kwargs) -> float:
+        """Evaluates the value under check, for more information see the __init__ method."""
+        # A cotangent of zero or less is not the inclination of a compression field, and it must be refused
+        # rather than reported as a failed check. ComparisonFormula.__bool__ answers through the unity check,
+        # which for a lower bound written "constant <= value" is constant/value. A negative value flips the
+        # sign of that ratio, so the bound would silently report OK, and a zero value divides by zero.
+        raise_if_less_or_equal_to_zero(cot_theta_f=cot_theta_f)
+
+        return float(cot_theta_f)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for the lower bound."""
+        _equation: str = r"1 \leq \cot(\theta_f)"
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=latex_replace_symbols(
+                template=_equation,
+                replacements={r"\cot(\theta_f)": f"{self.cot_theta_f:.{n}f}"},
+                unique_symbol_check=False,
+            ),
+            comparison_operator_label=r"\to",
+            unit="",
+        )
+
+
+class SubForm8Dot67To68UpperBound(ComparisonFormula):
+    r"""Class representing the upper bound of formulas 8.67 and 8.68, [$\cot\theta_f \leq 3,0$] in compression
+    flanges and [$\cot\theta_f \leq 1,25$] in tension flanges.
+    """
+
+    label = "8.67/8.68"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, cot_theta_f: DIMENSIONLESS, flange_type: FLANGE_TYPE) -> None:
+        r"""Check the selected inclination of the compression field in the flange against its upper bound.
+
+        FprEN 1992-1-1:2023 (E) art 8.2.5 (3) - Formula (8.67) and (8.68)
+
+        Parameters
+        ----------
+        cot_theta_f : DIMENSIONLESS
+            [$\cot\theta_f$] Cotangent of the selected inclination of the compression field in the flange [$-$].
+        flange_type : FLANGE_TYPE
+            Which of the two printed formulas applies: "compression" for Formula (8.67) or "tension" for
+            Formula (8.68).
+        """
+        super().__init__()
+        self.cot_theta_f = cot_theta_f
+        self.flange_type = flange_type
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(cot_theta_f: DIMENSIONLESS, *_args, **_kwargs) -> float:
+        """Evaluates the value under check, for more information see the __init__ method."""
+        # A cotangent of zero or less is not the inclination of a compression field, and it must be refused
+        # rather than reported as a failed check. ComparisonFormula.__bool__ answers through the unity check,
+        # which for a lower bound written "constant <= value" is constant/value. A negative value flips the
+        # sign of that ratio, so the bound would silently report OK, and a zero value divides by zero.
+        raise_if_less_or_equal_to_zero(cot_theta_f=cot_theta_f)
+
+        return float(cot_theta_f)
+
+    @staticmethod
+    def _evaluate_rhs(flange_type: FLANGE_TYPE, *_args, **_kwargs) -> float:
+        """Evaluates the upper bound, for more information see the __init__ method."""
+        return _upper_bound(flange_type)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for the upper bound."""
+        _equation: str = r"\cot(\theta_f) \leq limit"
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=latex_replace_symbols(
+                template=_equation,
+                replacements={r"\cot(\theta_f)": f"{self.cot_theta_f:.{n}f}", "limit": f"{_upper_bound(self.flange_type):.{n}f}"},
+                unique_symbol_check=False,
+            ),
+            comparison_operator_label=r"\to",
+            unit="",
+        )
+
+
+class Form8Dot67To68CheckCotangentFlangeCompressionField(AggregatedComparisonFormula):
+    r"""Class representing formulas 8.67 and 8.68 for the check of the cotangent of the inclination of the
+    compression field in the flanges.
+
+    The standard prints the two as separate numbered formulas with the same lower bound and a different upper
+    bound: 3,0 in compression flanges and 1,25 in tension flanges. They are one rule selected by the state of
+    the flange, so they are implemented as one class with that state as an input, the same way (8.22) to (8.24)
+    are one class selected by a ratio.
+
+    The printed range is one relation, but it is modelled as two comparisons joined with ``all`` so that each
+    bound carries its own unity check. Those two are available through ``comparison_formulas``, and
+    ``unity_check`` on this class is the larger of the two.
+    """
+
+    label = "8.67/8.68"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __new__(cls, cot_theta_f: DIMENSIONLESS, flange_type: FLANGE_TYPE) -> Self:
+        """Translates the arguments of this formula into the aggregation the base class evaluates."""
+        return super().__new__(cls, aggregation=all, comparison_formulas=cls._bounds(cot_theta_f, flange_type))
+
+    def __init__(self, cot_theta_f: DIMENSIONLESS, flange_type: FLANGE_TYPE) -> None:
+        r"""Check whether the selected inclination of the compression field in the flange lies within the
+        permitted range.
+
+        FprEN 1992-1-1:2023 (E) art 8.2.5 (3) - Formula (8.67) and (8.68)
+
+        The standard lets the designer select the inclination, so this is a verification of that choice and
+        not a value to be calculated. Both bounds are inclusive as printed. Lower angles in the tensile flange
+        than those given here may be adopted under the conditions of 8.2.5(5), which is a separate route and
+        not a relaxation of this check.
+
+        Parameters
+        ----------
+        cot_theta_f : DIMENSIONLESS
+            [$\cot\theta_f$] Cotangent of the selected inclination of the compression field in the flange
+            with respect to the longitudinal axis [$-$].
+        flange_type : FLANGE_TYPE
+            Which of the two printed formulas applies: "compression" for Formula (8.67), which bounds the
+            cotangent at 3,0, or "tension" for Formula (8.68), which bounds it at 1,25.
+        """
+        super().__init__(aggregation=all, comparison_formulas=self._bounds(cot_theta_f, flange_type))
+        self.cot_theta_f = cot_theta_f
+        self.flange_type = flange_type
+
+    @staticmethod
+    def _bounds(cot_theta_f: DIMENSIONLESS, flange_type: FLANGE_TYPE) -> Sequence[ComparisonFormula]:
+        """Builds the two halves of the printed range."""
+        return (
+            SubForm8Dot67To68LowerBound(cot_theta_f=cot_theta_f),
+            SubForm8Dot67To68UpperBound(cot_theta_f=cot_theta_f, flange_type=flange_type),
+        )
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formulas 8.67 and 8.68."""
+        _equation: str = r"1 \leq \cot(\theta_f) \leq limit"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\cot(\theta_f)": f"{self.cot_theta_f:.{n}f}",
+                "limit": f"{_upper_bound(self.flange_type):.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            # Every term here is dimensionless, so the representation with units is the same one.
+            numeric_equation_with_units=_numeric_equation,
+            comparison_operator_label=r"\to",
+            unit="",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -128,8 +128,8 @@ Total of 602 formulas present.
 |      8.64      |        :x:         |         |                                                                    |
 |      8.65      |        :x:         |         |                                                                    |
 |      8.66      |        :x:         |         |                                                                    |
-|      8.67      |        :x:         |         |                                                                    |
-|      8.68      |        :x:         |         |                                                                    |
+|      8.67      | :heavy_check_mark: |         | Form8Dot67To68CheckCotangentFlangeCompressionField                 |
+|      8.68      | :heavy_check_mark: |         | Form8Dot67To68CheckCotangentFlangeCompressionField                 |
 |      8.69      |        :x:         |         |                                                                    |
 |      8.70      |        :x:         |         |                                                                    |
 |      8.71      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_67_68.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_67_68.py
@@ -1,0 +1,157 @@
+"""Testing formulas 8.67 and 8.68 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_67_68 import (
+    Form8Dot67To68CheckCotangentFlangeCompressionField,
+    SubForm8Dot67To68LowerBound,
+    SubForm8Dot67To68UpperBound,
+)
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm8Dot67To68CheckCotangentFlangeCompressionField:
+    """Validation for formulas 8.67 and 8.68 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("cot_theta_f", "flange_type", "expected"),
+        [
+            # Formula (8.67), compression flanges, bounded at 3.0
+            ("2.0", "compression", True),
+            ("3.0", "compression", True),  # at the upper bound, which is inclusive
+            ("3.5", "compression", False),  # above the upper bound
+            # Formula (8.68), tension flanges, bounded at 1.25
+            ("1.25", "tension", True),  # at the upper bound, which is inclusive
+            ("1.5", "tension", False),  # above the upper bound
+            # the same cotangent passes in a compression flange and fails in a tension flange
+            ("2.0", "tension", False),
+            # the lower bound is the same for both and is inclusive
+            ("1.0", "compression", True),
+            ("1.0", "tension", True),
+            ("0.9", "compression", False),
+            ("0.9", "tension", False),
+        ],
+    )
+    def test_evaluation(self, cot_theta_f: str, flange_type: str, expected: bool) -> None:
+        """Tests the evaluation of the result for both flange types."""
+        # Create object to test
+        formula = Form8Dot67To68CheckCotangentFlangeCompressionField(cot_theta_f=float(cot_theta_f), flange_type=flange_type)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+
+    @pytest.mark.parametrize(
+        ("cot_theta_f", "flange_type", "expected_unity_check"),
+        [
+            (2.0, "compression", 0.6666666666666666),  # the upper bound governs: 2.0 / 3.0
+            (2.0, "tension", 1.6),  # the upper bound governs and is violated: 2.0 / 1.25
+            (0.8, "compression", 1.25),  # the lower bound governs: 1 / 0.8
+        ],
+    )
+    def test_unity_check_is_the_governing_bound(self, cot_theta_f: float, flange_type: str, expected_unity_check: float) -> None:
+        """Aggregating with all takes the largest unity check, so the governing bound is the one reported."""
+        # Create object to test
+        formula = Form8Dot67To68CheckCotangentFlangeCompressionField(cot_theta_f=cot_theta_f, flange_type=flange_type)
+
+        # Perform test by assert
+        assert formula.unity_check == pytest.approx(expected=expected_unity_check, rel=1e-4)
+
+    def test_both_bounds_are_exposed_separately(self) -> None:
+        """Each half of the printed range keeps its own left-hand side and right-hand side."""
+        # Example values
+        formula = Form8Dot67To68CheckCotangentFlangeCompressionField(cot_theta_f=2.0, flange_type="compression")
+        lower, upper = formula.comparison_formulas
+
+        # Perform test by assert
+        assert lower.lhs == pytest.approx(expected=1.0, rel=1e-4)
+        assert lower.rhs == pytest.approx(expected=2.0, rel=1e-4)
+        assert upper.lhs == pytest.approx(expected=2.0, rel=1e-4)
+        assert upper.rhs == pytest.approx(expected=3.0, rel=1e-4)
+
+    def test_raise_error_for_an_unknown_flange_type(self) -> None:
+        """The standard prints two formulas and no third case, so anything else is rejected."""
+        with pytest.raises(ValueError, match="Invalid flange type"):
+            Form8Dot67To68CheckCotangentFlangeCompressionField(cot_theta_f=2.0, flange_type="shear")
+
+    @pytest.mark.parametrize("cot_theta_f", [0.0, -1.0])
+    def test_raise_error_when_the_cotangent_is_not_positive(self, cot_theta_f: float) -> None:
+        """A cotangent of zero or less is not the inclination of a compression field and must be refused.
+
+        Reporting it as a failed check is not enough, because the check would not fail. The verdict is reached
+        through the unity check, which for the lower bound is 1 divided by the cotangent: a negative cotangent
+        turns that ratio negative and the bound reports OK, and a zero cotangent divides by zero.
+        """
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot67To68CheckCotangentFlangeCompressionField(cot_theta_f=cot_theta_f, flange_type="compression")
+
+    @pytest.mark.parametrize(
+        ("cot_theta_f", "flange_type", "representation", "expected"),
+        [
+            (2.0, "compression", "complete", r"CHECK \to 1 \leq \cot(\theta_f) \leq limit \to 1 \leq 2.000 \leq 3.000 \to OK"),
+            (2.0, "compression", "complete_with_units", r"CHECK \to 1 \leq \cot(\theta_f) \leq limit \to 1 \leq 2.000 \leq 3.000 \to OK"),
+            (2.0, "compression", "short", r"CHECK \to OK"),
+            (2.0, "tension", "complete", r"CHECK \to 1 \leq \cot(\theta_f) \leq limit \to 1 \leq 2.000 \leq 1.250 \to \text{Not OK}"),
+            (2.0, "tension", "short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex(self, cot_theta_f: float, flange_type: str, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        test_latex = Form8Dot67To68CheckCotangentFlangeCompressionField(cot_theta_f=cot_theta_f, flange_type=flange_type).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]
+
+
+class TestSubForm8Dot67To68Bounds:
+    """Validation for the two halves of formulas 8.67 and 8.68 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("cot_theta_f", "expected", "expected_latex"),
+        [
+            (2.0, True, r"CHECK \to 1 \leq \cot(\theta_f) \to 1 \leq 2.000 \to OK"),
+            (0.8, False, r"CHECK \to 1 \leq \cot(\theta_f) \to 1 \leq 0.800 \to \text{Not OK}"),
+        ],
+    )
+    def test_lower_bound(self, cot_theta_f: float, expected: bool, expected_latex: str) -> None:
+        """Tests the lower bound on its own."""
+        # Create object to test
+        formula = SubForm8Dot67To68LowerBound(cot_theta_f=cot_theta_f)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+        assert formula.latex().complete == expected_latex
+
+    @pytest.mark.parametrize(
+        ("cot_theta_f", "flange_type", "expected", "expected_latex"),
+        [
+            (2.0, "compression", True, r"CHECK \to \cot(\theta_f) \leq limit \to 2.000 \leq 3.000 \to OK"),
+            (2.0, "tension", False, r"CHECK \to \cot(\theta_f) \leq limit \to 2.000 \leq 1.250 \to \text{Not OK}"),
+        ],
+    )
+    def test_upper_bound(self, cot_theta_f: float, flange_type: str, expected: bool, expected_latex: str) -> None:
+        """Tests the upper bound on its own, for both flange types."""
+        # Create object to test
+        formula = SubForm8Dot67To68UpperBound(cot_theta_f=cot_theta_f, flange_type=flange_type)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+        assert formula.latex().complete == expected_latex
+
+    def test_raise_error_for_an_unknown_flange_type(self) -> None:
+        """The upper bound rejects anything that is neither of the two printed cases."""
+        with pytest.raises(ValueError, match="Invalid flange type"):
+            SubForm8Dot67To68UpperBound(cot_theta_f=2.0, flange_type="shear")
+
+    @pytest.mark.parametrize("cot_theta_f", [0.0, -1.0])
+    def test_both_bounds_refuse_a_non_positive_cotangent(self, cot_theta_f: float) -> None:
+        """Each half refuses a cotangent of zero or less on its own, not only through the aggregate."""
+        with pytest.raises(LessOrEqualToZeroError):
+            SubForm8Dot67To68LowerBound(cot_theta_f=cot_theta_f)
+        with pytest.raises(LessOrEqualToZeroError):
+            SubForm8Dot67To68UpperBound(cot_theta_f=cot_theta_f, flange_type="compression")


### PR DESCRIPTION
Implements formulas (8.67) and (8.68) of FprEN 1992-1-1:2023 (E), clause 8.2.5(3), page 129.

Contributes to #1083.

## A defect this pull request found, which also sits in #1096 and #1100

**A two-sided range check built on `AggregatedComparisonFormula` reports OK for a negative value under check, and raises `ZeroDivisionError` for zero.**

`ComparisonFormula.__bool__` answers through the unity check, which for `operator.le` is `lhs / rhs`. A lower bound has to be written as `constant <= value`, so the value under check sits in `rhs`. A negative value flips the sign of that ratio, and `-1.0 <= 1.0` is true, so the bound reports OK. Note that `ComparisonFormula._evaluate` compares `lhs` and `rhs` with the operator directly and gets it right, so `float(formula)` is correct while `bool(formula)` is not; `AggregatedComparisonFormula._evaluate` aggregates over `bool(...)`, so the aggregate inherits the wrong answer.

Measured on the three range checks in this series:

```
8.41  cot_theta = -1.0                 -> reports OK,  while 1 <= -1.0 <= 2.5 is False
8.58  cot_theta = -1.0, alpha_w = 60   -> reports OK,  while 0.577 <= -1.0 <= 2.5 is False
8.67  cot_theta_f = -1.0, compression  -> reports OK,  while 1 <= -1.0 <= 3.0 is False
all three, cot = 0.0                   -> ZeroDivisionError
```

This did not exist before: `DoubleComparisonFormula` applied its operators directly, and the defect arrived with the move to `AggregatedComparisonFormula`.

**The root cause is fixed in #1105**, which makes both `ComparisonFormula.__bool__` and `AggregatedComparisonFormula.__bool__` apply their operator instead of the ratio. That closes it for every comparison formula, present and future, and for values of any sign. Once it lands, #1096 and #1100 are correct without any change of their own; until then they carry the defect.

**This pull request also guards the cotangent**, and keeps that guard whatever happens to #1105. A cotangent of zero or less is not the inclination of a compression field, so it is refused as input rather than answered as a check. Both halves refuse it on their own, not only through the aggregate, and there are tests for both. After #1105 the guard is no longer what makes the class correct, it is only what keeps meaningless input out.

## Decisions

- The two formulas are one class. They sit under a single introductory sentence in 8.2.5(3), share the lower bound of 1, share the inclusivity of both bounds, and differ only in the upper bound: 3,0 in compression flanges, 1,25 in tension flanges. The flange state is therefore an input, the same way (8.22) to (8.24) are one class selected by a ratio. The blind verifier was asked whether that modelling is faithful or whether the standard means two different things, and answered that it is one selectable range whose ceiling depends on the state of the flange.
- The flange state is a `Literal["compression", "tension"]` mapped to the limit, following `Form5Dot1CriteriumDisregardSecondOrderEffects`. Anything else raises, because the page offers no third case and no default.
- 8.2.5(5) allows lower angles in the tensile flange than (8.68) gives, provided the factor `nu` is calculated from the state of strains rather than taken as the flat 0,5 of (8.71). The verifier confirmed that this is a separate design route tied to the crushing check and not a relaxation of this one, so the 1,25 cap stays hard here.
- The equation keeps the word `limit` as a placeholder that the flange state fills in, which is what `Form5Dot1` does for the same situation.

## Verification

Blindly verified against the rendered pages 128 and 129 of the standard by a second agent that never saw the implementation or the tests.

Verdict **OK**. It independently derived clause 8.2.5(3), both bounds and their inclusivity for each of the two formulas, and the same boolean for all seven test input sets, including the discriminating pair where the same cotangent passes in a compression flange and fails in a tension flange. It confirmed the two differ in nothing but the upper bound, confirmed the one-class modelling, and read the 8.2.5(5) route correctly as separate. Its remark on the unity check of the lower bound is what led to the defect above.

## Formulas as implemented

**Formulas (8.67) and (8.68)**, `Form8Dot67To68CheckCotangentFlangeCompressionField`

`equation`

$$
CHECK \to 1 \leq \cot(\theta_f) \leq limit
$$

`complete`, with `cot_theta_f = 2,0` in a compression flange, where the limit is 3,0

$$
CHECK \to 1 \leq \cot(\theta_f) \leq limit \to 1 \leq 2.000 \leq 3.000 \to OK
$$

and the same cotangent in a tension flange, where the limit is 1,25

$$
CHECK \to 1 \leq \cot(\theta_f) \leq limit \to 1 \leq 2.000 \leq 1.250 \to \text{Not OK}
$$

`complete_with_units` is deliberately the same string as `complete`, since every term here is dimensionless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Eurocode 2 formulas 8.67 and 8.68, checking the cotangent of the flange compression-field inclination.
  * Supports separate limits for compression and tension flanges, with validation for invalid angles and flange types.
  * Added readable formula representations, including versions with substituted values and units.

* **Documentation**
  * Updated the Eurocode 2 formula tracking table to mark formulas 8.67 and 8.68 as implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->