### PR TITLE
feat: add formulas 8.79 and 8.80 from FprEN 1992-1-1:2023 clause 8.3.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_79.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_79.py
@@ -1,0 +1,96 @@
+"""Formula 8.79 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2, MPA, NMM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot79TorsionalShearStressInWall(Formula):
+    r"""Class representing formula 8.79 for the calculation of the torsional shear stress in a wall element of a
+    section subject to a torsional moment.
+
+    It applies to closed thin-walled sections and solid sections, for which 8.3.2(1) allows warping torsion to be
+    ignored. Solid sections are first modelled as equivalent thin-walled sections according to 8.3.1(2).
+
+    The stress follows from the Bredt shear flow, so it is constant over the effective thickness of the wall and
+    the same for every wall of a section with a constant effective thickness.
+    """
+
+    label = "8.79"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        t_ed: NMM,
+        a_k: MM2,
+        t_eff_i: MM,
+    ) -> None:
+        r"""[$\tau_{t,i}$] Torsional shear stress in wall [$i$] [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.2(2) - Formula (8.79)
+
+        Parameters
+        ----------
+        t_ed : NMM
+            [$T_{Ed}$] Torsional moment the section is subject to. The standard introduces this symbol in the text
+            of 8.3.2(2) and not in the "where" list below the formula. Pass its magnitude, so that the resulting
+            shear stress is the one to be compared with the torsional resistance [$Nmm$].
+        a_k : MM2
+            [$A_k$] Area enclosed by the centre-lines of the connecting walls, including inner hollow areas
+            [$mm^2$].
+        t_eff_i : MM
+            [$t_{eff,i}$] Effective wall thickness. It may be taken as [$A/u$], but should not be taken as less
+            than twice the distance between the outer concrete surface and the centre of the longitudinal
+            reinforcement. For hollow sections the actual thickness is an upper limit. Here [$A$] is the total area
+            of the cross-section, including inner hollow areas, and [$u$] is the outer perimeter of the
+            cross-section [$mm$].
+        """
+        super().__init__()
+        self.t_ed = t_ed
+        self.a_k = a_k
+        self.t_eff_i = t_eff_i
+
+    @staticmethod
+    def _evaluate(
+        t_ed: NMM,
+        a_k: MM2,
+        t_eff_i: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(t_ed=t_ed)
+        raise_if_less_or_equal_to_zero(a_k=a_k, t_eff_i=t_eff_i)
+
+        return t_ed / (2 * a_k * t_eff_i)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.79."""
+        _equation: str = r"\frac{T_{Ed}}{2 \cdot A_k \cdot t_{eff,i}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"T_{Ed}": f"{self.t_ed:.{n}f}",
+                r"A_k": f"{self.a_k:.{n}f}",
+                r"t_{eff,i}": f"{self.t_eff_i:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"T_{Ed}": rf"{self.t_ed:.{n}f} \ Nmm",
+                r"A_k": rf"{self.a_k:.{n}f} \ mm^2",
+                r"t_{eff,i}": rf"{self.t_eff_i:.{n}f} \ mm",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{t,i}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_80.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_80.py
@@ -1,0 +1,88 @@
+"""Formula 8.80 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MPA, N
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot80ShearForceInWallDueToTorsion(Formula):
+    r"""Class representing formula 8.80 for the calculation of the shear force in a wall element due to torsion.
+
+    It turns the torsional shear stress of Formula (8.79) into the shear force acting on the wall, which is what
+    the shear rules of 8.2 need in order to design that wall.
+
+    The standard prints no "where" list under this formula. The symbols come from Formula (8.79) and from
+    Figure 8.16.
+    """
+
+    label = "8.80"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        tau_t_i: MPA,
+        t_eff_i: MM,
+        z_i: MM,
+    ) -> None:
+        r"""[$V_{Ed,i}$] Shear force in wall element [$i$] due to torsion [$N$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.2(3) - Formula (8.80)
+
+        Parameters
+        ----------
+        tau_t_i : MPA
+            [$\tau_{t,i}$] Torsional shear stress in wall [$i$], refer to Formula (8.79) [$MPa$].
+        t_eff_i : MM
+            [$t_{eff,i}$] Effective wall thickness, refer to Formula (8.79) [$mm$].
+        z_i : MM
+            [$z_i$] Side length of wall element [$i$], measured along the centre-line of that wall between the
+            intersections with the centre-lines of the adjacent walls, see Figure 8.16 [$mm$].
+        """
+        super().__init__()
+        self.tau_t_i = tau_t_i
+        self.t_eff_i = t_eff_i
+        self.z_i = z_i
+
+    @staticmethod
+    def _evaluate(
+        tau_t_i: MPA,
+        t_eff_i: MM,
+        z_i: MM,
+    ) -> N:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(tau_t_i=tau_t_i, t_eff_i=t_eff_i, z_i=z_i)
+
+        return tau_t_i * t_eff_i * z_i
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.80."""
+        _equation: str = r"\tau_{t,i} \cdot t_{eff,i} \cdot z_i"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{t,i}": f"{self.tau_t_i:.{n}f}",
+                r"t_{eff,i}": f"{self.t_eff_i:.{n}f}",
+                r"z_i": f"{self.z_i:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{t,i}": rf"{self.tau_t_i:.{n}f} \ MPa",
+                r"t_{eff,i}": rf"{self.t_eff_i:.{n}f} \ mm",
+                r"z_i": rf"{self.z_i:.{n}f} \ mm",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"V_{Ed,i}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="N",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -140,8 +140,8 @@ Total of 602 formulas present.
 |      8.76      | :heavy_check_mark: |         | Form8Dot76ShearStressResistanceAtInterface                         |
 |      8.77      | :heavy_check_mark: |         | Form8Dot77ShearStressResistanceAtInterfaceWithoutYielding          |
 |      8.78      | :heavy_check_mark: |         | Form8Dot78MinimumInterfaceReinforcementAlongEdge                   |
-|      8.79      |        :x:         |         |                                                                    |
-|      8.80      |        :x:         |         |                                                                    |
+|      8.79      | :heavy_check_mark: |         | Form8Dot79TorsionalShearStressInWall                               |
+|      8.80      | :heavy_check_mark: |         | Form8Dot80ShearForceInWallDueToTorsion                             |
 |      8.81      |        :x:         |         |                                                                    |
 |      8.82      |        :x:         |         |                                                                    |
 |      8.83      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_79.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_79.py
@@ -1,0 +1,90 @@
+"""Testing formula 8.79 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_79 import (
+    Form8Dot79TorsionalShearStressInWall,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot79TorsionalShearStressInWall:
+    """Validation for formula 8.79 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        t_ed = 90000000.0
+        a_k = 200000.0
+        t_eff_i = 120.0
+
+        # Object to test
+        formula = Form8Dot79TorsionalShearStressInWall(t_ed=t_ed, a_k=a_k, t_eff_i=t_eff_i)
+
+        # Expected result, manually calculated: 90000000 / (2 * 200000 * 120) = 90000000 / 48000000
+        manually_calculated_result = 1.875  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_with_zero_torsional_moment(self) -> None:
+        """Tests that a section without torsion gives no torsional shear stress."""
+        # Object to test
+        formula = Form8Dot79TorsionalShearStressInWall(t_ed=0.0, a_k=200000.0, t_eff_i=120.0)
+
+        # Expected result, manually calculated: 0 / (2 * 200000 * 120)
+        manually_calculated_result = 0.0  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, abs=1e-9)
+
+    @pytest.mark.parametrize(
+        ("t_ed", "a_k", "t_eff_i"),
+        [
+            (-90000000.0, 200000.0, 120.0),  # t_ed is negative
+            (90000000.0, -200000.0, 120.0),  # a_k is negative
+            (90000000.0, 0.0, 120.0),  # a_k is zero
+            (90000000.0, 200000.0, -120.0),  # t_eff_i is negative
+            (90000000.0, 200000.0, 0.0),  # t_eff_i is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, t_ed: float, a_k: float, t_eff_i: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot79TorsionalShearStressInWall(t_ed=t_ed, a_k=a_k, t_eff_i=t_eff_i)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\tau_{t,i} = \frac{T_{Ed}}{2 \cdot A_k \cdot t_{eff,i}} = "
+                    r"\frac{90000000.000}{2 \cdot 200000.000 \cdot 120.000} = 1.875 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\tau_{t,i} = \frac{T_{Ed}}{2 \cdot A_k \cdot t_{eff,i}} = "
+                    r"\frac{90000000.000 \ Nmm}{2 \cdot 200000.000 \ mm^2 \cdot 120.000 \ mm} = 1.875 \ MPa"
+                ),
+            ),
+            ("short", r"\tau_{t,i} = 1.875 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        t_ed = 90000000.0
+        a_k = 200000.0
+        t_eff_i = 120.0
+
+        # Object to test
+        latex = Form8Dot79TorsionalShearStressInWall(t_ed=t_ed, a_k=a_k, t_eff_i=t_eff_i).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_80.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_80.py
@@ -1,0 +1,75 @@
+"""Testing formula 8.80 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_80 import (
+    Form8Dot80ShearForceInWallDueToTorsion,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot80ShearForceInWallDueToTorsion:
+    """Validation for formula 8.80 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        tau_t_i = 1.875
+        t_eff_i = 120.0
+        z_i = 400.0
+
+        # Object to test
+        formula = Form8Dot80ShearForceInWallDueToTorsion(tau_t_i=tau_t_i, t_eff_i=t_eff_i, z_i=z_i)
+
+        # Expected result, manually calculated: 1.875 * 120 * 400 = 225 * 400
+        manually_calculated_result = 90000.0  # N
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("tau_t_i", "t_eff_i", "z_i"),
+        [
+            (-1.875, 120.0, 400.0),  # tau_t_i is negative
+            (1.875, -120.0, 400.0),  # t_eff_i is negative
+            (1.875, 120.0, -400.0),  # z_i is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, tau_t_i: float, t_eff_i: float, z_i: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot80ShearForceInWallDueToTorsion(tau_t_i=tau_t_i, t_eff_i=t_eff_i, z_i=z_i)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"V_{Ed,i} = \tau_{t,i} \cdot t_{eff,i} \cdot z_i = 1.875 \cdot 120.000 \cdot 400.000 = 90000.000 \ N",
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"V_{Ed,i} = \tau_{t,i} \cdot t_{eff,i} \cdot z_i = "
+                    r"1.875 \ MPa \cdot 120.000 \ mm \cdot 400.000 \ mm = 90000.000 \ N"
+                ),
+            ),
+            ("short", r"V_{Ed,i} = 90000.000 \ N"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        tau_t_i = 1.875
+        t_eff_i = 120.0
+        z_i = 400.0
+
+        # Object to test
+        latex = Form8Dot80ShearForceInWallDueToTorsion(tau_t_i=tau_t_i, t_eff_i=t_eff_i, z_i=z_i).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
Adds formulas (8.79) and (8.80) of FprEN 1992-1-1:2023 clause 8.3.2, "Internal forces due to torsion in compact or closed sections". These are the first two formulas of 8.3 on torsion and combined actions.

(8.79) gives the torsional shear stress in a wall element of a section subject to a torsional moment. (8.80) turns that stress into the shear force acting on the wall, which is what the shear rules of 8.2 need in order to design that wall.

Decisions a reviewer has to weigh:

- `T_Ed` is not listed in the "where" block of 8.3.2(2); the standard introduces it in the sentence above the formula. It is guarded with `raise_if_negative`, so the caller passes the magnitude of the torsional moment. The standard does not restrict its sign, and a negative value would return a negative stress.
- `z_i` of (8.80) is defined nowhere in text. The standard prints no "where" block under (8.80) and the symbol appears only in Figure 8.16, drawn along the centre-line of a wall. The parameter docstring says so explicitly rather than presenting the reading as if the standard stated it.
- (8.80) is printed with implicit multiplication, and (8.79) prints `2A_k`. The LaTeX uses `\cdot` in both places, matching every other formula in this repository.
- `t_eff,i` and `z_i` in (8.80) are guarded with `raise_if_negative` rather than `raise_if_less_or_equal_to_zero`: neither is a denominator, and a zero simply returns a zero force.

## Formulas as implemented

**Formula (8.79)**, `Form8Dot79TorsionalShearStressInWall`

`equation`

$$
\tau_{t,i} = \frac{T_{Ed}}{2 \cdot A_k \cdot t_{eff,i}}
$$

`complete`

$$
\tau_{t,i} = \frac{T_{Ed}}{2 \cdot A_k \cdot t_{eff,i}} = \frac{90000000.000}{2 \cdot 200000.000 \cdot 120.000} = 1.875 \ MPa
$$

`complete_with_units`

$$
\tau_{t,i} = \frac{T_{Ed}}{2 \cdot A_k \cdot t_{eff,i}} = \frac{90000000.000 \ Nmm}{2 \cdot 200000.000 \ mm^2 \cdot 120.000 \ mm} = 1.875 \ MPa
$$

**Formula (8.80)**, `Form8Dot80ShearForceInWallDueToTorsion`

`equation`

$$
V_{Ed,i} = \tau_{t,i} \cdot t_{eff,i} \cdot z_i
$$

`complete`

$$
V_{Ed,i} = \tau_{t,i} \cdot t_{eff,i} \cdot z_i = 1.875 \cdot 120.000 \cdot 400.000 = 90000.000 \ N
$$

`complete_with_units`

$$
V_{Ed,i} = \tau_{t,i} \cdot t_{eff,i} \cdot z_i = 1.875 \ MPa \cdot 120.000 \ mm \cdot 400.000 \ mm = 90000.000 \ N
$$

Contributes to #1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added calculations for torsional shear stress and torsional shear force in wall elements.
  - Added symbolic and numeric formula representations, including units and configurable precision.
  - Added validation for invalid physical input values.

- **Documentation**
  - Updated implementation status for Formulas 8.79 and 8.80.

- **Tests**
  - Added coverage for calculations, boundary cases, invalid inputs, and LaTeX output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->