### PR TITLE
1129 feature request allow for rhs profiles in shear calculation

### DIFF
--- a/blueprints/checks/eurocode/steel/strength_shear.py
+++ b/blueprints/checks/eurocode/steel/strength_shear.py
@@ -37,6 +37,7 @@ class CheckStrengthShearClass12:
     Notes
     -----
     Not all profile shapes have been implemented for this check yet. Currently, only I- and RHS-profiles are supported.
+    The shear areas of 6.2.6(3) apply to upright profiles only, so a profile with a rotation other than 0 is rejected.
 
     Parameters
     ----------

--- a/blueprints/checks/eurocode/steel/strength_shear.py
+++ b/blueprints/checks/eurocode/steel/strength_shear.py
@@ -10,6 +10,7 @@ from blueprints.codes.eurocode.en_1993_1_1_2005 import EN_1993_1_1_2005
 from blueprints.codes.eurocode.en_1993_1_1_2005.chapter_6_ultimate_limit_state import formula_6_17, formula_6_18, formula_6_18_sub_av, formula_6_19
 from blueprints.codes.formula import Formula
 from blueprints.structural_sections.steel.profile_definitions.i_profile import IProfile
+from blueprints.structural_sections.steel.profile_definitions.rhs_profile import RHSProfile
 from blueprints.structural_sections.steel.steel_cross_section import SteelCrossSection
 from blueprints.type_alias import DIMENSIONLESS, KN
 from blueprints.unit_conversion import KN_TO_N
@@ -35,7 +36,7 @@ class CheckStrengthShearClass12:
 
     Notes
     -----
-    Not all profile shapes have been implemented for this check yet. Currently, only I-profiles are supported.
+    Not all profile shapes have been implemented for this check yet. Currently, only I- and RHS-profiles are supported.
 
     Parameters
     ----------
@@ -72,7 +73,7 @@ class CheckStrengthShearClass12:
 
     def __post_init__(self) -> None:
         """Check on implemented_shapes."""
-        implemented_shapes = (IProfile,)
+        implemented_shapes = (IProfile, RHSProfile)
         if type(self.steel_cross_section.profile) not in implemented_shapes:
             raise NotImplementedError(f"The provided profile shape {type(self.steel_cross_section.profile).__name__} has not been implemented yet.")
 
