### PR TITLE
1107 bug fix bool operator for comparison formula

### DIFF
--- a/blueprints/codes/eurocode/en_1993_1_1_2005/chapter_5_structural_analysis/formula_5_7.py
+++ b/blueprints/codes/eurocode/en_1993_1_1_2005/chapter_5_structural_analysis/formula_5_7.py
@@ -1,5 +1,9 @@
 """Formula 5.7 from EN 1993-1-1:2005: Chapter 5 - Structural Analysis."""
 
+import operator
+from collections.abc import Callable
+from typing import Any
+
 from blueprints.codes.eurocode.en_1993_1_1_2005 import EN_1993_1_1_2005
 from blueprints.codes.formula import ComparisonFormula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
@@ -32,6 +36,11 @@ class Form5Dot7DisregardFrameSwayImperfections(ComparisonFormula):
         self.h_ed = h_ed
         self.v_ed = v_ed
 
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[Any, Any], bool]:
+        """Return the comparison operator for the formula."""
+        return operator.ge
+
     @staticmethod
     def _evaluate_lhs(h_ed: N, *args, **kwargs) -> float:  # noqa: ARG004
         """Evaluates the left-hand side of the comparison. See __init__ for details."""
@@ -43,22 +52,6 @@ class Form5Dot7DisregardFrameSwayImperfections(ComparisonFormula):
         """Evaluates the right-hand side of the comparison. See __init__ for details."""
         raise_if_negative(v_ed=v_ed)
         return 0.15 * v_ed
-
-    @property
-    def unity_check(self) -> float:
-        """Returns the unity check value."""
-        return self.lhs / self.rhs
-
-    @staticmethod
-    def _evaluate(h_ed: N, v_ed: N) -> bool:  # ty: ignore[invalid-method-override]
-        """Evaluates the formula, for more information see the __init__ method."""
-        lhs = Form5Dot7DisregardFrameSwayImperfections._evaluate_lhs(h_ed=h_ed)
-        rhs = Form5Dot7DisregardFrameSwayImperfections._evaluate_rhs(v_ed=v_ed)
-        return lhs >= rhs
-
-    def __bool__(self) -> bool:
-        """Allow truth-checking of the check object itself."""
-        return self._evaluate(h_ed=self.h_ed, v_ed=self.v_ed)
 
     def latex(self, n: int = 2) -> LatexFormula:
         """Returns LatexFormula object for formula 5.7."""

--- a/blueprints/codes/eurocode/en_1993_1_1_2005/chapter_5_structural_analysis/formula_5_8.py
+++ b/blueprints/codes/eurocode/en_1993_1_1_2005/chapter_5_structural_analysis/formula_5_8.py
@@ -1,5 +1,9 @@
 """Formula 5.8 from EN 1993-1-1:2005: Chapter 5 - Structural Analysis."""
 
+import operator
+from collections.abc import Callable
+from typing import Any
+
 import numpy as np
 
 from blueprints.codes.eurocode.en_1993_1_1_2005 import EN_1993_1_1_2005
@@ -44,6 +48,11 @@ class Form5Dot8CheckSlenderness(ComparisonFormula):
         self.f_y = f_y
         self.n_ed = n_ed
 
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[Any, Any], bool]:
+        """Return the comparison operator for the formula."""
+        return operator.gt
+
     @staticmethod
     def _evaluate_lhs(lambda_bar: DIMENSIONLESS, *_args, **_kwargs) -> float:
         """Evaluates the left-hand side of the comparison. See __init__ for details."""
@@ -56,32 +65,6 @@ class Form5Dot8CheckSlenderness(ComparisonFormula):
         raise_if_less_or_equal_to_zero(n_ed=n_ed)
         raise_if_negative(a=a, f_y=f_y)
         return 0.5 * np.sqrt(a * f_y / n_ed)
-
-    @property
-    def unity_check(self) -> float:
-        """Returns the unity check value."""
-        return self.lhs / self.rhs
-
-    @staticmethod
-    def _evaluate(  # ty: ignore[invalid-method-override]
-        lambda_bar: DIMENSIONLESS,
-        a: MM2,
-        f_y: MPA,
-        n_ed: N,
-    ) -> bool:
-        """Evaluates the formula, for more information see the __init__ method."""
-        lhs = Form5Dot8CheckSlenderness._evaluate_lhs(lambda_bar=lambda_bar)
-        rhs = Form5Dot8CheckSlenderness._evaluate_rhs(a=a, f_y=f_y, n_ed=n_ed)
-        return lhs > rhs
-
-    def __bool__(self) -> bool:
-        """Allow truth-checking of the check object itself."""
-        return self._evaluate(
-            lambda_bar=self.lambda_bar,
-            a=self.a,
-            f_y=self.f_y,
-            n_ed=self.n_ed,
-        )
 
     def latex(self, n: int = 2) -> LatexFormula:
         """Returns LatexFormula object for formula 5.8."""

