### PR TITLE
feat: add formulas 8.81 to 8.85 from FprEN 1992-1-1:2023 clause 8.3.4

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_81.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_81.py
@@ -62,7 +62,10 @@ class Form8Dot81DesignTorsionalCapacity(Formula):
 
     def latex(self, n: int = 3) -> LatexFormula:
         """Returns LatexFormula object for formula 8.81."""
-        _equation: str = r"\min\left\{\tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max}\right\}"
+        # \lbrace and \rbrace rather than \{ and \}: they render identically, but a backslash in front of a
+        # brace is eaten by the Markdown parser before the maths is rendered, which breaks the equation on
+        # GitHub. Seen on the pull request for this clause.
+        _equation: str = r"\min\left\lbrace \tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max} \right\rbrace"
         _numeric_equation: str = latex_replace_symbols(
             template=_equation,
             replacements={

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_81.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_81.py
@@ -1,0 +1,92 @@
+"""Formula 8.81 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MPA
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot81DesignTorsionalCapacity(Formula):
+    r"""Class representing formula 8.81 for the design torsional capacity of a single cell, thin-walled section
+    or a sub-section with constant effective wall thickness.
+
+    The three candidates are the resistances of Formulas (8.82), (8.83) and (8.84), which are yielding of the
+    shear reinforcement, yielding of the longitudinal reinforcement, and crushing of the compression field in
+    concrete. Whichever gives way first governs, so the standard takes the smallest.
+
+    The standard determines the three on the basis of Annex G, and says the capacity according to this formula
+    should be used when combinations of internal forces are verified according to 8.3.6.
+    """
+
+    label = "8.81"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        tau_t_rd_sw: MPA,
+        tau_t_rd_sl: MPA,
+        tau_t_rd_max: MPA,
+    ) -> None:
+        r"""[$\tau_{t,Rd}$] Design torsional capacity [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.4(1) - Formula (8.81)
+
+        Parameters
+        ----------
+        tau_t_rd_sw : MPA
+            [$\tau_{t,Rd,sw}$] Torsional stress resistance governed by yielding of the shear reinforcement,
+            refer to Formula (8.82) [$MPa$].
+        tau_t_rd_sl : MPA
+            [$\tau_{t,Rd,sl}$] Torsional stress resistance governed by yielding of the longitudinal
+            reinforcement, refer to Formula (8.83) [$MPa$].
+        tau_t_rd_max : MPA
+            [$\tau_{t,Rd,max}$] Torsional stress resistance governed by crushing of the compression field in
+            concrete, refer to Formula (8.84) [$MPa$].
+        """
+        super().__init__()
+        self.tau_t_rd_sw = tau_t_rd_sw
+        self.tau_t_rd_sl = tau_t_rd_sl
+        self.tau_t_rd_max = tau_t_rd_max
+
+    @staticmethod
+    def _evaluate(
+        tau_t_rd_sw: MPA,
+        tau_t_rd_sl: MPA,
+        tau_t_rd_max: MPA,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(tau_t_rd_sw=tau_t_rd_sw, tau_t_rd_sl=tau_t_rd_sl, tau_t_rd_max=tau_t_rd_max)
+
+        return min(tau_t_rd_sw, tau_t_rd_sl, tau_t_rd_max)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.81."""
+        _equation: str = r"\min\left\{\tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max}\right\}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{t,Rd,sw}": f"{self.tau_t_rd_sw:.{n}f}",
+                r"\tau_{t,Rd,sl}": f"{self.tau_t_rd_sl:.{n}f}",
+                r"\tau_{t,Rd,max}": f"{self.tau_t_rd_max:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{t,Rd,sw}": rf"{self.tau_t_rd_sw:.{n}f} \ MPa",
+                r"\tau_{t,Rd,sl}": rf"{self.tau_t_rd_sl:.{n}f} \ MPa",
+                r"\tau_{t,Rd,max}": rf"{self.tau_t_rd_max:.{n}f} \ MPa",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{t,Rd}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_82.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_82.py
@@ -1,0 +1,108 @@
+"""Formula 8.82 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG, MM, MM2, MPA
+from blueprints.utils.math_helpers import cot
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot82TorsionalStressResistanceShearReinforcement(Formula):
+    r"""Class representing formula 8.82 for the torsional capacity when governed by yielding of the shear
+    reinforcement.
+
+    It is one of the three resistances that Formula (8.81) takes the minimum of, together with Formulas (8.83)
+    and (8.84). It applies to a single cell, thin-walled section or a sub-section with constant effective wall
+    thickness.
+
+    The result is a shear stress, not a torsional moment. Formula (8.79) converts between the two.
+    """
+
+    label = "8.82"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        theta: DEG,
+        a_sw: MM2,
+        t_eff: MM,
+        s: MM,
+        f_ywd: MPA,
+    ) -> None:
+        r"""[$\tau_{t,Rd,sw}$] Torsional capacity when governed by yielding of the shear reinforcement [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.4(2) - Formula (8.82)
+
+        Parameters
+        ----------
+        theta : DEG
+            [$\theta$] Angle of compression field with respect to the longitudinal axis. Its range is restricted
+            by Formula (8.85), which needs [$\cot\theta_{min}$] of 8.2.3(4) and is therefore not enforced here
+            [$degrees$].
+        a_sw : MM2
+            [$A_{sw}$] Cross-sectional area of the shear reinforcement within the effective wall thickness in
+            Figure 8.16 [$mm^2$].
+        t_eff : MM
+            [$t_{eff}$] Constant effective wall thickness of the single cell, thin-walled section or sub-section,
+            refer to 8.3.4(1) and to the definition of [$t_{eff,i}$] in 8.3.2(2) [$mm$].
+        s : MM
+            [$s$] Spacing (in the longitudinal direction) between the shear reinforcement [$A_{sw}$] [$mm$].
+        f_ywd : MPA
+            [$f_{ywd}$] Design yield stress of the shear reinforcement [$MPa$].
+        """
+        super().__init__()
+        self.theta = theta
+        self.a_sw = a_sw
+        self.t_eff = t_eff
+        self.s = s
+        self.f_ywd = f_ywd
+
+    @staticmethod
+    def _evaluate(
+        theta: DEG,
+        a_sw: MM2,
+        t_eff: MM,
+        s: MM,
+        f_ywd: MPA,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_sw=a_sw, f_ywd=f_ywd)
+        raise_if_less_or_equal_to_zero(theta=theta, t_eff=t_eff, s=s)
+
+        return cot(theta) * a_sw / (t_eff * s) * f_ywd
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.82."""
+        _equation: str = r"\cot(\theta) \cdot \frac{A_{sw}}{t_{eff} \cdot s} \cdot f_{ywd}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\theta": f"{self.theta:.{n}f}",
+                r"A_{sw}": f"{self.a_sw:.{n}f}",
+                r"t_{eff}": f"{self.t_eff:.{n}f}",
+                r"\cdot s}": f"\\cdot {self.s:.{n}f}}}",
+                r"f_{ywd}": f"{self.f_ywd:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\theta": rf"{self.theta:.{n}f} ^\circ",
+                r"A_{sw}": rf"{self.a_sw:.{n}f} \ mm^2",
+                r"t_{eff}": rf"{self.t_eff:.{n}f} \ mm",
+                r"\cdot s}": rf"\cdot {self.s:.{n}f} \ mm}}",
+                r"f_{ywd}": rf"{self.f_ywd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{t,Rd,sw}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_83.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_83.py
@@ -1,0 +1,116 @@
+"""Formula 8.83 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG, MM, MM2, MPA
+from blueprints.utils.math_helpers import cot
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot83TorsionalStressResistanceLongitudinalReinforcement(Formula):
+    r"""Class representing formula 8.83 for the torsional capacity when governed by yielding of the longitudinal
+    reinforcement.
+
+    It is one of the three resistances that Formula (8.81) takes the minimum of, together with Formulas (8.82)
+    and (8.84). It applies to a single cell, thin-walled section or a sub-section with constant effective wall
+    thickness.
+
+    The standard prints the numerator as the single quantity [$\Sigma A_{sl} f_{yd}$], the yield force of the
+    longitudinal reinforcement. This class takes the area and the stress separately, which mirrors Formula
+    (8.82) and lets the unit representation expose a mismatch. The two are equal only when every bar counted
+    carries the same [$f_{yd}$]; for mixed steel grades, pass the area that gives the correct yield force.
+    """
+
+    label = "8.83"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        sum_a_sl: MM2,
+        f_yd: MPA,
+        t_eff: MM,
+        u_k: MM,
+        theta: DEG,
+    ) -> None:
+        r"""[$\tau_{t,Rd,sl}$] Torsional capacity when governed by yielding of the longitudinal reinforcement
+        [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.4(2) - Formula (8.83)
+
+        Parameters
+        ----------
+        sum_a_sl : MM2
+            [$\Sigma A_{sl}$] Sum of the areas of the longitudinal reinforcement that may be included in the
+            calculation of the torsional capacity. The amount of longitudinal reinforcement considered in Formula
+            (8.83) should have a resultant tensile force that acts at the centroid of the equivalent thin-walled
+            closed cross-section. The reinforcement should generally be distributed according to 12.3.3(9)
+            [$mm^2$].
+        f_yd : MPA
+            [$f_{yd}$] Design yield stress of the longitudinal reinforcement [$A_{sl}$] [$MPa$].
+        t_eff : MM
+            [$t_{eff}$] Constant effective wall thickness of the single cell, thin-walled section or sub-section,
+            refer to 8.3.4(1) and to the definition of [$t_{eff,i}$] in 8.3.2(2) [$mm$].
+        u_k : MM
+            [$u_k$] Perimeter of the area [$A_k$] [$mm$].
+        theta : DEG
+            [$\theta$] Angle of compression field with respect to the longitudinal axis. It sits in the
+            denominator through [$\cot\theta$], so the result grows without bound as the angle approaches 90
+            degrees. Formula (8.85) keeps it well away from there, but needs [$\cot\theta_{min}$] of 8.2.3(4)
+            and is therefore not enforced here [$degrees$].
+        """
+        super().__init__()
+        self.sum_a_sl = sum_a_sl
+        self.f_yd = f_yd
+        self.t_eff = t_eff
+        self.u_k = u_k
+        self.theta = theta
+
+    @staticmethod
+    def _evaluate(
+        sum_a_sl: MM2,
+        f_yd: MPA,
+        t_eff: MM,
+        u_k: MM,
+        theta: DEG,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(sum_a_sl=sum_a_sl, f_yd=f_yd)
+        raise_if_less_or_equal_to_zero(t_eff=t_eff, u_k=u_k, theta=theta)
+
+        return sum_a_sl * f_yd / (t_eff * u_k * cot(theta))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.83."""
+        _equation: str = r"\frac{\Sigma A_{sl} \cdot f_{yd}}{t_{eff} \cdot u_k \cdot \cot(\theta)}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Sigma A_{sl}": f"{self.sum_a_sl:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+                r"t_{eff}": f"{self.t_eff:.{n}f}",
+                r"u_k": f"{self.u_k:.{n}f}",
+                r"\theta": f"{self.theta:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Sigma A_{sl}": rf"{self.sum_a_sl:.{n}f} \ mm^2",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+                r"t_{eff}": rf"{self.t_eff:.{n}f} \ mm",
+                r"u_k": rf"{self.u_k:.{n}f} \ mm",
+                r"\theta": rf"{self.theta:.{n}f} ^\circ",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{t,Rd,sl}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_84.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_84.py
@@ -1,0 +1,98 @@
+"""Formula 8.84 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG, DIMENSIONLESS, MPA
+from blueprints.utils.math_helpers import cot
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot84TorsionalStressResistanceConcreteCrushing(Formula):
+    r"""Class representing formula 8.84 for the torsional strength when governed by crushing of the compression
+    field in concrete.
+
+    It is one of the three resistances that Formula (8.81) takes the minimum of, together with Formulas (8.82)
+    and (8.83). It applies to a single cell, thin-walled section or a sub-section with constant effective wall
+    thickness.
+
+    Unlike the other two, this one does not depend on the reinforcement, and 8.3.1(3) uses it to distribute the
+    acting torsional moment over the sub-sections of a complex shape.
+    """
+
+    label = "8.84"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        nu: DIMENSIONLESS,
+        f_cd: MPA,
+        theta: DEG,
+    ) -> None:
+        r"""[$\tau_{t,Rd,max}$] Torsional strength when governed by crushing of the compression field in concrete
+        [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.4(3) - Formula (8.84)
+
+        Parameters
+        ----------
+        nu : DIMENSIONLESS
+            [$\nu$] Strength reduction factor for concrete cracked in shear. It may be determined by the formulae
+            in Annex G. A value of [$\nu = 0,60$] may be used when [$\cot\theta = 1,0$]. Neither Annex G nor that
+            pairing is enforced here, so the choice stays with the caller [$-$].
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        theta : DEG
+            [$\theta$] Angle of compression field with respect to the longitudinal axis. Its range is restricted
+            by Formula (8.85), which needs [$\cot\theta_{min}$] of 8.2.3(4) and is therefore not enforced here
+            [$degrees$].
+        """
+        super().__init__()
+        self.nu = nu
+        self.f_cd = f_cd
+        self.theta = theta
+
+    @staticmethod
+    def _evaluate(
+        nu: DIMENSIONLESS,
+        f_cd: MPA,
+        theta: DEG,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(nu=nu, f_cd=f_cd)
+        raise_if_less_or_equal_to_zero(theta=theta)
+
+        return nu * f_cd / (cot(theta) + np.tan(np.deg2rad(theta)))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.84."""
+        _equation: str = r"\frac{\nu \cdot f_{cd}}{\cot(\theta) + \tan(\theta)}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\nu": f"{self.nu:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+                r"\theta": f"{self.theta:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\nu": f"{self.nu:.{n}f}",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+                r"\theta": rf"{self.theta:.{n}f} ^\circ",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{t,Rd,max}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_85.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_85.py
@@ -1,0 +1,201 @@
+"""Formula 8.85 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import operator
+from collections.abc import Callable, Sequence
+from typing import Self
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import AggregatedComparisonFormula, ComparisonFormula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG
+from blueprints.utils.math_helpers import cot
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class SubForm8Dot85LowerBound(ComparisonFormula):
+    r"""Class representing the lower bound of formula 8.85, [$1 / \cot\theta_{min} \leq \cot\theta$]."""
+
+    label = "8.85"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, theta: DEG, theta_min: DEG) -> None:
+        r"""Check the selected inclination of the compression field against its lower bound.
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.4(4) - Formula (8.85)
+
+        Parameters
+        ----------
+        theta : DEG
+            [$\theta$] Selected inclination of the compression field [$degrees$].
+        theta_min : DEG
+            [$\theta_{min}$] Minimal inclination of the compression field according to 8.2.3(4) [$degrees$].
+        """
+        super().__init__()
+        self.theta = theta
+        self.theta_min = theta_min
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(theta_min: DEG, *_args, **_kwargs) -> float:
+        """Evaluates the lower bound, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(theta_min=theta_min)
+
+        return float(1 / cot(theta_min))
+
+    @staticmethod
+    def _evaluate_rhs(theta: DEG, *_args, **_kwargs) -> float:
+        """Evaluates the value under check, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(theta=theta)
+
+        return float(cot(theta))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for the lower bound of formula 8.85."""
+        _equation: str = r"\frac{1}{\cot(\theta_{min})} \leq \cot(\theta)"
+        _replacements = {r"\theta_{min}": f"{self.theta_min:.{n}f}", r"\theta": f"{self.theta:.{n}f}"}
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=latex_replace_symbols(template=_equation, replacements=_replacements, unique_symbol_check=False),
+            comparison_operator_label=r"\to",
+            unit="",
+        )
+
+
+class SubForm8Dot85UpperBound(ComparisonFormula):
+    r"""Class representing the upper bound of formula 8.85, [$\cot\theta \leq \cot\theta_{min}$]."""
+
+    label = "8.85"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, theta: DEG, theta_min: DEG) -> None:
+        r"""Check the selected inclination of the compression field against its upper bound.
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.4(4) - Formula (8.85)
+
+        Parameters
+        ----------
+        theta : DEG
+            [$\theta$] Selected inclination of the compression field [$degrees$].
+        theta_min : DEG
+            [$\theta_{min}$] Minimal inclination of the compression field according to 8.2.3(4) [$degrees$].
+        """
+        super().__init__()
+        self.theta = theta
+        self.theta_min = theta_min
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(theta: DEG, *_args, **_kwargs) -> float:
+        """Evaluates the value under check, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(theta=theta)
+
+        return float(cot(theta))
+
+    @staticmethod
+    def _evaluate_rhs(theta_min: DEG, *_args, **_kwargs) -> float:
+        """Evaluates the upper bound, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(theta_min=theta_min)
+
+        return float(cot(theta_min))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for the upper bound of formula 8.85."""
+        _equation: str = r"\cot(\theta) \leq \cot(\theta_{min})"
+        _replacements = {r"\theta_{min}": f"{self.theta_min:.{n}f}", r"\theta": f"{self.theta:.{n}f}"}
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=latex_replace_symbols(template=_equation, replacements=_replacements, unique_symbol_check=False),
+            comparison_operator_label=r"\to",
+            unit="",
+        )
+
+
+class Form8Dot85CheckCotangentCompressionFieldTorsion(AggregatedComparisonFormula):
+    r"""Class representing formula 8.85 for the check of the cotangent of the inclination of the compression
+    field used in the torsional resistances of Formulas (8.82) to (8.84).
+
+    It is not the same range as Formula (8.41), even though both are bounded above by
+    [$\cot\theta_{min}$] of 8.2.3(4). The lower bound here is [$1 / \cot\theta_{min}$] instead of the constant
+    1, so torsion permits a flatter compression field than shear does, symmetric in [$\cot\theta$] about 1.
+
+    The printed range is one relation, but it is modelled as two comparisons joined with ``all`` so that each
+    bound carries its own unity check. Those two are available through ``comparison_formulas``, and
+    ``unity_check`` on this class is the larger of the two, so it exceeds 1 as soon as either bound is violated.
+    """
+
+    label = "8.85"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, theta: DEG, theta_min: DEG) -> None:
+        r"""Check whether the selected inclination of the compression field lies within the range the standard
+        gives for usual cases of torsion.
+
+        FprEN 1992-1-1:2023 (E) art. 8.3.4(4) - Formula (8.85)
+
+        The standard lets the designer select the inclination, so this is a verification of that choice and not
+        a value to be calculated. Both bounds are inclusive as printed, and the standard phrases the range as a
+        recommendation for usual cases, so it is a check and not a hard limit inside Formulas (8.82) to (8.84).
+
+        Parameters
+        ----------
+        theta : DEG
+            [$\theta$] Selected inclination of the compression field, used in Formulas (8.82) to (8.84)
+            [$degrees$].
+        theta_min : DEG
+            [$\theta_{min}$] Minimal inclination of the compression field according to 8.2.3(4). None of the
+            rules that give it carries a formula number, so it is an input here [$degrees$].
+        """
+        super().__init__(aggregation=all, comparison_formulas=self._bounds(theta, theta_min))
+        self.theta = theta
+        self.theta_min = theta_min
+
+    @staticmethod
+    def _bounds(theta: DEG, theta_min: DEG) -> Sequence[ComparisonFormula]:
+        """Builds the two halves of the printed range."""
+        return (
+            SubForm8Dot85LowerBound(theta=theta, theta_min=theta_min),
+            SubForm8Dot85UpperBound(theta=theta, theta_min=theta_min),
+        )
+
+    def __new__(cls, theta: DEG, theta_min: DEG) -> Self:
+        """Translates the arguments of this formula into the aggregation the base class evaluates."""
+        return super().__new__(cls, aggregation=all, comparison_formulas=cls._bounds(theta, theta_min))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.85."""
+        _equation: str = r"\frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \leq \cot(\theta_{min})"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\theta_{min}": f"{self.theta_min:.{n}f}",
+                r"\theta": f"{self.theta:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\theta_{min}": rf"{self.theta_min:.{n}f} ^\circ",
+                r"\theta": rf"{self.theta:.{n}f} ^\circ",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label=r"\to",
+            unit="",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -142,11 +142,11 @@ Total of 602 formulas present.
 |      8.78      | :heavy_check_mark: |         | Form8Dot78MinimumInterfaceReinforcementAlongEdge                   |
 |      8.79      |        :x:         |         |                                                                    |
 |      8.80      |        :x:         |         |                                                                    |
-|      8.81      |        :x:         |         |                                                                    |
+|      8.81      | :heavy_check_mark: |         | Form8Dot81DesignTorsionalCapacity                                  |
 |      8.82      | :heavy_check_mark: |         | Form8Dot82TorsionalStressResistanceShearReinforcement              |
 |      8.83      | :heavy_check_mark: |         | Form8Dot83TorsionalStressResistanceLongitudinalReinforcement       |
 |      8.84      | :heavy_check_mark: |         | Form8Dot84TorsionalStressResistanceConcreteCrushing                |
-|      8.85      |        :x:         |         |                                                                    |
+|      8.85      | :heavy_check_mark: |         | Form8Dot85CheckCotangentCompressionFieldTorsion                    |
 |      8.86      |        :x:         |         |                                                                    |
 |      8.87      |        :x:         |         |                                                                    |
 |      8.88      |        :x:         |         |                                                                    |

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -143,9 +143,9 @@ Total of 602 formulas present.
 |      8.79      |        :x:         |         |                                                                    |
 |      8.80      |        :x:         |         |                                                                    |
 |      8.81      |        :x:         |         |                                                                    |
-|      8.82      |        :x:         |         |                                                                    |
-|      8.83      |        :x:         |         |                                                                    |
-|      8.84      |        :x:         |         |                                                                    |
+|      8.82      | :heavy_check_mark: |         | Form8Dot82TorsionalStressResistanceShearReinforcement              |
+|      8.83      | :heavy_check_mark: |         | Form8Dot83TorsionalStressResistanceLongitudinalReinforcement       |
+|      8.84      | :heavy_check_mark: |         | Form8Dot84TorsionalStressResistanceConcreteCrushing                |
 |      8.85      |        :x:         |         |                                                                    |
 |      8.86      |        :x:         |         |                                                                    |
 |      8.87      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_81.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_81.py
@@ -47,15 +47,15 @@ class TestForm8Dot81DesignTorsionalCapacity:
             (
                 "complete",
                 (
-                    r"\tau_{t,Rd} = \min\left\{\tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max}\right\} = "
-                    r"\min\left\{3.625; 2.900; 4.000\right\} = 2.900 \ MPa"
+                    r"\tau_{t,Rd} = \min\left\lbrace \tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max} \right\rbrace = "
+                    r"\min\left\lbrace 3.625; 2.900; 4.000 \right\rbrace = 2.900 \ MPa"
                 ),
             ),
             (
                 "complete_with_units",
                 (
-                    r"\tau_{t,Rd} = \min\left\{\tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max}\right\} = "
-                    r"\min\left\{3.625 \ MPa; 2.900 \ MPa; 4.000 \ MPa\right\} = 2.900 \ MPa"
+                    r"\tau_{t,Rd} = \min\left\lbrace \tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max} \right\rbrace = "
+                    r"\min\left\lbrace 3.625 \ MPa; 2.900 \ MPa; 4.000 \ MPa \right\rbrace = 2.900 \ MPa"
                 ),
             ),
             ("short", r"\tau_{t,Rd} = 2.900 \ MPa"),

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_81.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_81.py
@@ -1,0 +1,75 @@
+"""Testing formula 8.81 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_81 import (
+    Form8Dot81DesignTorsionalCapacity,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot81DesignTorsionalCapacity:
+    """Validation for formula 8.81 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("tau_t_rd_sw", "tau_t_rd_sl", "tau_t_rd_max", "expected"),
+        [
+            # The three values of the worked examples of Formulas (8.82), (8.83) and (8.84)
+            (3.625, 2.9, 4.0, 2.9),  # the longitudinal reinforcement governs
+            (2.5, 2.9, 4.0, 2.5),  # the shear reinforcement governs
+            (3.625, 2.9, 1.5, 1.5),  # crushing of the compression field governs
+            (2.9, 2.9, 2.9, 2.9),  # all three coincide
+        ],
+    )
+    def test_evaluation(self, tau_t_rd_sw: float, tau_t_rd_sl: float, tau_t_rd_max: float, expected: float) -> None:
+        """Tests that each of the three candidates governs when it is the smallest."""
+        # Object to test
+        formula = Form8Dot81DesignTorsionalCapacity(tau_t_rd_sw=tau_t_rd_sw, tau_t_rd_sl=tau_t_rd_sl, tau_t_rd_max=tau_t_rd_max)
+
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("tau_t_rd_sw", "tau_t_rd_sl", "tau_t_rd_max"),
+        [
+            (-3.625, 2.9, 4.0),  # tau_t_rd_sw is negative
+            (3.625, -2.9, 4.0),  # tau_t_rd_sl is negative
+            (3.625, 2.9, -4.0),  # tau_t_rd_max is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, tau_t_rd_sw: float, tau_t_rd_sl: float, tau_t_rd_max: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot81DesignTorsionalCapacity(tau_t_rd_sw=tau_t_rd_sw, tau_t_rd_sl=tau_t_rd_sl, tau_t_rd_max=tau_t_rd_max)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\tau_{t,Rd} = \min\left\{\tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max}\right\} = "
+                    r"\min\left\{3.625; 2.900; 4.000\right\} = 2.900 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\tau_{t,Rd} = \min\left\{\tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max}\right\} = "
+                    r"\min\left\{3.625 \ MPa; 2.900 \ MPa; 4.000 \ MPa\right\} = 2.900 \ MPa"
+                ),
+            ),
+            ("short", r"\tau_{t,Rd} = 2.900 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot81DesignTorsionalCapacity(tau_t_rd_sw=3.625, tau_t_rd_sl=2.9, tau_t_rd_max=4.0).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_82.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_82.py
@@ -1,0 +1,93 @@
+"""Testing formula 8.82 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_82 import (
+    Form8Dot82TorsionalStressResistanceShearReinforcement,
+)
+from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError, NegativeValueError
+
+# Angle chosen so that its cotangent is a round number, which keeps the hand calculation readable
+THETA_COT_2 = 26.565051177078  # cot(theta) = 2
+
+
+class TestForm8Dot82TorsionalStressResistanceShearReinforcement:
+    """Validation for formula 8.82 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_sw = 100.0
+        t_eff = 120.0
+        s = 200.0
+        f_ywd = 435.0
+
+        # Object to test
+        formula = Form8Dot82TorsionalStressResistanceShearReinforcement(theta=THETA_COT_2, a_sw=a_sw, t_eff=t_eff, s=s, f_ywd=f_ywd)
+
+        # Expected result, manually calculated: 2 * 100 / (120 * 200) * 435 = 2 * 100 / 24000 * 435
+        manually_calculated_result = 3.625  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("theta", "a_sw", "t_eff", "s", "f_ywd"),
+        [
+            (THETA_COT_2, -100.0, 120.0, 200.0, 435.0),  # a_sw is negative
+            (THETA_COT_2, 100.0, 120.0, 200.0, -435.0),  # f_ywd is negative
+            (-THETA_COT_2, 100.0, 120.0, 200.0, 435.0),  # theta is negative
+            (0.0, 100.0, 120.0, 200.0, 435.0),  # theta is zero, for which the cotangent diverges
+            (THETA_COT_2, 100.0, -120.0, 200.0, 435.0),  # t_eff is negative
+            (THETA_COT_2, 100.0, 0.0, 200.0, 435.0),  # t_eff is zero
+            (THETA_COT_2, 100.0, 120.0, -200.0, 435.0),  # s is negative
+            (THETA_COT_2, 100.0, 120.0, 0.0, 435.0),  # s is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, theta: float, a_sw: float, t_eff: float, s: float, f_ywd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot82TorsionalStressResistanceShearReinforcement(theta=theta, a_sw=a_sw, t_eff=t_eff, s=s, f_ywd=f_ywd)
+
+    def test_raise_error_when_theta_exceeds_90_degrees(self) -> None:
+        """Test an angle beyond the range of the cotangent."""
+        with pytest.raises(GreaterThan90Error):
+            Form8Dot82TorsionalStressResistanceShearReinforcement(theta=120.0, a_sw=100.0, t_eff=120.0, s=200.0, f_ywd=435.0)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\tau_{t,Rd,sw} = \cot(\theta) \cdot \frac{A_{sw}}{t_{eff} \cdot s} \cdot f_{ywd} = "
+                    r"\cot(26.565) \cdot \frac{100.000}{120.000 \cdot 200.000} \cdot 435.000 = 3.625 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\tau_{t,Rd,sw} = \cot(\theta) \cdot \frac{A_{sw}}{t_{eff} \cdot s} \cdot f_{ywd} = "
+                    r"\cot(26.565 ^\circ) \cdot \frac{100.000 \ mm^2}{120.000 \ mm \cdot 200.000 \ mm} \cdot 435.000 \ MPa = 3.625 \ MPa"
+                ),
+            ),
+            ("short", r"\tau_{t,Rd,sw} = 3.625 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot82TorsionalStressResistanceShearReinforcement(
+            theta=THETA_COT_2,
+            a_sw=100.0,
+            t_eff=120.0,
+            s=200.0,
+            f_ywd=435.0,
+        ).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_83.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_83.py
@@ -1,0 +1,93 @@
+"""Testing formula 8.83 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_83 import (
+    Form8Dot83TorsionalStressResistanceLongitudinalReinforcement,
+)
+from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError, NegativeValueError
+
+# Angle chosen so that its cotangent is a round number, which keeps the hand calculation readable
+THETA_COT_2 = 26.565051177078  # cot(theta) = 2
+
+
+class TestForm8Dot83TorsionalStressResistanceLongitudinalReinforcement:
+    """Validation for formula 8.83 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        sum_a_sl = 2400.0
+        f_yd = 435.0
+        t_eff = 120.0
+        u_k = 1500.0
+
+        # Object to test
+        formula = Form8Dot83TorsionalStressResistanceLongitudinalReinforcement(sum_a_sl=sum_a_sl, f_yd=f_yd, t_eff=t_eff, u_k=u_k, theta=THETA_COT_2)
+
+        # Expected result, manually calculated: 2400 * 435 / (120 * 1500 * 2) = 1044000 / 360000
+        manually_calculated_result = 2.9  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("sum_a_sl", "f_yd", "t_eff", "u_k", "theta"),
+        [
+            (-2400.0, 435.0, 120.0, 1500.0, THETA_COT_2),  # sum_a_sl is negative
+            (2400.0, -435.0, 120.0, 1500.0, THETA_COT_2),  # f_yd is negative
+            (2400.0, 435.0, -120.0, 1500.0, THETA_COT_2),  # t_eff is negative
+            (2400.0, 435.0, 0.0, 1500.0, THETA_COT_2),  # t_eff is zero
+            (2400.0, 435.0, 120.0, -1500.0, THETA_COT_2),  # u_k is negative
+            (2400.0, 435.0, 120.0, 0.0, THETA_COT_2),  # u_k is zero
+            (2400.0, 435.0, 120.0, 1500.0, -THETA_COT_2),  # theta is negative
+            (2400.0, 435.0, 120.0, 1500.0, 0.0),  # theta is zero, for which the cotangent diverges
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, sum_a_sl: float, f_yd: float, t_eff: float, u_k: float, theta: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot83TorsionalStressResistanceLongitudinalReinforcement(sum_a_sl=sum_a_sl, f_yd=f_yd, t_eff=t_eff, u_k=u_k, theta=theta)
+
+    def test_raise_error_when_theta_exceeds_90_degrees(self) -> None:
+        """Test an angle beyond the range of the cotangent."""
+        with pytest.raises(GreaterThan90Error):
+            Form8Dot83TorsionalStressResistanceLongitudinalReinforcement(sum_a_sl=2400.0, f_yd=435.0, t_eff=120.0, u_k=1500.0, theta=120.0)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\tau_{t,Rd,sl} = \frac{\Sigma A_{sl} \cdot f_{yd}}{t_{eff} \cdot u_k \cdot \cot(\theta)} = "
+                    r"\frac{2400.000 \cdot 435.000}{120.000 \cdot 1500.000 \cdot \cot(26.565)} = 2.900 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\tau_{t,Rd,sl} = \frac{\Sigma A_{sl} \cdot f_{yd}}{t_{eff} \cdot u_k \cdot \cot(\theta)} = "
+                    r"\frac{2400.000 \ mm^2 \cdot 435.000 \ MPa}{120.000 \ mm \cdot 1500.000 \ mm \cdot \cot(26.565 ^\circ)} = 2.900 \ MPa"
+                ),
+            ),
+            ("short", r"\tau_{t,Rd,sl} = 2.900 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot83TorsionalStressResistanceLongitudinalReinforcement(
+            sum_a_sl=2400.0,
+            f_yd=435.0,
+            t_eff=120.0,
+            u_k=1500.0,
+            theta=THETA_COT_2,
+        ).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_84.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_84.py
@@ -1,0 +1,93 @@
+"""Testing formula 8.84 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_84 import (
+    Form8Dot84TorsionalStressResistanceConcreteCrushing,
+)
+from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError, NegativeValueError
+
+# Angle chosen so that its cotangent and tangent are round numbers, which keeps the hand calculation readable
+THETA_COT_2 = 26.565051177078  # cot(theta) = 2, tan(theta) = 0.5
+
+
+class TestForm8Dot84TorsionalStressResistanceConcreteCrushing:
+    """Validation for formula 8.84 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        nu = 0.5
+        f_cd = 20.0
+
+        # Object to test
+        formula = Form8Dot84TorsionalStressResistanceConcreteCrushing(nu=nu, f_cd=f_cd, theta=THETA_COT_2)
+
+        # Expected result, manually calculated: 0.5 * 20 / (2 + 0.5) = 10 / 2.5
+        manually_calculated_result = 4.0  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_at_45_degrees(self) -> None:
+        """Tests a second angle, since a single one cannot distinguish the sum of the two functions from a
+        multiple of one of them. At 45 degrees the denominator is 1 + 1 and the resistance is at its maximum.
+        """
+        # Object to test
+        formula = Form8Dot84TorsionalStressResistanceConcreteCrushing(nu=0.5, f_cd=20.0, theta=45.0)
+
+        # Expected result, manually calculated: 0.5 * 20 / (1 + 1) = 10 / 2
+        manually_calculated_result = 5.0  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("nu", "f_cd", "theta"),
+        [
+            (-0.5, 20.0, THETA_COT_2),  # nu is negative
+            (0.5, -20.0, THETA_COT_2),  # f_cd is negative
+            (0.5, 20.0, -THETA_COT_2),  # theta is negative
+            (0.5, 20.0, 0.0),  # theta is zero, for which the cotangent diverges
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, nu: float, f_cd: float, theta: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot84TorsionalStressResistanceConcreteCrushing(nu=nu, f_cd=f_cd, theta=theta)
+
+    def test_raise_error_when_theta_exceeds_90_degrees(self) -> None:
+        """Test an angle beyond the range of the cotangent."""
+        with pytest.raises(GreaterThan90Error):
+            Form8Dot84TorsionalStressResistanceConcreteCrushing(nu=0.5, f_cd=20.0, theta=120.0)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\tau_{t,Rd,max} = \frac{\nu \cdot f_{cd}}{\cot(\theta) + \tan(\theta)} = "
+                    r"\frac{0.500 \cdot 20.000}{\cot(26.565) + \tan(26.565)} = 4.000 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\tau_{t,Rd,max} = \frac{\nu \cdot f_{cd}}{\cot(\theta) + \tan(\theta)} = "
+                    r"\frac{0.500 \cdot 20.000 \ MPa}{\cot(26.565 ^\circ) + \tan(26.565 ^\circ)} = 4.000 \ MPa"
+                ),
+            ),
+            ("short", r"\tau_{t,Rd,max} = 4.000 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot84TorsionalStressResistanceConcreteCrushing(nu=0.5, f_cd=20.0, theta=THETA_COT_2).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_85.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_85.py
@@ -1,0 +1,218 @@
+"""Testing formula 8.85 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_85 import (
+    Form8Dot85CheckCotangentCompressionFieldTorsion,
+    SubForm8Dot85LowerBound,
+    SubForm8Dot85UpperBound,
+)
+from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError
+
+# Angles chosen so that their cotangents are round numbers, which keeps the hand calculations readable
+THETA_COT_0_25 = 75.963756532074  # cot(theta) = 0.25
+THETA_COT_0_4 = 68.198590513648  # cot(theta) = 0.4
+THETA_COT_1 = 45.0  # cot(theta) = 1
+THETA_COT_2 = 26.565051177078  # cot(theta) = 2
+THETA_COT_2_5 = 21.801409486352  # cot(theta) = 2.5
+THETA_COT_3 = 18.434948822922  # cot(theta) = 3
+
+
+class TestForm8Dot85CheckCotangentCompressionFieldTorsion:
+    """Validation for formula 8.85 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("theta", "expected"),
+        [
+            # With cot(theta_min) = 2.5 the printed range on cot(theta) runs from 1/2.5 = 0.4 up to 2.5
+            (THETA_COT_1, True),  # in the middle of the range, where both bounds are equally far away
+            (THETA_COT_2, True),  # inside the range
+            (THETA_COT_2_5, True),  # exactly on the upper bound, which is inclusive
+            (THETA_COT_3, False),  # steeper than the upper bound allows
+            (THETA_COT_0_4, True),  # exactly on the lower bound, which is inclusive
+            (THETA_COT_0_25, False),  # flatter than the lower bound allows
+        ],
+    )
+    def test_evaluation(self, theta: float, expected: bool) -> None:
+        """Tests the evaluation of the result."""
+        # Create object to test
+        formula = Form8Dot85CheckCotangentCompressionFieldTorsion(theta=theta, theta_min=THETA_COT_2_5)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+
+    def test_range_is_wider_than_the_one_of_formula_8_41(self) -> None:
+        """The lower bound is 1/cot(theta_min) and not the constant 1 of Formula (8.41), so an inclination
+        flatter than 45 degrees passes here while (8.41) would reject it.
+        """
+        # cot(theta) = 0.5, which is below the lower bound of 1 that Formula (8.41) prints
+        formula = Form8Dot85CheckCotangentCompressionFieldTorsion(theta=63.434948822922, theta_min=THETA_COT_2_5)
+
+        assert bool(formula) is True
+
+    @pytest.mark.parametrize("theta", [THETA_COT_1, THETA_COT_2, 60.0])
+    def test_an_inverted_range_is_not_silently_reordered(self, theta: float) -> None:
+        """For cot(theta_min) < 1 the printed lower bound 1/cot(theta_min) exceeds the printed upper bound
+        cot(theta_min), so nothing can satisfy the relation. The standard prints the two sides fixed, so the
+        class reports that rather than swapping them into a range that would pass.
+
+        8.2.3(4) puts cot(theta_min) at 2,5 or higher, so this does not arise in practice. It is here so that a
+        later change cannot introduce the reordering unnoticed.
+        """
+        # theta_min = 60 degrees gives cot(theta_min) = 0.577, hence a lower bound of 1.732 above an upper
+        # bound of 0.577
+        formula = Form8Dot85CheckCotangentCompressionFieldTorsion(theta=theta, theta_min=60.0)
+
+        assert bool(formula) is False
+
+    @pytest.mark.parametrize(
+        ("theta", "expected_unity_check"),
+        [
+            (THETA_COT_1, 0.4),  # both bounds give 0.4, since the range is symmetric in cot(theta) about 1
+            (THETA_COT_2, 0.8),  # the upper bound governs: 2.0 / 2.5
+            (THETA_COT_3, 1.2),  # the upper bound governs and is violated: 3.0 / 2.5
+            (THETA_COT_0_25, 1.6),  # the lower bound governs and is violated: 0.4 / 0.25
+        ],
+    )
+    def test_unity_check_is_the_governing_bound(self, theta: float, expected_unity_check: float) -> None:
+        """Aggregating with all takes the largest unity check, so the governing bound is the one reported."""
+        # Create object to test
+        formula = Form8Dot85CheckCotangentCompressionFieldTorsion(theta=theta, theta_min=THETA_COT_2_5)
+
+        # Perform test by assert
+        assert formula.unity_check == pytest.approx(expected=expected_unity_check, rel=1e-4)
+
+    def test_both_bounds_are_exposed_separately(self) -> None:
+        """Each half of the printed range keeps its own left-hand side, right-hand side and unity check."""
+        # Example values
+        formula = Form8Dot85CheckCotangentCompressionFieldTorsion(theta=THETA_COT_2, theta_min=THETA_COT_2_5)
+        lower, upper = formula.comparison_formulas
+
+        # Perform test by assert
+        assert lower.lhs == pytest.approx(expected=0.4, rel=1e-4)
+        assert lower.rhs == pytest.approx(expected=2.0, rel=1e-4)
+        assert lower.unity_check == pytest.approx(expected=0.2, rel=1e-4)
+        assert upper.lhs == pytest.approx(expected=2.0, rel=1e-4)
+        assert upper.rhs == pytest.approx(expected=2.5, rel=1e-4)
+        assert upper.unity_check == pytest.approx(expected=0.8, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("theta", "theta_min"),
+        [
+            (0.0, THETA_COT_2_5),  # theta is zero, for which the cotangent diverges
+            (-THETA_COT_2, THETA_COT_2_5),  # theta is negative
+            (THETA_COT_2, 0.0),  # theta_min is zero, for which the cotangent diverges
+            (THETA_COT_2, -THETA_COT_2_5),  # theta_min is negative
+        ],
+    )
+    def test_raise_error_when_the_angles_are_less_or_equal_to_zero(self, theta: float, theta_min: float) -> None:
+        """Both inputs are inclinations, so neither can be zero or less."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot85CheckCotangentCompressionFieldTorsion(theta=theta, theta_min=theta_min)
+
+    @pytest.mark.parametrize(
+        ("theta", "theta_min"),
+        [
+            (120.0, THETA_COT_2_5),  # theta exceeds 90 degrees
+            (THETA_COT_2, 120.0),  # theta_min exceeds 90 degrees
+        ],
+    )
+    def test_raise_error_when_the_angles_exceed_90_degrees(self, theta: float, theta_min: float) -> None:
+        """Beyond 90 degrees the cotangent turns negative, which is not an inclination the standard offers."""
+        with pytest.raises(GreaterThan90Error):
+            Form8Dot85CheckCotangentCompressionFieldTorsion(theta=theta, theta_min=theta_min)
+
+    @pytest.mark.parametrize(
+        ("theta", "representation", "expected"),
+        [
+            (
+                THETA_COT_2,
+                "complete",
+                (
+                    r"CHECK \to \frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \leq \cot(\theta_{min}) \to "
+                    r"\frac{1}{\cot(21.801)} \leq \cot(26.565) \leq \cot(21.801) \to OK"
+                ),
+            ),
+            (
+                THETA_COT_2,
+                "complete_with_units",
+                (
+                    r"CHECK \to \frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \leq \cot(\theta_{min}) \to "
+                    r"\frac{1}{\cot(21.801 ^\circ)} \leq \cot(26.565 ^\circ) \leq \cot(21.801 ^\circ) \to OK"
+                ),
+            ),
+            (THETA_COT_2, "short", r"CHECK \to OK"),
+            (
+                THETA_COT_3,
+                "complete",
+                (
+                    r"CHECK \to \frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \leq \cot(\theta_{min}) \to "
+                    r"\frac{1}{\cot(21.801)} \leq \cot(18.435) \leq \cot(21.801) \to \text{Not OK}"
+                ),
+            ),
+            (THETA_COT_3, "short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex(self, theta: float, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        test_latex = Form8Dot85CheckCotangentCompressionFieldTorsion(theta=theta, theta_min=THETA_COT_2_5).latex()
+
+        actual = {
+            "complete": test_latex.complete,
+            "complete_with_units": test_latex.complete_with_units,
+            "short": test_latex.short,
+        }
+
+        assert expected == actual[representation]
+
+
+class TestSubForm8Dot85Bounds:
+    """Validation for the two halves of formula 8.85 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("theta", "expected", "expected_latex"),
+        [
+            (
+                THETA_COT_2,
+                True,
+                r"CHECK \to \frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \to \frac{1}{\cot(21.801)} \leq \cot(26.565) \to OK",
+            ),
+            (
+                THETA_COT_0_25,
+                False,
+                (
+                    r"CHECK \to \frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \to "
+                    r"\frac{1}{\cot(21.801)} \leq \cot(75.964) \to \text{Not OK}"
+                ),
+            ),
+        ],
+    )
+    def test_lower_bound(self, theta: float, expected: bool, expected_latex: str) -> None:
+        """Tests the lower bound on its own."""
+        # Create object to test
+        formula = SubForm8Dot85LowerBound(theta=theta, theta_min=THETA_COT_2_5)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+        assert formula.latex().complete == expected_latex
+
+    @pytest.mark.parametrize(
+        ("theta", "expected", "expected_latex"),
+        [
+            (THETA_COT_2, True, r"CHECK \to \cot(\theta) \leq \cot(\theta_{min}) \to \cot(26.565) \leq \cot(21.801) \to OK"),
+            (
+                THETA_COT_3,
+                False,
+                r"CHECK \to \cot(\theta) \leq \cot(\theta_{min}) \to \cot(18.435) \leq \cot(21.801) \to \text{Not OK}",
+            ),
+        ],
+    )
+    def test_upper_bound(self, theta: float, expected: bool, expected_latex: str) -> None:
+        """Tests the upper bound on its own."""
+        # Create object to test
+        formula = SubForm8Dot85UpperBound(theta=theta, theta_min=THETA_COT_2_5)
+
+        # Perform test by assert
+        assert bool(formula) is expected
+        assert formula.latex().complete == expected_latex