@@ -93,30 +94,83 @@ class CheckStrengthShearClass12:
         (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18a/d/e)).
         """
         if isinstance(self.steel_cross_section.profile, IProfile):
-            # Get parameters from profile, average top and bottom flange properties
-            a = float(self.steel_cross_section.profile.area)
-            b1 = self.steel_cross_section.profile.top_flange_width
-            b2 = self.steel_cross_section.profile.bottom_flange_width
-            tf1 = self.steel_cross_section.profile.top_flange_thickness
-            tf2 = self.steel_cross_section.profile.bottom_flange_thickness
-            tw = self.steel_cross_section.profile.web_thickness
-            hw = self.steel_cross_section.profile.total_height - (
-                self.steel_cross_section.profile.top_flange_thickness + self.steel_cross_section.profile.bottom_flange_thickness
-            )
-            r1 = self.steel_cross_section.profile.top_radius
-            r2 = self.steel_cross_section.profile.bottom_radius
-
-            assert all(param is not None for param in [a, b1, b2, tf1, tf2, tw, hw, r1, r2]), (
-                "All profile parameters must be defined for I-profile shear area calculation."
-            )
-
-            if self.axis == "Vz" and self.steel_cross_section.fabrication_method in ["hot-rolled", "cold-formed"]:
-                return formula_6_18_sub_av.Form6Dot18SubARolledIandHSection(a=a, b1=b1, b2=b2, hw=hw, r1=r1, r2=r2, tf1=tf1, tf2=tf2, tw=tw, eta=1.0)
-            if self.axis == "Vz" and self.steel_cross_section.fabrication_method == "welded":
-                return formula_6_18_sub_av.Form6Dot18SubDWeldedIHandBoxSection(hw_list=[hw], tw_list=[tw], eta=1.0)
-            # when axis == "Vy"
-            return formula_6_18_sub_av.Form6Dot18SubEWeldedIHandBoxSection(a=a, hw_list=[hw], tw_list=[tw])
+            return self._shear_area_iprofile()
+        if isinstance(self.steel_cross_section.profile, RHSProfile):
+            return self._shear_area_rhs()
         raise NotImplementedError("Profile type is not supported")  # pragma: no cover
+
+    def _shear_area_iprofile(self) -> Formula:
+        """Calculate the shear area of an I-profile steel cross-section (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18a/d/e))."""
+        profile = self.steel_cross_section.profile
+        assert isinstance(profile, IProfile)
+
+        # Get parameters from profile, average top and bottom flange properties
+        a = float(profile.area)
+        b1 = profile.top_flange_width
+        b2 = profile.bottom_flange_width
+        tf1 = profile.top_flange_thickness
+        tf2 = profile.bottom_flange_thickness
+        tw = profile.web_thickness
+        hw = profile.total_height - (profile.top_flange_thickness + profile.bottom_flange_thickness)
+        r1 = profile.top_radius
+        r2 = profile.bottom_radius
+
+        assert all(param is not None for param in [a, b1, b2, tf1, tf2, tw, hw, r1, r2]), (
+            "All profile parameters must be defined for I-profile shear area calculation."
+        )
+
+        if self.axis == "Vz" and self.steel_cross_section.fabrication_method in ["hot-rolled", "cold-formed"]:
+            return formula_6_18_sub_av.Form6Dot18SubARolledIandHSection(a=a, b1=b1, b2=b2, hw=hw, r1=r1, r2=r2, tf1=tf1, tf2=tf2, tw=tw, eta=1.0)
+        if self.axis == "Vz" and self.steel_cross_section.fabrication_method == "welded":
+            return formula_6_18_sub_av.Form6Dot18SubDWeldedIHandBoxSection(hw_list=[hw], tw_list=[tw], eta=1.0)
+        # when axis == "Vy"
+        return formula_6_18_sub_av.Form6Dot18SubEWeldedIHandBoxSection(a=a, hw_list=[hw], tw_list=[tw])
+
+    def _shear_area_rhs(self) -> Formula:
+        """Calculate the shear area of an RHS-profile steel cross-section (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18a/d/e))."""
+        profile = self.steel_cross_section.profile
+        assert isinstance(profile, RHSProfile)
+
+        # Get parameters from profile
+        a = float(profile.area)
+        b = profile.total_width
+        h = profile.total_height
+        t_w1 = profile.left_wall_thickness
+        t_w2 = profile.right_wall_thickness
+        t_f1 = profile.top_wall_thickness
+        t_f2 = profile.bottom_wall_thickness
+        r_i1 = profile.top_left_inner_radius
+        r_i2 = profile.top_right_inner_radius
+        r_i3 = profile.bottom_left_inner_radius
+        r_i4 = profile.bottom_right_inner_radius
+        r_o1 = profile.top_left_outer_radius
+        r_o2 = profile.top_right_outer_radius
+        r_o3 = profile.bottom_left_outer_radius
+        r_o4 = profile.bottom_right_outer_radius
+
+        assert all(param is not None for param in [a, b, h, t_w1, t_w2, t_f1, t_f2, r_i1, r_i2, r_i3, r_i4, r_o1, r_o2, r_o3, r_o4]), (
+            "All profile parameters must be defined for RHS-profile shear area calculation."
+        )
+
+        # Check for rolled rectangular hollow sections of uniform thickness
+        if self.steel_cross_section.fabrication_method in ["hot-rolled", "cold-formed"] and not (
+            t_w1 == t_w2 == t_f1 == t_f2 and r_i1 == r_i2 == r_i3 == r_i4 and r_o1 == r_o2 == r_o3 == r_o4
+        ):
+            raise NotImplementedError(
+                "Currently, when RHS-profiles are hot-rolled/cold-formed, it must be provided with equal wall thicknesses and equal corner radii."
+            )
+
+        h_w1 = h - t_f1 - t_f2 - r_i1 - r_i3
+        h_w2 = h - t_f1 - t_f2 - r_i2 - r_i4
+
+        if self.axis == "Vz" and self.steel_cross_section.fabrication_method in ["hot-rolled", "cold-formed"]:
+            return formula_6_18_sub_av.Form6Dot18SubF1RolledRectangularHollowSectionDepth(a, b, h)
+        if self.axis == "Vz" and self.steel_cross_section.fabrication_method == "welded":
+            return formula_6_18_sub_av.Form6Dot18SubDWeldedIHandBoxSection([h_w1, h_w2], [t_w1, t_w2], eta=1.0)
+        if self.axis == "Vy" and self.steel_cross_section.fabrication_method in ["hot-rolled", "cold-formed"]:
+            return formula_6_18_sub_av.Form6Dot18SubF2RolledRectangularHollowSectionWidth(a, b, h)
+        # when axis == "Vy" and welded
+        return formula_6_18_sub_av.Form6Dot18SubEWeldedIHandBoxSection(a, [h_w1, h_w2], [t_w1, t_w2])
 
     def plastic_resistance(self) -> Formula:
         """Calculate the shear force plastic resistance of the steel cross-section (EN 1993-1-1:2005 art. 6.2.6(2) - Formula (6.18)).