--- a/blueprints/codes/eurocode/en_1993_5_2007/chapter_5_ultimate_limit_states/formula_5_18.py
+++ b/blueprints/codes/eurocode/en_1993_5_2007/chapter_5_ultimate_limit_states/formula_5_18.py
@@ -1,5 +1,9 @@
 """Formula 5.18 from EN 1993-5:2007: Chapter 5 - Ultimate limit state."""
 
+import operator
+from collections.abc import Callable
+from typing import Any
+
 from blueprints.codes.eurocode.en_1993_5_2007 import EN_1993_5_2007
 from blueprints.codes.formula import ComparisonFormula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
@@ -34,6 +38,11 @@ class Form5Dot18CompressionCheckUProfilesClass1And2(ComparisonFormula):
         self.n_ed = n_ed
         self.n_pl_rd = n_pl_rd
 
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[Any, Any], bool]:
+        """Return the comparison operator for the formula."""
+        return operator.le
+
     @staticmethod
     def _evaluate_lhs(
         n_ed: KN,
@@ -48,25 +57,10 @@ class Form5Dot18CompressionCheckUProfilesClass1And2(ComparisonFormula):
         """Evaluates the right-hand side of the comparison; see __init__ for details."""
         return 0.25
 
-    @staticmethod
-    def _evaluate(  # ty: ignore[invalid-method-override]
-        n_ed: KN,
-        n_pl_rd: KN,
-    ) -> bool:
-        """Evaluates the comparison; see __init__ for details."""
-        return (
-            Form5Dot18CompressionCheckUProfilesClass1And2._evaluate_lhs(n_ed=n_ed, n_pl_rd=n_pl_rd)
-            <= Form5Dot18CompressionCheckUProfilesClass1And2._evaluate_rhs()
-        )
-
     @property
     def unity_check(self) -> float:
         """Returns the unity check value."""
         return self.lhs
-
-    def __bool__(self) -> bool:
-        """Allow truth-checking of the check object itself."""
-        return self._evaluate(self.n_ed, self.n_pl_rd)
 
     def latex(self, n: int = 3) -> LatexFormula:
         """Returns LatexFormula object for formula 5.18."""

--- a/blueprints/codes/eurocode/en_1993_5_2007/chapter_5_ultimate_limit_states/formula_5_19.py
+++ b/blueprints/codes/eurocode/en_1993_5_2007/chapter_5_ultimate_limit_states/formula_5_19.py
@@ -1,5 +1,9 @@
 """Formula 5.19 from EN 1993-5:2007: Chapter 5 - Ultimate limit state."""
 
+import operator
+from collections.abc import Callable
+from typing import Any
+
 from blueprints.codes.eurocode.en_1993_5_2007 import EN_1993_5_2007
 from blueprints.codes.formula import ComparisonFormula
 from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
@@ -33,6 +37,11 @@ class Form5Dot19CompressionCheckClass3Profiles(ComparisonFormula):
         self.n_ed = n_ed
         self.n_pl_rd = n_pl_rd
 
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[Any, Any], bool]:
+        """Return the comparison operator for the formula."""
+        return operator.le
+
     @staticmethod
     def _evaluate_lhs(
         n_ed: KN,
@@ -47,25 +56,10 @@ class Form5Dot19CompressionCheckClass3Profiles(ComparisonFormula):
         """Evaluates the right-hand side of the comparison; see __init__ for details."""
         return 0.1
 
-    @staticmethod
-    def _evaluate(  # ty: ignore[invalid-method-override]
-        n_ed: KN,
-        n_pl_rd: KN,
-    ) -> bool:
-        """Evaluates the comparison; see __init__ for details."""
-        return (
-            Form5Dot19CompressionCheckClass3Profiles._evaluate_lhs(n_ed=n_ed, n_pl_rd=n_pl_rd)
-            <= Form5Dot19CompressionCheckClass3Profiles._evaluate_rhs()
-        )
-
     @property
     def unity_check(self) -> float:
         """Returns the unity check value."""
         return self.lhs
-
-    def __bool__(self) -> bool:
-        """Allow truth-checking of the check object itself."""
-        return self._evaluate(self.n_ed, self.n_pl_rd)
 
     def latex(self, n: int = 3) -> LatexFormula:
         """Returns LatexFormula object for formula 5.19."""

--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -225,7 +225,9 @@ class ComparisonFormula(Formula, ABC):
         bool
             True if the comparison condition is satisfied, False otherwise.
         """
-        return self._comparison_operator()(self.lhs, self.rhs)
+        # bool() is required here: if _evaluate_lhs/_evaluate_rhs return numpy floats, the comparison
+        # operator returns a numpy.bool_, and Python requires __bool__ to return a real bool.
+        return bool(self._comparison_operator()(self.lhs, self.rhs))
 
     @classmethod
     def _evaluate(cls, *args, **kwargs) -> bool:

--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -211,7 +211,7 @@ class ComparisonFormula(Formula, ABC):
     def __bool__(self) -> bool:
         """Return whether the comparison condition is satisfied.
 
-        Returns True if the unity check is less than or equal to 1.0, indicating the condition is satisfied.
+        Returns True if the comparison e.g. lhs <= rhs is satisfied.
         This allows ComparisonFormula instances to be used directly in boolean contexts.
 
         Examples
@@ -225,15 +225,15 @@ class ComparisonFormula(Formula, ABC):
         bool
             True if unity_check <= 1.0 (condition is satisfied), False otherwise.
         """
-        return self.unity_check <= 1.0
+        return self._comparison_operator()(self.lhs, self.rhs)
 
     @classmethod
     def _evaluate(cls, *args, **kwargs) -> bool:
         """Implements the comparison using the class-level operator."""
         lhs = cls._evaluate_lhs(*args, **kwargs)
         rhs = cls._evaluate_rhs(*args, **kwargs)
-        comparison = cls._comparison_operator
-        return comparison()(lhs, rhs)
+        comparison = cls._comparison_operator()
+        return comparison(lhs, rhs)
 
 
 class AggregatedComparisonFormula(ComparisonFormula):
@@ -325,6 +325,32 @@ class AggregatedComparisonFormula(ComparisonFormula):
             if self.aggregation is all
             else min(formula.unity_check for formula in self.comparison_formulas)
         )
+
+    def __bool__(self) -> bool:
+        """Return whether the aggregated comparison condition is satisfied.
+
+        Returns True if the aggregated comparison condition is satisfied based on the aggregation function (all or any).
+        This allows AggregatedComparisonFormula instances to be used directly in boolean contexts.
+
+        Examples
+        --------
+        formula1 = SomeComparisonFormula(...)
+        formula2 = SomeComparisonFormula(...)
+
+        aggregated_formula = AggregatedComparisonFormula(all, [formula1, formula2])
+        if aggregated_formula:  # Equivalent to: if all(formula1, formula2)
+            print("All conditions satisfied")
+
+        aggregated_formula = AggregatedComparisonFormula(any, [formula1, formula2])
+        if aggregated_formula:  # Equivalent to: if any(formula1, formula2)
+            print("At least one condition satisfied")
+
+        Returns
+        -------
+        bool
+            True if the aggregated condition is satisfied, False otherwise.
+        """
+        return self.aggregation(bool(formula) for formula in self.comparison_formulas)
 
     @classmethod
     def _evaluate(

--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -396,7 +396,7 @@ class AggregatedComparisonFormula(ComparisonFormula):
         LatexFormula
             The latex representation of the formula, given in math mode.
         """
-        aggregation = " \\land " if self.aggregation is all else " \\lor "
+        aggregation = r"\ \&\ " if self.aggregation is all else r"\ \text{or}\ "
         comparison_equations = aggregation.join(formula.latex(n).equation for formula in self.comparison_formulas)
         comparison_numeric_equations = aggregation.join(formula.latex(n).numeric_equation for formula in self.comparison_formulas)
         return LatexFormula(

--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -217,13 +217,13 @@ class ComparisonFormula(Formula, ABC):
         Examples
         --------
         formula = SomeComparisonFormula(...)
-        if formula:  # Equivalent to: if formula.unity_check <= 1.0
+        if formula:  # Equivalent to: if formula.__bool__()
             print("Condition satisfied")
 
         Returns
         -------
         bool
-            True if unity_check <= 1.0 (condition is satisfied), False otherwise.
+            True if the comparison condition is satisfied, False otherwise.
         """
         return self._comparison_operator()(self.lhs, self.rhs)
 

--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -383,6 +383,31 @@ class AggregatedComparisonFormula(ComparisonFormula):
             raise ValueError("All provided comparison formulas must be instances of ComparisonFormula.")
         return aggregation(bool(formula) for formula in comparison_formulas)
 
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Return the latex representation of the aggregated comparison formula.
+
+        Parameters
+        ----------
+        n : int, optional
+            The number of decimal places to round the result to.
+
+        Returns
+        -------
+        LatexFormula
+            The latex representation of the formula, given in math mode.
+        """
+        aggregation = " \\land " if self.aggregation is all else " \\lor "
+        comparison_equations = aggregation.join(formula.latex(n).equation for formula in self.comparison_formulas)
+        comparison_numeric_equations = aggregation.join(formula.latex(n).numeric_equation for formula in self.comparison_formulas)
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else "\\text{Not OK}",
+            equation=comparison_equations,
+            numeric_equation=comparison_numeric_equations,
+            comparison_operator_label="\\to",
+            unit="",
+        )
+
 
 class DoubleComparisonFormula(Formula):
     """Base class for double comparison formulas used in the codes.

--- a/tests/codes/eurocode/en_1993_1_1_2005/chapter_5_structural_analysis/test_formula_5_7.py
+++ b/tests/codes/eurocode/en_1993_1_1_2005/chapter_5_structural_analysis/test_formula_5_7.py
@@ -20,7 +20,7 @@ class TestForm5Dot8NeglectFrameTilt:
 
         # Expected results
         exp_result = True
-        exp_uc = h_ed / (0.15 * v_ed)
+        exp_uc = (0.15 * v_ed) / h_ed  # h_ed >= 0.15 * v_ed => unity check = (0.15 * v_ed) / h_ed
 
         # Test
         assert form == exp_result

--- a/tests/codes/eurocode/en_1993_1_1_2005/chapter_5_structural_analysis/test_formula_5_8.py
+++ b/tests/codes/eurocode/en_1993_1_1_2005/chapter_5_structural_analysis/test_formula_5_8.py
@@ -23,7 +23,9 @@ class TestForm5Dot8CheckSlenderness:
 
         # Expected result, manually calculated
         expected_result = True
-        expected_unity_check = lambda_bar / (0.5 * np.sqrt(a * f_y / n_ed))
+        expected_unity_check = (
+            0.5 * np.sqrt(a * f_y / n_ed)
+        ) / lambda_bar  # lambda_bar > 0.5 * sqrt(A * f_y / N_ed) => unity check = (0.5 * sqrt(A * f_y / N_ed)) / lambda_bar
 
         assert formula == expected_result
         assert formula.unity_check == expected_unity_check

--- a/tests/codes/eurocode/en_1993_5_2007/chapter_5_ultimate_limit_states/test_formula_5_9.py
+++ b/tests/codes/eurocode/en_1993_5_2007/chapter_5_ultimate_limit_states/test_formula_5_9.py
@@ -46,7 +46,7 @@ class TestForm5Dot9ReducedBendingMomentResistance:
 
     @pytest.mark.parametrize(
         ("invalid_argument", "invalid_value"),
-        itertools.product(("beta_b", "w_pl", "rho", "a_v", "t_w", "alpha", "f_y", "gamma_m_0", "mc_rd"), (-1.0, 0.0)),
+        tuple(itertools.product(("beta_b", "w_pl", "rho", "a_v", "t_w", "alpha", "f_y", "gamma_m_0", "mc_rd"), (-1.0, 0.0))),
     )
     def test_raise_error_when_invalid_values_are_given(self, invalid_argument: str, invalid_value: float) -> None:
         """Test a zero and negative value for parameters."""

--- a/tests/codes/test_formula.py
+++ b/tests/codes/test_formula.py
@@ -4,6 +4,7 @@ import operator
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
 import pytest
 
 from blueprints.codes.formula import AggregatedComparisonFormula, ComparisonFormula, DoubleComparisonFormula, Formula
@@ -396,6 +397,30 @@ def test_comparison_formula_bool_with_negative_values_eq() -> None:
     assert formula.lhs == -10
     assert formula.rhs == -5
     assert bool(formula) is False
+
+
+def test_comparison_formula_bool_with_numpy_floats_returns_real_bool() -> None:
+    """Test that __bool__ returns a real Python bool even when lhs/rhs are numpy floats.
+
+    When _evaluate_lhs/_evaluate_rhs return numpy floats (e.g. from np.sqrt, np.tan, etc.),
+    operator.le/.ge/.eq on them returns numpy.bool_ rather than bool. Python requires __bool__
+    to return an actual bool, so without an explicit bool() cast this raises:
+    TypeError: __bool__ should return bool, returned numpy.bool_
+    """
+    a = np.float64(5.0)
+    b = np.float64(5.0)
+    c = np.float64(20.0)
+
+    # Sanity check that the raw comparison operator indeed returns numpy.bool_, not bool.
+    raw_comparison_result = ComparisonFormulaTestLessOrEqual._comparison_operator()(a + b, c / 2)  # noqa: SLF001
+    assert isinstance(raw_comparison_result, np.bool_)
+    assert not isinstance(raw_comparison_result, bool)
+
+    formula = ComparisonFormulaTestLessOrEqual(a=a, b=b, c=c)
+
+    result = bool(formula)
+
+    assert result is True
 
 
 # Helper function to create dynamic test classes for DoubleComparisonFormula

--- a/tests/codes/test_formula.py
+++ b/tests/codes/test_formula.py
@@ -340,6 +340,64 @@ def test_comparison_formula_equal_unity_check_property() -> None:
     assert formula.unity_check == 1.0
 
 
+def test_comparison_formula_bool_with_negative_values_le() -> None:
+    """Test __bool__ for the <= operator with negative lhs and/or rhs values.
+
+    A unity_check-based bool (lhs / rhs <= 1.0) silently flips when dividing by a negative
+    number, so these cases would misreport pass/fail under that old implementation.
+    """
+    # lhs=-10, rhs=-5: -10 <= -5 is True. unity_check = -10 / -5 = 2.0, which a
+    # unity_check-based bool would wrongly read as "not satisfied".
+    formula = ComparisonFormulaTestLessOrEqual(a=-10, b=0, c=-10)
+    assert formula.lhs == -10
+    assert formula.rhs == -5
+    assert bool(formula) is True
+
+    # lhs=10, rhs=-5: 10 <= -5 is False. unity_check = 10 / -5 = -2.0, which a
+    # unity_check-based bool would wrongly read as "satisfied".
+    formula = ComparisonFormulaTestLessOrEqual(a=10, b=0, c=-10)
+    assert formula.lhs == 10
+    assert formula.rhs == -5
+    assert bool(formula) is False
+
+    # lhs=-10, rhs=5: -10 <= 5 is True.
+    formula = ComparisonFormulaTestLessOrEqual(a=-10, b=0, c=10)
+    assert formula.lhs == -10
+    assert formula.rhs == 5
+    assert bool(formula) is True
+
+
+def test_comparison_formula_bool_with_negative_values_ge() -> None:
+    """Test __bool__ for the >= operator with negative lhs and/or rhs values."""
+    # lhs=-5, rhs=-10: -5 >= -10 is True.
+    formula = ComparisonFormulaTestGreaterOrEqual(a=-5, b=0, c=-20)
+    assert formula.lhs == -5
+    assert formula.rhs == -10
+    assert bool(formula) is True
+
+    # lhs=-20, rhs=-5: -20 >= -5 is False. unity_check = rhs / lhs = -5 / -20 = 0.25, which a
+    # unity_check-based bool would wrongly read as "satisfied".
+    formula = ComparisonFormulaTestGreaterOrEqual(a=-20, b=0, c=-10)
+    assert formula.lhs == -20
+    assert formula.rhs == -5
+    assert bool(formula) is False
+
+
+def test_comparison_formula_bool_with_negative_values_eq() -> None:
+    """Test __bool__ for the == operator with negative lhs and/or rhs values."""
+    # lhs=-10, rhs=-10: equal.
+    formula = ComparisonFormulaTestEqual(a=-15, b=5, c=-20)
+    assert formula.lhs == -10
+    assert formula.rhs == -10
+    assert bool(formula) is True
+
+    # lhs=-10, rhs=-5: not equal.
+    formula = ComparisonFormulaTestEqual(a=-15, b=5, c=-10)
+    assert formula.lhs == -10
+    assert formula.rhs == -5
+    assert bool(formula) is False
+
+
 # Helper function to create dynamic test classes for DoubleComparisonFormula
 def _create_double_comparison_formula_test_class(
     comp_op_lhs: Callable[[float, float], bool], comp_op_rhs: Callable[[float, float], bool], comp_op_ids: str = ""
@@ -729,6 +787,30 @@ class TestAggregatedComparisonFormula:
         f2 = self._le(10, 1, 4)  # lhs=11, rhs=2  →  fails
         f3 = self._le(10, 3, 4)  # lhs=13, rhs=2  →  fails
         formula = AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[f1, f2, f3])
+        assert formula
+        assert bool(formula) is True
+
+    def test_aggregated_comparison_formula_bool_with_negative_values_all_passes(self) -> None:
+        """Test 'all' aggregation bool with negative lhs/rhs values, where each sub-formula passes."""
+        f1 = self._le(-10, 0, -10)  # lhs=-10, rhs=-5  →  -10 <= -5 True
+        f2 = self._ge(-5, 0, -20)  # lhs=-5, rhs=-10  →  -5 >= -10 True
+        formula = AggregatedComparisonFormulaTest(aggregation=all, comparison_formulas=[f1, f2])
+        assert formula
+        assert bool(formula) is True
+
+    def test_aggregated_comparison_formula_bool_with_negative_values_all_fails(self) -> None:
+        """Test 'all' aggregation bool with negative lhs/rhs values, where one sub-formula fails."""
+        f1 = self._le(-10, 0, -10)  # lhs=-10, rhs=-5  →  -10 <= -5 True
+        f2 = self._le(10, 0, -10)  # lhs=10, rhs=-5  →  10 <= -5 False
+        formula = AggregatedComparisonFormulaTest(aggregation=all, comparison_formulas=[f1, f2])
+        assert not formula
+        assert bool(formula) is False
+
+    def test_aggregated_comparison_formula_bool_with_negative_values_any_passes(self) -> None:
+        """Test 'any' aggregation bool with negative lhs/rhs values, where one sub-formula passes."""
+        f1 = self._le(10, 0, -10)  # lhs=10, rhs=-5  →  10 <= -5 False
+        f2 = self._le(-10, 0, -10)  # lhs=-10, rhs=-5  →  -10 <= -5 True
+        formula = AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[f1, f2])
         assert formula
         assert bool(formula) is True
 

--- a/tests/codes/test_formula.py
+++ b/tests/codes/test_formula.py
@@ -631,14 +631,90 @@ def test_double_comparison_formula_invalid_operators(
 
 
 class AggregatedComparisonFormulaTest(AggregatedComparisonFormula):
-    """Dummy aggregated comparison formula for testing purposes."""
+    """Dummy aggregated comparison formula for testing purposes.
+
+    Relies on the concrete ``latex`` implementation of ``AggregatedComparisonFormula`` itself
+    (no override here), so that implementation is what gets exercised by the latex tests below.
+    """
 
     label = "Dummy testing aggregated comparison formula"
     source_document = "Dummy testing document"
 
+
+class ComparisonFormulaTestLatexLessOrEqual(ComparisonFormula):
+    """Dummy comparison formula with a realistic latex representation (<=), for testing AggregatedComparisonFormula.latex."""
+
+    label = "Dummy testing comparison formula (latex, <=)"
+    source_document = "Dummy testing document"
+
+    def __init__(self, x: float, y: float) -> None:
+        """Dummy comparison formula for testing purposes."""
+        super().__init__()
+        self.x = x
+        self.y = y
+
+    @staticmethod
+    def _evaluate_lhs(x: float, **_) -> float:
+        """Left-hand side value of the comparison."""
+        return x
+
+    @staticmethod
+    def _evaluate_rhs(y: float, **_) -> float:
+        """Right-hand side value of the comparison."""
+        return y
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[Any, Any], bool]:
+        """Abstract property for the comparison operator (e.g., operator.le, operator.ge, etc.)."""
+        return operator.le
+
     def latex(self, n: int = 3) -> LatexFormula:
         """Dummy latex implementation for testing purposes."""
-        return LatexFormula(return_symbol=r"check", result=str(round(float(self), n)), equation=r"\text{aggregated check}")
+        return LatexFormula(
+            return_symbol="CHECK_X",
+            result="OK" if bool(self) else r"\text{Not OK}",
+            equation=r"X \leq Y",
+            numeric_equation=rf"{self.x:.{n}f} \leq {self.y:.{n}f}",
+            comparison_operator_label=r"\to",
+        )
+
+
+class ComparisonFormulaTestLatexGreaterOrEqual(ComparisonFormula):
+    """Dummy comparison formula with a realistic latex representation (>=), for testing AggregatedComparisonFormula.latex."""
+
+    label = "Dummy testing comparison formula (latex, >=)"
+    source_document = "Dummy testing document"
+
+    def __init__(self, x: float, y: float) -> None:
+        """Dummy comparison formula for testing purposes."""
+        super().__init__()
+        self.x = x
+        self.y = y
+
+    @staticmethod
+    def _evaluate_lhs(x: float, **_) -> float:
+        """Left-hand side value of the comparison."""
+        return x
+
+    @staticmethod
+    def _evaluate_rhs(y: float, **_) -> float:
+        """Right-hand side value of the comparison."""
+        return y
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[Any, Any], bool]:
+        """Abstract property for the comparison operator (e.g., operator.le, operator.ge, etc.)."""
+        return operator.ge
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Dummy latex implementation for testing purposes."""
+        return LatexFormula(
+            return_symbol="CHECK_Y",
+            result="OK" if bool(self) else r"\text{Not OK}",
+            equation=r"X \geq Y",
+            numeric_equation=rf"{self.x:.{n}f} \geq {self.y:.{n}f}",
+            comparison_operator_label=r"\to",
+        )
 
 
 class TestAggregatedComparisonFormula:
@@ -931,3 +1007,60 @@ class TestAggregatedComparisonFormula:
         outer = AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[inner_any, inner_all])
         assert not outer
         assert bool(outer) is False
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"CHECK \to X \leq Y\ \&\ X \geq Y \to 10.000 \leq 20.000\ \&\ 15.000 \geq 10.000 \to OK",
+            ),
+            ("short", r"CHECK \to OK"),
+            (
+                "complete_with_units",
+                r"CHECK \to X \leq Y\ \&\ X \geq Y \to 10.000 \leq 20.000\ \&\ 15.000 \geq 10.000 \to OK",
+            ),
+        ],
+    )
+    def test_latex_all_aggregation_all_pass(self, representation: str, expected: str) -> None:
+        """Test the latex representation for 'all' aggregation when every sub-formula passes."""
+        # f1: 10 <= 20 -> True, f2: 15 >= 10 -> True
+        f1 = ComparisonFormulaTestLatexLessOrEqual(x=10, y=20)
+        f2 = ComparisonFormulaTestLatexGreaterOrEqual(x=15, y=10)
+        formula = AggregatedComparisonFormulaTest(aggregation=all, comparison_formulas=[f1, f2])
+
+        latex = formula.latex()
+
+        actual = {
+            "complete": latex.complete,
+            "short": latex.short,
+            "complete_with_units": latex.complete_with_units,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"CHECK \to X \leq Y\ \text{or}\ X \geq Y \to 30.000 \leq 20.000\ \text{or}\ 5.000 \geq 10.000 \to \text{Not OK}",
+            ),
+            ("short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex_any_aggregation_all_fail(self, representation: str, expected: str) -> None:
+        """Test the latex representation for 'any' aggregation when every sub-formula fails."""
+        # f1: 30 <= 20 -> False, f2: 5 >= 10 -> False
+        f1 = ComparisonFormulaTestLatexLessOrEqual(x=30, y=20)
+        f2 = ComparisonFormulaTestLatexGreaterOrEqual(x=5, y=10)
+        formula = AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[f1, f2])
+
+        latex = formula.latex()
+
+        actual = {
+            "complete": latex.complete,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Description

Hi Enrique,
This is the fix (Sina edition). My PR text is not as fancy as yours, but my code is human written and checked. 😄 

The unity check for formula 5-7 and 5-8 was wrong. When you have lhs > rhs, you should calculate the u.c. = rhs / lhs. 

Fixes #1107 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how comparison-based formulas determine satisfaction (including proper handling for negative values and real boolean results).
  * Updated unity-check calculations for sway imperfections and slenderness-related checks to match the intended expressions.
  * Improved aggregated results output so LaTeX clearly renders **“OK”** vs **“Not OK”** consistently.
* **Tests**
  * Expanded regression coverage for comparison truthiness and aggregated LaTeX rendering.
  * Updated expected values to reflect corrected unity-check and comparison behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->