### PR DESCRIPTION
Adds all five numbered formulas of FprEN 1992-1-1:2023 clause 8.3.4, "Torsional resistance of compact or closed sections", paragraphs (1) to (4). The clause is complete with this pull request.

(8.81) is the design torsional capacity, the minimum of the three resistances of (8.82), (8.83) and (8.84): yielding of the shear reinforcement, yielding of the longitudinal reinforcement, and crushing of the compression field in concrete. (8.85) is the range the standard gives for the inclination of the compression field used in those three. All of it applies to a single cell, thin-walled section or a sub-section with constant effective wall thickness.

Decisions a reviewer has to weigh:

- **(8.85) uses `AggregatedComparisonFormula`, not `DoubleComparisonFormula`.** The repository holds both for this shape: (8.41) uses the latter, (8.58) the former. The deciding difference is that `DoubleComparisonFormula` does not inherit from `ComparisonFormula` and therefore has no `unity_check` at all, so `Form8Dot41InclinationCompressionField.unity_check` raises `AttributeError`. Modelled as two aggregated comparisons, each bound of (8.85) keeps its own unity check and the aggregate is the governing one. (8.41) is left alone.
- **(8.85) is not a duplicate of (8.41)**, although both are bounded above by `cot θ_min` of 8.2.3(4). The lower bound here is `1/cot θ_min` instead of the constant 1, so torsion permits a flatter compression field than shear does, symmetric in `cot θ` about 1. With `cot θ_min = 2.5` the range on `cot θ` is `[0.4, 2.5]`, and both unity checks read 0.4 at `cot θ = 1`.
- If `cot θ_min < 1` the printed lower bound exceeds the printed upper bound and nothing satisfies the relation. The class reports that rather than reordering the two sides, and a test pins it. 8.2.3(4) puts `cot θ_min` at 2,5 or higher, so it does not arise in practice.
- The standard prints the numerator of (8.83) as the single quantity `ΣA_sl f_yd`, the yield force of the longitudinal reinforcement. This class takes the area and the stress separately, which mirrors (8.82) and lets `complete_with_units` expose a unit mismatch. The two are equal only when every bar counted carries the same `f_yd`, and the class docstring says so.
- All angles are taken in degrees rather than as a pre-computed cotangent, following the choice made for (8.55) to (8.57).
- Formula (8.85) is a recommendation for usual cases, and enforcing it inside (8.82) to (8.84) would need `cot θ_min`, which none of those classes has. It is documented on the `theta` parameter of each and left as a separate check.
- `nu` in (8.84) is left entirely to the caller. The standard points at Annex G and offers 0,60 for `cot θ = 1,0`; neither is enforced.
- (8.84) is tested at two angles. Its denominator `cot θ + tan θ` is symmetric about 45 degrees, so a single angle cannot distinguish the sum of the two functions from a multiple of one of them.
- (8.81) keeps the printed `min{a; b; c}` with braces and semicolons instead of the `\min\left(a, b\right)` used elsewhere in the repository. Those other uses are all clamps on a computed value, not a min-set the standard prints.
- The docs table still shows (8.79) and (8.80) as not implemented, because this branch starts from main and those two sit in #1135.