@@ -167,7 +221,7 @@ class CheckStrengthShearClass12:
         Report
             Report of the plastic shear force check.
         """
-        report = Report("Check: shear force steel I-beam")
+        report = Report("Check: shear force (Class 3/4)")
 
         # will not generate a report if no shear force is applied, as the check is not necessary in that case
         if self.v == 0:
@@ -338,7 +392,7 @@ class CheckStrengthShearClass34:
         Report
             Report of the elastic shear force check.
         """
-        report = Report("Check: shear force steel I-beam (Class 3/4)")
+        report = Report("Check: shear force (Class 3/4)")
 
         # will not generate a report if no shear force is applied, as the check is not necessary in that case
         if self.v == 0:

--- a/blueprints/checks/eurocode/steel/strength_shear.py
+++ b/blueprints/checks/eurocode/steel/strength_shear.py
@@ -76,6 +76,11 @@ class CheckStrengthShearClass12:
         implemented_shapes = (IProfile, RHSProfile)
         if type(self.steel_cross_section.profile) not in implemented_shapes:
             raise NotImplementedError(f"The provided profile shape {type(self.steel_cross_section.profile).__name__} has not been implemented yet.")
+        if self.steel_cross_section.profile.rotation != 0:
+            raise ValueError(
+                f"The profile must be oriented with rotation=0 for plastic shear checks. "
+                f"Current rotation is {self.steel_cross_section.profile.rotation} degrees."
+            )
 
     @staticmethod
     def source_docs() -> list[str]:

--- a/blueprints/checks/eurocode/steel/strength_shear.py
+++ b/blueprints/checks/eurocode/steel/strength_shear.py
@@ -221,7 +221,7 @@ class CheckStrengthShearClass12:
         Report
             Report of the plastic shear force check.
         """
-        report = Report("Check: shear force (Class 3/4)")
+        report = Report("Check: shear force (Class 1/2)")
 
         # will not generate a report if no shear force is applied, as the check is not necessary in that case
         if self.v == 0:

--- a/blueprints/checks/eurocode/steel/strength_shear.py
+++ b/blueprints/checks/eurocode/steel/strength_shear.py
@@ -91,8 +91,11 @@ class CheckStrengthShearClass12:
         """Calculate the shear area of the steel cross-section.
 
         Based on the applied shear force axis and fabrication method
