### PR TITLE
1060 documentation issue build internal wrapper for sectionproperties to bp coordinates

### DIFF
--- a/blueprints/structural_sections/__init__.py
+++ b/blueprints/structural_sections/__init__.py
@@ -1,9 +1,13 @@
 """Structural sections package."""
 
+from blueprints.structural_sections._coordinate_wrappers._section_properties import BPSectionProperties
+from blueprints.structural_sections._coordinate_wrappers._stress_post import BPStressPost
 from blueprints.structural_sections._polygon_builder import PolygonBuilder
 from blueprints.structural_sections._profile import Profile
 
 __all__ = [
+    "BPSectionProperties",
+    "BPStressPost",
     "PolygonBuilder",
     "Profile",
 ]

--- a/blueprints/structural_sections/_coordinate_wrappers/__init__.py
+++ b/blueprints/structural_sections/_coordinate_wrappers/__init__.py
@@ -1,0 +1,1 @@
+"""Coordinate wrappers for structural sections."""

--- a/blueprints/structural_sections/_coordinate_wrappers/_section_properties.py
+++ b/blueprints/structural_sections/_coordinate_wrappers/_section_properties.py
@@ -1,0 +1,434 @@
+"""Section properties container using the Blueprints coordinate system.
+
+Coordinate System:
+
+    z (vertical, usually strong axis)
+        ↑
+        |     x (longitudinal beam direction, into screen)
+        |    ↗
+        |   /
+        |  /
+        | /
+        |/
+    ←-----O
+    y (horizontal/side, usually weak axis)
+
+Blueprints coordinate system:
+    x — longitudinal beam direction (into the screen)
+    y — horizontal, positive to the left
+    z — vertical, positive upwards
+
+The underlying ``sectionproperties`` library uses:
+    x — horizontal, positive to the right
+    y — vertical, positive upwards
+    z — longitudinal beam direction (into the screen)
+
+Mapping between the two systems:
+    bp_y = -sp_x
+    bp_z =  sp_y
+    bp_x =  sp_z
+
+This module wraps :class:`sectionproperties.post.post.SectionProperties` so that
+all attribute names, sign conventions and ``plus``/``minus`` fibre labels are
+expressed in the Blueprints frame as :class:`SectionProperties`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+from sectionproperties.post.post import SectionProperties as SpSectionProperties
+
+
+def _neg(value: float | None) -> float | None:
+    """Negate a value if it is not ``None``."""
+    return -value if value is not None else None
+
+
+@dataclass
+class BPSectionProperties:
+    """Section properties expressed in the Blueprints coordinate system.
+
+    Coordinate System:
+
+        z (vertical, usually strong axis)
+              ↑
+              |     x (longitudinal beam direction, into screen)
+              |    ↗
+              |   /
+              |  /
+              | /
+              |/
+        ←-----O
+        y (horizontal/side, usually weak axis)
+
+    Attributes
+    ----------
+    area : float | None
+        Cross-sectional area.
+    perimeter : float | None
+        Cross-sectional perimeter.
+    mass : float | None
+        Cross-sectional mass.
+    ea : float | None
+        Modulus weighted area (axial rigidity).
+    ga : float | None
+        Modulus weighted product of shear modulus and area.
+    nu_eff : float | None
+        Effective Poisson's ratio.
+    e_eff : float | None
+        Effective elastic modulus.
+    g_eff : float | None
+        Effective shear modulus.
+    qy : float | None
+        First moment of area about the y-axis (∫ z dA).
+    qz : float | None
+        First moment of area about the z-axis (∫ y dA).
+    iyy_g : float | None
+        Second moment of area about the global y-axis.
+    izz_g : float | None
+        Second moment of area about the global z-axis.
+    iyz_g : float | None
+        Product moment of area about the global yz-axes.
+    cy : float | None
+        y-coordinate of the elastic centroid.
+    cz : float | None
+        z-coordinate of the elastic centroid.
+    iyy_c : float | None
+        Second moment of area about the centroidal y-axis.
+    izz_c : float | None
+        Second moment of area about the centroidal z-axis.
+    iyz_c : float | None
+        Product moment of area about the centroidal yz-axes.
+    zyy_plus : float | None
+        Section modulus about the centroidal y-axis for stresses at the
+        positive extreme of z (top fibre).
+    zyy_minus : float | None
+        Section modulus about the centroidal y-axis for stresses at the
+        negative extreme of z (bottom fibre).
+    zzz_plus : float | None
+        Section modulus about the centroidal z-axis for stresses at the
+        positive extreme of y.
+    zzz_minus : float | None
+        Section modulus about the centroidal z-axis for stresses at the
+        negative extreme of y.
+    ry_c : float | None
+        Radius of gyration about the centroidal y-axis.
+    rz_c : float | None
+        Radius of gyration about the centroidal z-axis.
+    i11_c : float | None
+        Second moment of area about the centroidal 11-axis.
+    i22_c : float | None
+        Second moment of area about the centroidal 22-axis.
+    phi : float | None
+        Principal axis angle [rad], measured counter-clockwise from the
+        positive y-axis to the positive 11-axis in the Blueprints frame.
+    z11_plus : float | None
+        Section modulus about the principal 11-axis for stresses at the
+        positive extreme of the 22-axis.
+    z11_minus : float | None
+        Section modulus about the principal 11-axis for stresses at the
+        negative extreme of the 22-axis.
+    z22_plus : float | None
+        Section modulus about the principal 22-axis for stresses at the
+        positive extreme of the 11-axis.
+    z22_minus : float | None
+        Section modulus about the principal 22-axis for stresses at the
+        negative extreme of the 11-axis.
+    r11_c : float | None
+        Radius of gyration about the principal 11-axis.
+    r22_c : float | None
+        Radius of gyration about the principal 22-axis.
+    my_yy : float | None
+        Yield moment about the y-axis.
+    my_zz : float | None
+        Yield moment about the z-axis.
+    my_11 : float | None
+        Yield moment about the 11-axis.
+    my_22 : float | None
+        Yield moment about the 22-axis.
+    j : float | None
+        Torsion constant.
+    omega : npt.NDArray[np.float64] | None
+        Warping function (per mesh node).
+    psi_shear : npt.NDArray[np.float64] | None
+        Psi shear function (per mesh node).
+    phi_shear : npt.NDArray[np.float64] | None
+        Phi shear function (per mesh node).
+    delta_s : float | None
+        Shear factor.
+    y_se : float | None
+        y-coordinate of the shear centre (elasticity approach).
+    z_se : float | None
+        z-coordinate of the shear centre (elasticity approach).
+    y11_se : float | None
+        11-coordinate of the shear centre (elasticity approach).
+    z22_se : float | None
+        22-coordinate of the shear centre (elasticity approach).
+    y_st : float | None
+        y-coordinate of the shear centre (Trefftz's approach).
+    z_st : float | None
+        z-coordinate of the shear centre (Trefftz's approach).
+    gamma : float | None
+        Warping constant.
+    a_sy : float | None
+        Shear area for shear in the y-direction.
+    a_sz : float | None
+        Shear area for shear in the z-direction.
+    a_syz : float | None
+        Shear area about the yz-axes.
+    a_s11 : float | None
+        Shear area about the 11-bending axis.
+    a_s22 : float | None
+        Shear area about the 22-bending axis.
+    beta_y_plus : float | None
+        Monosymmetry constant for bending about the y-axis with the top
+        flange (positive z) in compression.
+    beta_y_minus : float | None
+        Monosymmetry constant for bending about the y-axis with the bottom
+        flange (negative z) in compression.
+    beta_z_plus : float | None
+        Monosymmetry constant for bending about the z-axis with the flange
+        at positive y in compression.
+    beta_z_minus : float | None
+        Monosymmetry constant for bending about the z-axis with the flange
+        at negative y in compression.
+    beta_11_plus : float | None
+        Monosymmetry constant for bending about the 11-axis with the
+        positive 22-side in compression.
+    beta_11_minus : float | None
+        Monosymmetry constant for bending about the 11-axis with the
+        negative 22-side in compression.
+    beta_22_plus : float | None
+        Monosymmetry constant for bending about the 22-axis with the
+        positive 11-side in compression.
+    beta_22_minus : float | None
+        Monosymmetry constant for bending about the 22-axis with the
+        negative 11-side in compression.
+    y_pc : float | None
+        y-coordinate of the global plastic centroid.
+    z_pc : float | None
+        z-coordinate of the global plastic centroid.
+    y11_pc : float | None
+        11-coordinate of the principal plastic centroid.
+    z22_pc : float | None
+        22-coordinate of the principal plastic centroid.
+    syy : float | None
+        Plastic section modulus about the centroidal y-axis.
+    szz : float | None
+        Plastic section modulus about the centroidal z-axis.
+    sf_yy_plus : float | None
+        Shape factor for bending about the y-axis with respect to the top
+        fibre (positive z).
+    sf_yy_minus : float | None
+        Shape factor for bending about the y-axis with respect to the
+        bottom fibre (negative z).
+    sf_zz_plus : float | None
+        Shape factor for bending about the z-axis with respect to the
+        fibre at positive y.
+    sf_zz_minus : float | None
+        Shape factor for bending about the z-axis with respect to the
+        fibre at negative y.
+    s11 : float | None
+        Plastic section modulus about the 11-axis.
+    s22 : float | None
+        Plastic section modulus about the 22-axis.
+    sf_11_plus : float | None
+        Shape factor for bending about the 11-axis with respect to the
+        positive 22-side.
+    sf_11_minus : float | None
+        Shape factor for bending about the 11-axis with respect to the
+        negative 22-side.
+    sf_22_plus : float | None
+        Shape factor for bending about the 22-axis with respect to the
+        positive 11-side.
+    sf_22_minus : float | None
+        Shape factor for bending about the 22-axis with respect to the
+        negative 11-side.
+    """
+
+    area: float | None = None
+    perimeter: float | None = None
+    mass: float | None = None
+    ea: float | None = None
+    ga: float | None = None
+    nu_eff: float | None = None
+    e_eff: float | None = None
+    g_eff: float | None = None
+    qy: float | None = None
+    qz: float | None = None
+    iyy_g: float | None = None
+    izz_g: float | None = None
+    iyz_g: float | None = None
+    cy: float | None = None
+    cz: float | None = None
+    iyy_c: float | None = None
+    izz_c: float | None = None
+    iyz_c: float | None = None
+    zyy_plus: float | None = None
+    zyy_minus: float | None = None
+    zzz_plus: float | None = None
+    zzz_minus: float | None = None
+    ry_c: float | None = None
+    rz_c: float | None = None
+    i11_c: float | None = None
+    i22_c: float | None = None
+    phi: float | None = None
+    z11_plus: float | None = None
+    z11_minus: float | None = None
+    z22_plus: float | None = None
+    z22_minus: float | None = None
+    r11_c: float | None = None
+    r22_c: float | None = None
+    my_yy: float | None = None
+    my_zz: float | None = None
+    my_11: float | None = None
+    my_22: float | None = None
+    j: float | None = None
+    omega: npt.NDArray[np.float64] | None = None
+    psi_shear: npt.NDArray[np.float64] | None = None
+    phi_shear: npt.NDArray[np.float64] | None = None
+    delta_s: float | None = None
+    y_se: float | None = None
+    z_se: float | None = None
+    y11_se: float | None = None
+    z22_se: float | None = None
+    y_st: float | None = None
+    z_st: float | None = None
+    gamma: float | None = None
+    a_sy: float | None = None
+    a_sz: float | None = None
+    a_syz: float | None = None
+    a_s11: float | None = None
+    a_s22: float | None = None
+    beta_y_plus: float | None = None
+    beta_y_minus: float | None = None
+    beta_z_plus: float | None = None
+    beta_z_minus: float | None = None
+    beta_11_plus: float | None = None
+    beta_11_minus: float | None = None
+    beta_22_plus: float | None = None
+    beta_22_minus: float | None = None
+    y_pc: float | None = None
+    z_pc: float | None = None
+    y11_pc: float | None = None
+    z22_pc: float | None = None
+    syy: float | None = None
+    szz: float | None = None
+    sf_yy_plus: float | None = None
+    sf_yy_minus: float | None = None
+    sf_zz_plus: float | None = None
+    sf_zz_minus: float | None = None
+    s11: float | None = None
+    s22: float | None = None
+    sf_11_plus: float | None = None
+    sf_11_minus: float | None = None
+    sf_22_plus: float | None = None
+    sf_22_minus: float | None = None
+
+    def asdict(self) -> dict[str, Any]:
+        """Return the section properties as a dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_sectionproperties(cls, props: SpSectionProperties) -> BPSectionProperties:
+        """Create a Blueprints ``BPSectionProperties`` from a raw ``sectionproperties`` result.
+
+        The values are re-labelled and their signs adjusted so that the returned
+        object is expressed in the Blueprints coordinate system.
+
+        Parameters
+        ----------
+        props : SpSectionProperties
+            Section properties as calculated by the ``sectionproperties`` library.
+        """
+        # bp_y = -sp_x, bp_z = sp_y — see module docstring for the full mapping.
+        # Axis-labelled scalars follow the axis rename (sp x/y ↔ bp y/z) with a
+        # sign flip whenever an odd power of a horizontal coordinate is involved.
+        # The plus/minus fibre labels flip for quantities keyed to the z-axis in
+        # bp (because bp's positive y is sp's negative x), and for quantities
+        # keyed to the principal 22-axis (because the bp view mirrors sp
+        # horizontally, so 90° CCW from +11 in bp points opposite to sp).
+        return cls(
+            area=props.area,
+            perimeter=props.perimeter,
+            mass=props.mass,
+            ea=props.ea,
+            ga=props.ga,
+            nu_eff=props.nu_eff,
+            e_eff=props.e_eff,
+            g_eff=props.g_eff,
+            qy=props.qx,
+            qz=_neg(props.qy),
+            iyy_g=props.ixx_g,
+            izz_g=props.iyy_g,
+            iyz_g=_neg(props.ixy_g),
+            cy=_neg(props.cx),
+            cz=props.cy,
+            iyy_c=props.ixx_c,
+            izz_c=props.iyy_c,
+            iyz_c=_neg(props.ixy_c),
+            zyy_plus=props.zxx_plus,
+            zyy_minus=props.zxx_minus,
+            zzz_plus=props.zyy_minus,
+            zzz_minus=props.zyy_plus,
+            ry_c=props.rx_c,
+            rz_c=props.ry_c,
+            i11_c=props.i11_c,
+            i22_c=props.i22_c,
+            phi=_neg(props.phi),
+            z11_plus=props.z11_minus,
+            z11_minus=props.z11_plus,
+            z22_plus=props.z22_plus,
+            z22_minus=props.z22_minus,
+            r11_c=props.r11_c,
+            r22_c=props.r22_c,
+            my_yy=props.my_xx,
+            my_zz=props.my_yy,
+            my_11=props.my_11,
+            my_22=props.my_22,
+            j=props.j,
+            omega=props.omega,
+            psi_shear=props.psi_shear,
+            phi_shear=props.phi_shear,
+            delta_s=props.delta_s,
+            y_se=_neg(props.x_se),
+            z_se=props.y_se,
+            y11_se=props.x11_se,
+            z22_se=_neg(props.y22_se),
+            y_st=_neg(props.x_st),
+            z_st=props.y_st,
+            gamma=props.gamma,
+            a_sy=props.a_sx,
+            a_sz=props.a_sy,
+            a_syz=_neg(props.a_sxy),
+            a_s11=props.a_s11,
+            a_s22=props.a_s22,
+            beta_y_plus=props.beta_x_plus,
+            beta_y_minus=props.beta_x_minus,
+            beta_z_plus=props.beta_y_minus,
+            beta_z_minus=props.beta_y_plus,
+            beta_11_plus=props.beta_11_minus,
+            beta_11_minus=props.beta_11_plus,
+            beta_22_plus=props.beta_22_plus,
+            beta_22_minus=props.beta_22_minus,
+            y_pc=_neg(props.x_pc),
+            z_pc=props.y_pc,
+            y11_pc=props.x11_pc,
+            z22_pc=_neg(props.y22_pc),
+            syy=props.sxx,
+            szz=props.syy,
+            sf_yy_plus=props.sf_xx_plus,
+            sf_yy_minus=props.sf_xx_minus,
+            sf_zz_plus=props.sf_yy_minus,
+            sf_zz_minus=props.sf_yy_plus,
+            s11=props.s11,
+            s22=props.s22,
+            sf_11_plus=props.sf_11_minus,
+            sf_11_minus=props.sf_11_plus,
+            sf_22_plus=props.sf_22_plus,
+            sf_22_minus=props.sf_22_minus,
+        )

--- a/blueprints/structural_sections/_coordinate_wrappers/_stress_post.py
+++ b/blueprints/structural_sections/_coordinate_wrappers/_stress_post.py
@@ -1,0 +1,415 @@
+"""Stress calculation wrapper using the Blueprints coordinate system.
+
+Coordinate System:
+
+    z (vertical, usually strong axis)
+        ↑
+        |     x (longitudinal beam direction, into screen)
+        |    ↗
+        |   /
+        |  /
+        | /
+        |/
+    ←-----O
+    y (horizontal/side, usually weak axis)
+
+Blueprints coordinate system:
+    x — longitudinal beam direction (into the screen)
+    y — horizontal, positive to the left
+    z — vertical, positive upwards
+
+The underlying ``sectionproperties`` library uses:
+    x — horizontal, positive to the right
+    y — vertical, positive upwards
+    z — longitudinal beam direction (into the screen)
+
+Mapping between the two systems:
+    bp_y = -sp_x
+    bp_z =  sp_y
+    bp_x =  sp_z
+
+This module wraps :class:`sectionproperties.post.stress_post.StressPost` so that
+all stress directions and sign conventions are expressed in the Blueprints frame.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    import matplotlib.axes
+    from sectionproperties.analysis.section import MaterialGroup, Section
+    from sectionproperties.post.stress_post import StressPost as SpStressPost
+    from sectionproperties.pre.pre import Material
+
+
+def _neg_array(value: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Negate a numpy array."""
+    return -value
+
+
+class BPStressPost:
+    """Wrapper for StressPost results expressed in the Blueprints coordinate system.
+
+    This class wraps the :class:`sectionproperties.post.stress_post.StressPost` object
+    and converts all stress results from the sectionproperties coordinate system to
+    the Blueprints coordinate system.
+
+    Parameters
+    ----------
+    stress_post : SpStressPost
+        The sectionproperties StressPost object to wrap.
+
+    Attributes
+    ----------
+    _sp_stress_post : SpStressPost
+        The underlying sectionproperties StressPost object.
+    """
+
+    def __init__(self, stress_post: SpStressPost) -> None:
+        """Initialize the BPStressPost wrapper.
+
+        Parameters
+        ----------
+        stress_post : SpStressPost
+            The sectionproperties StressPost object to wrap.
+        """
+        self._sp_stress_post = stress_post
+
+    def get_stress(self) -> list[dict[str, str | npt.NDArray[np.float64]]]:
+        """Return the stresses within each material in Blueprints coordinate system.
+
+        Returns
+        -------
+        list[dict[str, str | npt.NDArray[np.float64]]]
+            A list of dictionaries containing the cross-section stresses at each node
+            for each material, expressed in the Blueprints coordinate system.
+
+        Note
+        ----
+        Each list of stresses in the dictionary contains the stresses at every node
+        (order from ``node 0`` to ``node n``) in the entire mesh. As a result, when
+        the current material does not exist at a node, a value of zero will be
+        reported.
+
+        Dictionary keys and values
+        --------------------------
+        In general the stresses are described by an action followed by a stress
+        direction ``(action)_(stress-direction)``, e.g. ``mx_zy`` represents the
+        shear stress in the zy direction caused by the torsion ``mx``.
+
+        The following keys are available in each dictionary:
+
+        - ``"material"`` - material name
+        - ``"sig_xx_n"`` - normal stress σ_xx,N from axial load N
+        - ``"sig_xx_my"`` - normal stress σ_xx,My from bending moment My
+        - ``"sig_xx_mz"`` - normal stress σ_xx,Mz from bending moment Mz
+        - ``"sig_xx_m11"`` - normal stress σ_xx,M11 from bending moment M11
+        - ``"sig_xx_m22"`` - normal stress σ_xx,M22 from bending moment M22
+        - ``"sig_xx_m"`` - normal stress σ_xx,ΣM from all bending moments
+        - ``"sig_xy_mx"`` - y component of shear stress σ_xy,Mx from torsion Mx
+        - ``"sig_xz_mx"`` - z component of shear stress σ_xz,Mx from torsion Mx
+        - ``"sig_xyz_mx"`` - resultant shear stress σ_xyz,Mx from torsion Mx
+        - ``"sig_xy_vy"`` - y component of shear stress σ_xy,Vy from shear force Vy
+        - ``"sig_xz_vy"`` - z component of shear stress σ_xz,Vy from shear force Vy
+        - ``"sig_xyz_vy"`` - resultant shear stress σ_xyz,Vy from shear force Vy
+        - ``"sig_xy_vz"`` - y component of shear stress σ_xy,Vz from shear force Vz
+        - ``"sig_xz_vz"`` - z component of shear stress σ_xz,Vz from shear force Vz
+        - ``"sig_xyz_vz"`` - resultant shear stress σ_xyz,Vz from shear force Vz
+        - ``"sig_xy_v"`` - y component of shear stress σ_xy,ΣV from all shear forces
+        - ``"sig_xz_v"`` - z component of shear stress σ_xz,ΣV from all shear forces
+        - ``"sig_xyz_v"`` - resultant shear stress σ_xyz,ΣV from all shear forces
+        - ``"sig_xx"`` - combined normal stress σ_xx from all actions
+        - ``"sig_xy"`` - y component of shear stress σ_xy from all actions
+        - ``"sig_xz"`` - z component of shear stress σ_xz from all actions
+        - ``"sig_xyz"`` - resultant shear stress σ_xyz from all actions
+        - ``"sig_11"`` - major principal stress σ_11 from all actions
+        - ``"sig_33"`` - minor principal stress σ_33 from all actions
+        - ``"sig_vm"`` - von Mises stress σ_vM from all actions
+        """
+        # Get stress from sectionproperties
+        sp_stress_list = self._sp_stress_post.get_stress()
+
+        # Convert each material group's stress to Blueprints coordinate system
+        bp_stress_list: list[dict[str, str | npt.NDArray[np.float64]]] = []
+
+        for sp_stress in sp_stress_list:
+            # Coordinate transformation:
+            # bp_x <-> sp_z (longitudinal)
+            # bp_y <-> -sp_x (horizontal, sign flipped)
+            # bp_z <-> sp_y (vertical)
+            #
+            # For stress components:
+            # sig_xx (bp) <-> sig_zz (sp) - normal stress in longitudinal direction
+            # sig_xy (bp) <-> -sig_zx (sp) - shear stress xy component (sign flipped)
+            # sig_xz (bp) <-> sig_zy (sp) - shear stress xz component
+            # sig_xyz (bp) <-> sig_zxy (sp) - resultant shear stress magnitude (unchanged)
+
+            bp_stress = {
+                "material": sp_stress["material"],
+                # Normal stresses from axial force and bending
+                "sig_xx_n": sp_stress["sig_zz_n"],
+                "sig_xx_my": sp_stress["sig_zz_mxx"],  # My (bp) = Mxx (sp)
+                "sig_xx_mz": sp_stress["sig_zz_myy"],  # Mz (bp) = Myy (sp)
+                "sig_xx_m11": sp_stress["sig_zz_m11"],
+                "sig_xx_m22": sp_stress["sig_zz_m22"],
+                "sig_xx_m": sp_stress["sig_zz_m"],
+                # Shear stresses from torsion Mx (bp) = Mzz (sp)
+                "sig_xy_mx": _neg_array(sp_stress["sig_zx_mzz"]),
+                "sig_xz_mx": sp_stress["sig_zy_mzz"],
+                "sig_xyz_mx": sp_stress["sig_zxy_mzz"],
+                # Shear stresses from shear force Vy (bp) = Vx (sp, but sign flipped)
+                "sig_xy_vy": _neg_array(sp_stress["sig_zx_vx"]),
+                "sig_xz_vy": sp_stress["sig_zy_vx"],
+                "sig_xyz_vy": sp_stress["sig_zxy_vx"],
+                # Shear stresses from shear force Vz (bp) = Vy (sp)
+                "sig_xy_vz": _neg_array(sp_stress["sig_zx_vy"]),
+                "sig_xz_vz": sp_stress["sig_zy_vy"],
+                "sig_xyz_vz": sp_stress["sig_zxy_vy"],
+                # Combined shear stresses from all shear forces
+                "sig_xy_v": _neg_array(sp_stress["sig_zx_v"]),
+                "sig_xz_v": sp_stress["sig_zy_v"],
+                "sig_xyz_v": sp_stress["sig_zxy_v"],
+                # Combined stresses from all actions
+                "sig_xx": sp_stress["sig_zz"],
+                "sig_xy": _neg_array(sp_stress["sig_zx"]),
+                "sig_xz": sp_stress["sig_zy"],
+                "sig_xyz": sp_stress["sig_zxy"],
+                # Principal stresses (invariant under coordinate transformation)
+                "sig_11": sp_stress["sig_11"],
+                "sig_33": sp_stress["sig_33"],
+                # von Mises stress (invariant under coordinate transformation)
+                "sig_vm": sp_stress["sig_vm"],
+            }
+
+            bp_stress_list.append(bp_stress)
+
+        return bp_stress_list
+
+    def plot_stress(
+        self,
+        stress: str,
+        title: str | None = None,
+        cmap: str = "coolwarm",
+        stress_limits: tuple[float, float] | None = None,
+        normalize: bool = True,
+        fmt: str = "{x:.4e}",
+        colorbar_label: str = "Stress",
+        alpha: float = 0.5,
+        material_list: list[Material] | None = None,
+        **kwargs: object,
+    ) -> matplotlib.axes.Axes:
+        """Plot filled stress contours over the finite element mesh.
+
+        This method converts Blueprints stress labels to sectionproperties labels
+        and delegates to the underlying StressPost object.
+
+        Parameters
+        ----------
+        stress : str
+            Type of stress to plot in Blueprints coordinate system.
+            See notes below for available options.
+        title : str | None
+            Plot title. If None, uses default plot title for selected stress.
+        cmap : str
+            Matplotlib color map. Defaults to "coolwarm".
+        stress_limits : tuple[float, float] | None
+            Custom colorbar stress limits (sig_min, sig_max).
+        normalize : bool
+            If True, CenteredNorm is used to scale the colormap. Defaults to True.
+        fmt : str
+            Number formatting string. Defaults to "{x:.4e}".
+        colorbar_label : str
+            Colorbar label. Defaults to "Stress".
+        alpha : float
+            Transparency of the mesh outlines: 0 ≤ alpha ≤ 1. Defaults to 0.5.
+        material_list : list[Material] | None
+            If specified, only plots materials present in the list.
+        **kwargs
+            Passed to plotting_context.
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+            Matplotlib axes object.
+
+        Notes
+        -----
+        Available stress types (Blueprints coordinate system):
+        - "n_xx" - normal stress from axial load N
+        - "my_xx" - normal stress from bending moment My
+        - "mz_xx" - normal stress from bending moment Mz
+        - "m11_xx" - normal stress from bending moment M11
+        - "m22_xx" - normal stress from bending moment M22
+        - "m_xx" - normal stress from all bending moments
+        - "mx_xy" - y component of shear stress from torsion Mx
+        - "mx_xz" - z component of shear stress from torsion Mx
+        - "mx_xyz" - resultant shear stress from torsion Mx
+        - "vy_xy" - y component of shear stress from shear force Vy
+        - "vy_xz" - z component of shear stress from shear force Vy
+        - "vy_xyz" - resultant shear stress from shear force Vy
+        - "vz_xy" - y component of shear stress from shear force Vz
+        - "vz_xz" - z component of shear stress from shear force Vz
+        - "vz_xyz" - resultant shear stress from shear force Vz
+        - "v_xy" - y component of shear stress from all shear forces
+        - "v_xz" - z component of shear stress from all shear forces
+        - "v_xyz" - resultant shear stress from all shear forces
+        - "xx" - combined normal stress from all actions
+        - "xy" - y component of shear stress from all actions
+        - "xz" - z component of shear stress from all actions
+        - "xyz" - resultant shear stress from all actions
+        - "11" - major principal stress from all actions
+        - "33" - minor principal stress from all actions
+        - "vm" - von Mises stress from all actions
+        """
+        # Map Blueprints stress labels to sectionproperties labels
+        stress_mapping = {
+            # Normal stresses
+            "n_xx": "n_zz",
+            "my_xx": "mxx_zz",
+            "mz_xx": "myy_zz",
+            "m11_xx": "m11_zz",
+            "m22_xx": "m22_zz",
+            "m_xx": "m_zz",
+            # Torsion shear stresses
+            "mx_xy": "mzz_zx",
+            "mx_xz": "mzz_zy",
+            "mx_xyz": "mzz_zxy",
+            # Shear force Vy stresses
+            "vy_xy": "vx_zx",
+            "vy_xz": "vx_zy",
+            "vy_xyz": "vx_zxy",
+            # Shear force Vz stresses
+            "vz_xy": "vy_zx",
+            "vz_xz": "vy_zy",
+            "vz_xyz": "vy_zxy",
+            # Combined shear stresses
+            "v_xy": "v_zx",
+            "v_xz": "v_zy",
+            "v_xyz": "v_zxy",
+            # Combined stresses
+            "xx": "zz",
+            "xy": "zx",
+            "xz": "zy",
+            "xyz": "zxy",
+            # Principal stresses
+            "11": "11",
+            "33": "33",
+            # von Mises
+            "vm": "vm",
+        }
+
+        # Convert stress label to sectionproperties format
+        sp_stress = stress_mapping.get(stress, stress)
+
+        # Delegate to underlying StressPost object
+        return self._sp_stress_post.plot_stress(
+            stress=sp_stress,
+            title=title,
+            cmap=cmap,
+            stress_limits=stress_limits,
+            normalize=normalize,
+            fmt=fmt,
+            colorbar_label=colorbar_label,
+            alpha=alpha,
+            material_list=material_list,
+            **kwargs,
+        )
+
+    def plot_mohrs_circles(
+        self,
+        x: float,
+        y: float,
+        title: str | None = None,
+        **kwargs: object,
+    ) -> matplotlib.axes.Axes:
+        """Plot Mohr's circles of the 3D stress state at position (x, y).
+
+        Note: The coordinates (x, y) are in the sectionproperties coordinate system.
+
+        Parameters
+        ----------
+        x : float
+            x-coordinate of the point (sectionproperties coordinate system).
+        y : float
+            y-coordinate of the point (sectionproperties coordinate system).
+        title : str | None
+            Plot title. If None, uses default plot title.
+        **kwargs
+            Passed to plotting_context.
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+            Matplotlib axes object.
+        """
+        return self._sp_stress_post.plot_mohrs_circles(x=x, y=y, title=title, **kwargs)
+
+    def plot_stress_vector(
+        self,
+        stress: str,
+        title: str | None = None,
+        cmap: str = "YlOrBr",
+        normalize: bool = False,
+        alpha: float = 0.5,
+        material_list: list[Material] | None = None,
+        **kwargs: object,
+    ) -> tuple[matplotlib.axes.Axes, Any]:
+        """Plot stress vectors over the finite element mesh.
+
+        Parameters
+        ----------
+        stress : str
+            Type of stress to plot. Must be a shear stress with direction components.
+        title : str | None
+            Plot title. If None, uses default plot title for selected stress.
+        cmap : str
+            Matplotlib color map. Defaults to "YlOrBr".
+        normalize : bool
+            If True, CenteredNorm is used. Defaults to False.
+        alpha : float
+            Transparency of the mesh outlines. Defaults to 0.5.
+        material_list : list[Material] | None
+            If specified, only plots materials present in the list.
+        **kwargs
+            Passed to plotting_context.
+
+        Returns
+        -------
+        tuple[matplotlib.axes.Axes, Any]
+            Matplotlib axes object and quiver plot object.
+        """
+        # Map Blueprints stress labels to sectionproperties labels
+        stress_mapping = {
+            "mx": "mzz",
+            "vy": "vx",
+            "vz": "vy",
+            "v": "v",
+        }
+
+        # Convert stress label
+        sp_stress = stress_mapping.get(stress, stress)
+
+        # Delegate to underlying StressPost object
+        return self._sp_stress_post.plot_stress_vector(
+            stress=sp_stress,
+            title=title,
+            cmap=cmap,
+            normalize=normalize,
+            alpha=alpha,
+            material_list=material_list,
+            **kwargs,
+        )
+
+    @property
+    def section(self) -> Section:
+        """Get the underlying section object."""
+        return self._sp_stress_post.section
+
+    @property
+    def material_groups(self) -> list[MaterialGroup]:
+        """Get the material groups."""
+        return self._sp_stress_post.material_groups

--- a/blueprints/structural_sections/_profile.py
+++ b/blueprints/structural_sections/_profile.py
@@ -8,12 +8,12 @@ from typing import Any, ClassVar, Self
 
 import matplotlib.pyplot as plt
 from sectionproperties.analysis import Section
-from sectionproperties.post.post import SectionProperties
-from sectionproperties.post.stress_post import StressPost
 from sectionproperties.pre import Geometry
 from shapely import Point, Polygon
 from shapely.affinity import rotate, translate
 
+from blueprints.structural_sections._coordinate_wrappers._section_properties import BPSectionProperties
+from blueprints.structural_sections._coordinate_wrappers._stress_post import BPStressPost
 from blueprints.type_alias import DEG, KN, KNM, M3_M, MM, MM2
 from blueprints.unit_conversion import KN_TO_N, KNM_TO_NMM, M_TO_MM, MM3_TO_M3
 
@@ -35,7 +35,7 @@ class Profile(ABC):
     rotation: DEG = field(default=0.0, kw_only=True)
     """Rotation of the profile [degrees]. Positive values rotate the profile counter-clockwise around its centroid."""
 
-    _section_props_cache: dict[tuple[bool, bool, bool], SectionProperties] = field(
+    _section_props_cache: dict[tuple[bool, bool, bool], BPSectionProperties] = field(
         default_factory=dict, init=False, repr=False, compare=False, hash=False
     )
     """Cache for section properties to avoid recalculation."""
@@ -165,7 +165,7 @@ class Profile(ABC):
         geometric: bool = True,
         plastic: bool = True,
         warping: bool = False,
-    ) -> SectionProperties:
+    ) -> BPSectionProperties:
         """Calculate and return the section properties of the profile.
 
         Parameters
@@ -193,17 +193,20 @@ class Profile(ABC):
         if plastic:
             section.calculate_plastic_properties()
 
-        # Cache the result
-        self._section_props_cache[cache_key] = section.section_props
+        # Wrap the raw sectionproperties result in the Blueprints coordinate system.
+        props = BPSectionProperties.from_sectionproperties(section.section_props)
 
-        return section.section_props
+        # Cache the result
+        self._section_props_cache[cache_key] = props
+
+        return props
 
     @property
     def plotter(self) -> Callable[[Any], plt.Figure]:
         """Default plotter function for the profile."""
         raise AttributeError("No plotter is defined.")
 
-    def calculate_stress(self, n: KN = 0, v_y: KN = 0, v_z: KN = 0, m_x: KNM = 0, m_y: KNM = 0, m_z: KNM = 0) -> StressPost:
+    def calculate_stress(self, n: KN = 0, v_y: KN = 0, v_z: KN = 0, m_x: KNM = 0, m_y: KNM = 0, m_z: KNM = 0) -> BPStressPost:
         """Calculate the stress distribution for the profile given internal forces.
 
         # Coordinate System Blueprints:
@@ -235,8 +238,8 @@ class Profile(ABC):
 
         Returns
         -------
-        StressPost
-            The stress distribution result object for the section under the given loads.
+        BPStressPost
+            The stress distribution result object for the section under the given loads, expressed in Blueprints coordinate system.
         """
         section = self._section()
         section.calculate_geometric_properties()
@@ -258,7 +261,7 @@ class Profile(ABC):
         #   ←-----O                                                        O------>
         #    y (horizontal/side, usually weak axis)                     x (horizontal/side, usually weak axis)
 
-        return section.calculate_stress(
+        stress_post = section.calculate_stress(
             n=float(n) * KN_TO_N,
             vx=-float(v_y) * KN_TO_N,
             vy=float(v_z) * KN_TO_N,
@@ -266,6 +269,9 @@ class Profile(ABC):
             myy=float(m_z) * KNM_TO_NMM,
             mzz=float(m_x) * KNM_TO_NMM,
         )
+
+        # Wrap the raw stress post result in the Blueprints coordinate system.
+        return BPStressPost(stress_post)
 
     def unit_stress(self) -> dict[str, Any]:
         """Calculate the unit stress distribution for the profile.


### PR DESCRIPTION
## Description

As proof of concept - the wrapper for sectionproperties and stresses. questions:
- do we like this approach?
- does more need to be wrapped?
- how to deal with this breaking change and make it known?
- how do we properly test this?

Fixes #1060

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to structural section properties using the Blueprints coordinate system.
  * Added stress-result tools with coordinate conversion, stress retrieval, contour and vector plotting, and Mohr’s circle visualization.
  * Structural profile calculations now return the new section-property and stress-result formats.
  * Added serialization support for section properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->