## Formulas as implemented

**Formula (8.81)**, `Form8Dot81DesignTorsionalCapacity`

`equation`

$$
\tau_{t,Rd} = \min\left\lbrace \tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max} \right\rbrace
$$

`complete`

$$
\tau_{t,Rd} = \min\left\lbrace \tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max} \right\rbrace = \min\left\lbrace 3.625; 2.900; 4.000 \right\rbrace = 2.900 \ MPa
$$

`complete_with_units`

$$
\tau_{t,Rd} = \min\left\lbrace \tau_{t,Rd,sw}; \tau_{t,Rd,sl}; \tau_{t,Rd,max} \right\rbrace = \min\left\lbrace 3.625 \ MPa; 2.900 \ MPa; 4.000 \ MPa \right\rbrace = 2.900 \ MPa
$$

**Formula (8.82)**, `Form8Dot82TorsionalStressResistanceShearReinforcement`

`equation`

$$
\tau_{t,Rd,sw} = \cot(\theta) \cdot \frac{A_{sw}}{t_{eff} \cdot s} \cdot f_{ywd}
$$

`complete`

$$
\tau_{t,Rd,sw} = \cot(\theta) \cdot \frac{A_{sw}}{t_{eff} \cdot s} \cdot f_{ywd} = \cot(26.565) \cdot \frac{100.000}{120.000 \cdot 200.000} \cdot 435.000 = 3.625 \ MPa
$$