-        (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18a/d/e)).
+        (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18)).
         """
+        if self.steel_cross_section.fabrication_method is None:
+            raise ValueError("Fabrication method must be specified for shear area calculation.")
+
         if isinstance(self.steel_cross_section.profile, IProfile):
             return self._shear_area_iprofile()
         if isinstance(self.steel_cross_section.profile, RHSProfile):
@@ -100,7 +103,7 @@ class CheckStrengthShearClass12:
         raise NotImplementedError("Profile type is not supported")  # pragma: no cover
 
     def _shear_area_iprofile(self) -> Formula:
-        """Calculate the shear area of an I-profile steel cross-section (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18a/d/e))."""
+        """Calculate the shear area of an I-profile steel cross-section (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18))."""
         profile = self.steel_cross_section.profile
         assert isinstance(profile, IProfile)
 
@@ -127,7 +130,7 @@ class CheckStrengthShearClass12:
         return formula_6_18_sub_av.Form6Dot18SubEWeldedIHandBoxSection(a=a, hw_list=[hw], tw_list=[tw])
 
     def _shear_area_rhs(self) -> Formula:
-        """Calculate the shear area of an RHS-profile steel cross-section (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18a/d/e))."""
+        """Calculate the shear area of an RHS-profile steel cross-section (EN 1993-1-1:2005 art. 6.2.6(3) - Formulas (6.18))."""
         profile = self.steel_cross_section.profile
         assert isinstance(profile, RHSProfile)
 

--- a/tests/checks/eurocode/steel/conftest.py
+++ b/tests/checks/eurocode/steel/conftest.py
@@ -3,9 +3,37 @@
 import pytest
 
 from blueprints.materials.steel import SteelMaterial, SteelStrengthClass
+from blueprints.structural_sections.steel.profile_definitions.rhs_profile import RHSProfile
 from blueprints.structural_sections.steel.standard_profiles.chs import CHS
 from blueprints.structural_sections.steel.standard_profiles.heb import HEB
-from blueprints.structural_sections.steel.steel_cross_section import SteelCrossSection
+from blueprints.structural_sections.steel.standard_profiles.rhscf import RHSCF
+from blueprints.structural_sections.steel.steel_cross_section import FabricationMethod, SteelCrossSection
+
+
+@pytest.fixture(scope="class")
+def rhs_steel_cross_section() -> SteelCrossSection:
+    """Create a SteelCrossSection fixture with RHS profile and S355 steel material."""
+    steel_material = SteelMaterial(steel_class=SteelStrengthClass.S355)
+    profile = RHSCF.RHSCF200x100x8
+    return SteelCrossSection(profile=profile, material=steel_material)
+
+
+@pytest.fixture(scope="class")
+def rhs_welded_steel_cross_section() -> SteelCrossSection:
+    """Create a SteelCrossSection fixture with RHS profile and S355 steel material."""
+    steel_material = SteelMaterial(steel_class=SteelStrengthClass.S355)
+    profile = RHSCF.RHSCF200x100x8
+    return SteelCrossSection(profile=profile, material=steel_material, fabrication_method=FabricationMethod.WELDED)
+
+
+@pytest.fixture(scope="class")
+def rhs_custom_steel_cross_section() -> SteelCrossSection:
+    """Create a SteelCrossSection fixture with custom RHS profile and S355 steel material."""
+    steel_material = SteelMaterial(steel_class=SteelStrengthClass.S355)
+    profile = RHSProfile(
+        total_width=200, total_height=300, left_wall_thickness=10, right_wall_thickness=11, top_wall_thickness=12, bottom_wall_thickness=12
+    )
+    return SteelCrossSection(profile=profile, material=steel_material, fabrication_method=FabricationMethod.COLD_FORMED)
 
 
 @pytest.fixture(scope="class")
@@ -21,7 +49,7 @@ def heb_welded_steel_cross_section() -> SteelCrossSection:
     """Create a SteelCrossSection fixture with welded HEB300 profile and S355 steel material."""
     steel_material = SteelMaterial(steel_class=SteelStrengthClass.S355)
     profile = HEB.HEB300
-    return SteelCrossSection(profile=profile, material=steel_material, fabrication_method="welded")
+    return SteelCrossSection(profile=profile, material=steel_material, fabrication_method=FabricationMethod.WELDED)
 
 
 @pytest.fixture(scope="class")

--- a/tests/checks/eurocode/steel/conftest.py
+++ b/tests/checks/eurocode/steel/conftest.py
@@ -37,6 +37,16 @@ def rhs_custom_steel_cross_section() -> SteelCrossSection:
 
 
 @pytest.fixture(scope="class")
+def rhs_custom_no_fabrication_steel_cross_section() -> SteelCrossSection:
+    """Create a SteelCrossSection fixture with custom RHS profile and S355 steel material, without specifying fabrication method."""
+    steel_material = SteelMaterial(steel_class=SteelStrengthClass.S355)
+    profile = RHSProfile(
+        total_width=200, total_height=300, left_wall_thickness=10, right_wall_thickness=11, top_wall_thickness=12, bottom_wall_thickness=12
+    )
+    return SteelCrossSection(profile=profile, material=steel_material)
+
+
+@pytest.fixture(scope="class")
 def heb_steel_cross_section() -> SteelCrossSection:
     """Create a SteelCrossSection fixture with HEB300 profile and S355 steel material."""
     steel_material = SteelMaterial(steel_class=SteelStrengthClass.S355)

--- a/tests/checks/eurocode/steel/test_strength_shear.py
+++ b/tests/checks/eurocode/steel/test_strength_shear.py
@@ -4,6 +4,9 @@ import numpy as np
 import pytest
 
 from blueprints.checks.eurocode.steel.strength_shear import CheckStrengthShearClass12, CheckStrengthShearClass34
+from blueprints.codes.eurocode.en_1993_1_1_2005.chapter_3_materials.table_3_1 import SteelStrengthClass
+from blueprints.materials.steel import SteelMaterial
+from blueprints.structural_sections.steel.profile_definitions.i_profile import IProfile
 from blueprints.structural_sections.steel.steel_cross_section import SteelCrossSection
 
 
@@ -150,6 +153,25 @@ class TestCheckStrengthShearClass12:
         calc = CheckStrengthShearClass12(rhs_custom_no_fabrication_steel_cross_section, v, axis="Vz", gamma_m0=1.0)
         with pytest.raises(ValueError):
             calc.result()
+
+    def test_invalid_rotation(self) -> None:
+        """Test ValueError is raised for invalid rotation input."""
+        steel_material = SteelMaterial(steel_class=SteelStrengthClass.S355)
+        heb_300_profile = IProfile(
+            rotation=50,
+            top_flange_width=100,
+            top_flange_thickness=10,
+            bottom_flange_width=100,
+            bottom_flange_thickness=10,
+            total_height=500,
+            web_thickness=40,
+            top_radius=0,
+            bottom_radius=0,
+        )
+        with pytest.raises(ValueError):
+            CheckStrengthShearClass12(
+                steel_cross_section=SteelCrossSection(profile=heb_300_profile, material=steel_material), v=1, axis="Vy", gamma_m0=1.0
+            )
 
 
 class TestCheckStrengthShearClass34:

--- a/tests/checks/eurocode/steel/test_strength_shear.py
+++ b/tests/checks/eurocode/steel/test_strength_shear.py
@@ -1,5 +1,6 @@
 """Tests for shear strength checks according to Eurocode 3."""
 
+import numpy as np
 import pytest
 
 from blueprints.checks.eurocode.steel.strength_shear import CheckStrengthShearClass12, CheckStrengthShearClass34
@@ -96,6 +97,52 @@ class TestCheckStrengthShearClass12:
         docs = calc.source_docs()
         assert isinstance(docs, list)
         assert len(docs) == 1
+
+    def test_rhs_profile(self, rhs_steel_cross_section: SteelCrossSection) -> None:
+        """Test shear check for RHS profile."""
+        a = 4324.0  # mm²
+        fy = 355.0  # MPa
+        b = 100.0  # mm
+        h = 200.0  # mm
+
+        v = 1.0  # kN,  arbitrary small value to trigger the check
+        calc = CheckStrengthShearClass12(rhs_steel_cross_section, v, axis="Vz", gamma_m0=1.0)
+        result = calc.result()
+        assert result.is_ok is True
+        assert result.required == pytest.approx(fy / np.sqrt(3) * a * h / (b + h), rel=1e-3)
+
+        calc = CheckStrengthShearClass12(rhs_steel_cross_section, v, axis="Vy", gamma_m0=1.0)
+        result = calc.result()
+        assert result.is_ok is True
+        assert result.required == pytest.approx(fy / np.sqrt(3) * a * b / (b + h), rel=1e-3)
+
+    def test_welded_rhs_profile(self, rhs_welded_steel_cross_section: SteelCrossSection) -> None:
+        """Test shear check for RHS profile."""
+        a = 4324.0  # mm²
+        fy = 355.0  # MPa
+        h = 200.0  # mm
+        t = 8.0  # mm
+        r_i = 12.0  # mm
+        h_w = h - 2 * t - 2 * r_i
+        eta = 1.0
+
+        v = 1.0  # kN,  arbitrary small value to trigger the check
+        calc = CheckStrengthShearClass12(rhs_welded_steel_cross_section, v, axis="Vz", gamma_m0=1.0)
+        result = calc.result()
+        assert result.is_ok is True
+        assert result.required == pytest.approx(fy / np.sqrt(3) * eta * 2 * h_w * t, rel=1e-3)
+
+        calc = CheckStrengthShearClass12(rhs_welded_steel_cross_section, v, axis="Vy", gamma_m0=1.0)
+        result = calc.result()
+        assert result.is_ok is True
+        assert result.required == pytest.approx(fy / np.sqrt(3) * (a - 2 * h_w * t), rel=1e-3)
+
+    def test_custom_rhs_profile(self, rhs_custom_steel_cross_section: SteelCrossSection) -> None:
+        """Test shear check for custom RHS profile."""
+        v = 1.0  # kN, arbitrary small value to trigger the check
+        calc = CheckStrengthShearClass12(rhs_custom_steel_cross_section, v, axis="Vz", gamma_m0=1.0)
+        with pytest.raises(NotImplementedError):
+            calc.result()
 
 
 class TestCheckStrengthShearClass34:

--- a/tests/checks/eurocode/steel/test_strength_shear.py
+++ b/tests/checks/eurocode/steel/test_strength_shear.py
@@ -151,7 +151,7 @@ class TestCheckStrengthShearClass12:
         """Test shear check for custom RHS profile without specifying fabrication method."""
         v = 1.0  # kN, arbitrary small value to trigger the check
         calc = CheckStrengthShearClass12(rhs_custom_no_fabrication_steel_cross_section, v, axis="Vz", gamma_m0=1.0)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Fabrication method must be specified for shear area calculation."):
             calc.result()
 
     def test_invalid_rotation(self) -> None:
@@ -168,7 +168,7 @@ class TestCheckStrengthShearClass12:
             top_radius=0,
             bottom_radius=0,
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"The profile must be oriented with rotation=0 for plastic shear checks."):
             CheckStrengthShearClass12(
                 steel_cross_section=SteelCrossSection(profile=heb_300_profile, material=steel_material), v=1, axis="Vy", gamma_m0=1.0
             )

--- a/tests/checks/eurocode/steel/test_strength_shear.py
+++ b/tests/checks/eurocode/steel/test_strength_shear.py
@@ -144,6 +144,13 @@ class TestCheckStrengthShearClass12:
         with pytest.raises(NotImplementedError):
             calc.result()
 
+    def test_custom_no_fabrication_rhs_profile(self, rhs_custom_no_fabrication_steel_cross_section: SteelCrossSection) -> None:
+        """Test shear check for custom RHS profile without specifying fabrication method."""
+        v = 1.0  # kN, arbitrary small value to trigger the check
+        calc = CheckStrengthShearClass12(rhs_custom_no_fabrication_steel_cross_section, v, axis="Vz", gamma_m0=1.0)
+        with pytest.raises(ValueError):
+            calc.result()
+
 
 class TestCheckStrengthShearClass34:
     """Tests for CheckStrengthShearClass34."""


### PR DESCRIPTION
## Description

Allow for rhs profiles in plastic shear calculation. also disallows for nonzero rotations, as formula dont apply. in a future: lets make it then fall back to the elastic shear calc. as that one always works.

Fixes #1129, #1133

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added shear-strength checks for rectangular hollow section (RHS) steel profiles.
  * Supports rolled and welded RHS sections across both shear axes.
  * Added validation for geometry, wall thickness, corner radii, and fabrication details.

* **Bug Fixes**
  * Generalized shear-check report titles for Class 1/2 and Class 3/4 sections.
  * Improved validation for unsupported profiles, missing fabrication methods, and invalid section orientations.

* **Tests**
  * Added coverage for standard, welded, custom, and incomplete RHS configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->