`complete_with_units`

$$
\tau_{t,Rd,sw} = \cot(\theta) \cdot \frac{A_{sw}}{t_{eff} \cdot s} \cdot f_{ywd} = \cot(26.565 ^\circ) \cdot \frac{100.000 \ mm^2}{120.000 \ mm \cdot 200.000 \ mm} \cdot 435.000 \ MPa = 3.625 \ MPa
$$

**Formula (8.83)**, `Form8Dot83TorsionalStressResistanceLongitudinalReinforcement`

`equation`

$$
\tau_{t,Rd,sl} = \frac{\Sigma A_{sl} \cdot f_{yd}}{t_{eff} \cdot u_k \cdot \cot(\theta)}
$$

`complete`

$$
\tau_{t,Rd,sl} = \frac{\Sigma A_{sl} \cdot f_{yd}}{t_{eff} \cdot u_k \cdot \cot(\theta)} = \frac{2400.000 \cdot 435.000}{120.000 \cdot 1500.000 \cdot \cot(26.565)} = 2.900 \ MPa
$$

`complete_with_units`

$$
\tau_{t,Rd,sl} = \frac{\Sigma A_{sl} \cdot f_{yd}}{t_{eff} \cdot u_k \cdot \cot(\theta)} = \frac{2400.000 \ mm^2 \cdot 435.000 \ MPa}{120.000 \ mm \cdot 1500.000 \ mm \cdot \cot(26.565 ^\circ)} = 2.900 \ MPa
$$

**Formula (8.84)**, `Form8Dot84TorsionalStressResistanceConcreteCrushing`

`equation`

$$
\tau_{t,Rd,max} = \frac{\nu \cdot f_{cd}}{\cot(\theta) + \tan(\theta)}
$$

`complete`

$$
\tau_{t,Rd,max} = \frac{\nu \cdot f_{cd}}{\cot(\theta) + \tan(\theta)} = \frac{0.500 \cdot 20.000}{\cot(26.565) + \tan(26.565)} = 4.000 \ MPa
$$

`complete_with_units`

$$
\tau_{t,Rd,max} = \frac{\nu \cdot f_{cd}}{\cot(\theta) + \tan(\theta)} = \frac{0.500 \cdot 20.000 \ MPa}{\cot(26.565 ^\circ) + \tan(26.565 ^\circ)} = 4.000 \ MPa
$$

**Formula (8.85)**, `Form8Dot85CheckCotangentCompressionFieldTorsion`

`equation`

$$
CHECK \to \frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \leq \cot(\theta_{min})
$$

`complete`

$$
CHECK \to \frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \leq \cot(\theta_{min}) \to \frac{1}{\cot(21.801)} \leq \cot(26.565) \leq \cot(21.801) \to OK
$$

`complete_with_units`

$$
CHECK \to \frac{1}{\cot(\theta_{min})} \leq \cot(\theta) \leq \cot(\theta_{min}) \to \frac{1}{\cot(21.801 ^\circ)} \leq \cot(26.565 ^\circ) \leq \cot(21.801 ^\circ) \to OK
$$

Contributes to #1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eurocode torsional design calculations for formulas 8.81–8.85.
  * Added checks for torsional capacity, reinforcement resistance, concrete crushing, and compression-field inclination.
  * Added symbolic, numeric, and unit-aware LaTeX representations for the calculations.

* **Documentation**
  * Marked formulas 8.81–8.85 as complete and linked them to their implementations.

* **Tests**
  * Added coverage for calculations, input validation, boundary conditions, angle handling, and formatted output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->