### PR TITLE
feat: add table 8.3 from FprEN 1992-1-1:2023 clause 8.4.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/table_8_3.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/table_8_3.py
@@ -1,0 +1,298 @@
+"""Table 8.3 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import ClassVar
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class PunchingSupportType(StrEnum):
+    """Types of support of Table 8.3 of FprEN 1992-1-1:2023 (E).
+
+    The five types are the row headings of Table 8.3, so this list is closed: a support that fits none of
+    them has no coefficient in the standard.
+    """
+
+    INTERNAL_COLUMN = "internal columns"
+    EDGE_COLUMN = "edge columns"
+    CORNER_COLUMN = "corner columns"
+    END_OF_WALL = "ends of walls"
+    CORNER_OF_WALL = "corners of walls"
+
+    @property
+    def has_refined_value(self) -> bool:
+        """Whether Table 8.3 gives a refined coefficient for this type of support.
+
+        The rows for ends of walls and corners of walls print a single cell spanning both the approximated and
+        the refined column, so those two supports have one value and no refined route.
+
+        Returns
+        -------
+        bool
+            True for the three column types, False for the two wall types.
+        """
+        return self in (
+            PunchingSupportType.INTERNAL_COLUMN,
+            PunchingSupportType.EDGE_COLUMN,
+            PunchingSupportType.CORNER_COLUMN,
+        )
+
+
+class SubTable8Dot3RefinedCoefficientShearForceConcentration(Formula):
+    r"""Class representing the refined coefficient [$\beta_e$] of Table 8.3 of FprEN 1992-1-1:2023.
+
+    The table prints the expression once for internal, edge and corner columns; only the eccentricity
+    [$e_b$] that goes into it is defined per type of support. It is printed as an expression with a lower
+    bound, [$1 + 1,1 e_b / b_b \geq 1,05$], and implemented as a maximum against that bound.
+    """
+
+    label = "Table 8.3"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        e_b: MM,
+        b_b: MM,
+    ) -> None:
+        r"""[$\beta_e$] Refined coefficient accounting for concentrations of the shear forces [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.2(6) - Table 8.3
+
+        Parameters
+        ----------
+        e_b : MM
+            [$e_b$] Eccentricity of the line of action of the support forces with respect to the centroid of
+            the control perimeter, combined from [$e_{b,x}$] and [$e_{b,y}$] according to the type of support,
+            see footnote a of Table 8.3 [$mm$].
+        b_b : MM
+            [$b_b$] Geometric mean of the minimum and maximum overall widths of the control perimeter, see
+            footnote a of Table 8.3 and Figure 8.21 b) [$mm$].
+        """
+        super().__init__()
+        self.e_b = e_b
+        self.b_b = b_b
+
+    @staticmethod
+    def _evaluate(
+        e_b: MM,
+        b_b: MM,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(e_b=e_b)
+        raise_if_less_or_equal_to_zero(b_b=b_b)
+
+        return max(1 + 1.1 * e_b / b_b, 1.05)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for the refined coefficient of Table 8.3."""
+        _equation: str = r"\max\left(1 + 1.1 \cdot \frac{e_b}{b_b}, 1.05\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"e_b": f"{self.e_b:.{n}f}",
+                r"b_b": f"{self.b_b:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"e_b": rf"{self.e_b:.{n}f} \ mm",
+                r"b_b": rf"{self.b_b:.{n}f} \ mm",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\beta_e",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )
+
+
+@dataclass(frozen=True)
+class Table8Dot3CoefficientsShearForceConcentration:
+    r"""Implementation of Table 8.3 from FprEN 1992-1-1:2023.
+
+    Coefficients [$\beta_e$] accounting for concentrations of the shear forces, which Formula (8.92) needs.
+    The table offers two routes per type of support. The approximated route is a single printed number. The
+    refined route is [$1 + 1,1 e_b / b_b \geq 1,05$], the same expression for all three column types, with an
+    eccentricity [$e_b$] whose definition differs per type.
+
+    8.4.2(6) allows the approximated values for internal, edge and corner columns to be used only if all four
+    conditions listed there are fulfilled, and states that the refined values may be applied in those cases as
+    well for a more refined calculation. Choosing between the two routes is therefore a decision of the caller,
+    which is why this class exposes both instead of one coefficient.
+
+    The rows for ends of walls and corners of walls print one cell spanning both columns of the table, so
+    those two supports have a single value and no refined route. The four conditions of 8.4.2(6) name only
+    columns, so they do not gate the wall values either.
+
+    Footnote a of the table reads: [$e_{b,x}$], [$e_{b,y}$] are the eccentricities of the line of action of the
+    support forces with respect to the centroid of the control perimeter. The line of action should be
+    determined accounting for the axial force and the moments in the two directions transferred by the slab to
+    the support, including the internal forces in a column over the slab if present.
+
+    **The two directions are not interchangeable for an edge column.** Figure 8.21 a) draws the slab edge as a
+    straight line with [$e_{b,x}$] measured across it and [$e_{b,y}$] measured along it, so x is the direction
+    perpendicular to the slab edge and y the direction parallel to it. The edge column row halves the
+    perpendicular component, so passing the two the other way round gives a different coefficient without any
+    error being raised: for [$e_{b,x} = 30$] mm and [$e_{b,y} = 40$] mm it is 55 mm as printed against 65 mm
+    swapped. For internal columns the definition is a root of squares and for corner columns it is symmetric in
+    the two, so there the orientation makes no difference.
+
+    Footnote a also reads: [$b_b$] is the geometric mean of the minimum and maximum overall widths of the
+    control perimeter, see Figure 8.21 b). Where the length of straight segments of the control perimeter is
+    limited to [$3 d_v$] according to 8.4.2(3), the overall width of the control perimeter should not be
+    reduced. That is a rule for how the caller measures [$b_{b,min}$] and [$b_{b,max}$], not a value, so it is
+    stated here and not applied to them.
+
+    Parameters
+    ----------
+    support_type : PunchingSupportType
+        The type of support, being the row of Table 8.3.
+    e_b_x : MM | None
+        [$e_{b,x}$] Eccentricity perpendicular to the slab edge, being the x-direction of Figure 8.21 a). Its
+        sign does not matter, since every definition of [$e_b$] takes either its square or its absolute value.
+        Only needed for the refined route. Defaults to None [$mm$].
+    e_b_y : MM | None
+        [$e_{b,y}$] Eccentricity parallel to the slab edge, being the y-direction of Figure 8.21 a). Only
+        needed for the refined route. Defaults to None [$mm$].
+    b_b_min : MM | None
+        [$b_{b,min}$] Minimum overall width of the control perimeter according to Figure 8.21 b). Only needed
+        for the refined route. Defaults to None [$mm$].
+    b_b_max : MM | None
+        [$b_{b,max}$] Maximum overall width of the control perimeter according to Figure 8.21 b). Only needed
+        for the refined route. Defaults to None [$mm$].
+
+    Examples
+    --------
+    >>> table = Table8Dot3CoefficientsShearForceConcentration(PunchingSupportType.INTERNAL_COLUMN)
+    >>> table.beta_e_approximated
+    1.15
+    """
+
+    support_type: PunchingSupportType
+    e_b_x: MM | None = None
+    e_b_y: MM | None = None
+    b_b_min: MM | None = None
+    b_b_max: MM | None = None
+    label: str = field(init=False, default="Table 8.3")
+    source_document: str = field(init=False, default=FPR_EN_1992_1_1_2023)
+
+    # The approximated value printed per type of support. For the two wall types the printed cell spans both
+    # columns of the table, so this is the only value the standard gives for them.
+    _approximated: ClassVar[dict[PunchingSupportType, DIMENSIONLESS]] = {
+        PunchingSupportType.INTERNAL_COLUMN: 1.15,
+        PunchingSupportType.EDGE_COLUMN: 1.4,
+        PunchingSupportType.CORNER_COLUMN: 1.5,
+        PunchingSupportType.END_OF_WALL: 1.4,
+        PunchingSupportType.CORNER_OF_WALL: 1.2,
+    }
+
+    @property
+    def beta_e_approximated(self) -> DIMENSIONLESS:
+        r"""[$\beta_e$] Approximated coefficient accounting for concentrations of the shear forces [$-$].
+
+        Returns
+        -------
+        DIMENSIONLESS
+            The value printed in the approximated column of Table 8.3. For ends of walls and corners of walls
+            the printed cell spans both columns, so the same value is the only one the standard gives.
+        """
+        return self._approximated[self.support_type]
+
+    @property
+    def e_b(self) -> MM:
+        r"""[$e_b$] Eccentricity of the line of action of the support forces, combined according to the type of
+        support as printed in the refined column of Table 8.3.
+
+        Returns
+        -------
+        MM
+            [$\sqrt{e_{b,x}^2 + e_{b,y}^2}$] for internal columns, [$0,5 |e_{b,x}| + |e_{b,y}|$] for edge
+            columns and [$0,27 \left(|e_{b,x}| + |e_{b,y}|\right)$] for corner columns. The edge column
+            definition halves the component perpendicular to the slab edge only, so the two eccentricities are
+            not interchangeable there, see the class docstring [$mm$].
+
+        Raises
+        ------
+        ValueError
+            If the type of support has no refined route, or if an eccentricity was not given.
+        """
+        self._raise_if_refined_route_unavailable()
+        if self.e_b_x is None or self.e_b_y is None:
+            raise ValueError("Both e_b_x and e_b_y are needed for the refined coefficient of Table 8.3.")
+
+        match self.support_type:
+            case PunchingSupportType.INTERNAL_COLUMN:
+                return float(np.sqrt(self.e_b_x**2 + self.e_b_y**2))
+            case PunchingSupportType.EDGE_COLUMN:
+                return 0.5 * abs(self.e_b_x) + abs(self.e_b_y)
+            case _:
+                return 0.27 * (abs(self.e_b_x) + abs(self.e_b_y))
+
+    @property
+    def b_b(self) -> MM:
+        r"""[$b_b$] Geometric mean of the minimum and maximum overall widths of the control perimeter,
+        [$\sqrt{b_{b,min} \cdot b_{b,max}}$], according to footnote a of Table 8.3.
+
+        Returns
+        -------
+        MM
+            The geometric mean of the two widths [$mm$].
+
+        Raises
+        ------
+        ValueError
+            If the type of support has no refined route, or if a width was not given.
+        LessOrEqualToZeroError
+            If one of the widths is zero or negative.
+        """
+        self._raise_if_refined_route_unavailable()
+        if self.b_b_min is None or self.b_b_max is None:
+            raise ValueError("Both b_b_min and b_b_max are needed for the refined coefficient of Table 8.3.")
+        raise_if_less_or_equal_to_zero(b_b_min=self.b_b_min, b_b_max=self.b_b_max)
+
+        return float(np.sqrt(self.b_b_min * self.b_b_max))
+
+    @property
+    def beta_e_refined(self) -> SubTable8Dot3RefinedCoefficientShearForceConcentration:
+        r"""[$\beta_e$] Refined coefficient accounting for concentrations of the shear forces [$-$].
+
+        Returns
+        -------
+        SubTable8Dot3RefinedCoefficientShearForceConcentration
+            The refined coefficient. It is a float, so it can be used wherever the approximated value can, and
+            it carries a ``latex`` method for the expression printed in the table.
+
+        Raises
+        ------
+        ValueError
+            If the type of support has no refined route, or if one of the four inputs was not given.
+        """
+        return SubTable8Dot3RefinedCoefficientShearForceConcentration(e_b=self.e_b, b_b=self.b_b)
+
+    def _raise_if_refined_route_unavailable(self) -> None:
+        """Guards the refined route against the two types of support for which the table prints no expression.
+
+        Raises
+        ------
+        ValueError
+            If the type of support is an end or a corner of a wall.
+        """
+        if not self.support_type.has_refined_value:
+            raise ValueError(
+                f"Table 8.3 gives no refined coefficient for {self.support_type.value}, only the value of "
+                f"{self.beta_e_approximated} that spans both columns of the table."
+            )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/tables.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/tables.md
@@ -30,7 +30,7 @@ Total of 92 tables present.
 |     7.2      | :x:  |         |             |
 |     8.1      | :x:  |         |             |
 |     8.2      | :heavy_check_mark: | Coefficients depending on the roughness of the surface | Table8Dot2CoefficientsSurfaceRoughness, SurfaceRoughness |
-|     8.3      | :x:  |         |             |
+|     8.3      | :heavy_check_mark: | Coefficients accounting for concentrations of the shear forces | Table8Dot3CoefficientsShearForceConcentration, SubTable8Dot3RefinedCoefficientShearForceConcentration, PunchingSupportType |
 |     9.1      | :x:  |         |             |
 |     9.2      | :x:  |         |             |
 |     9.3      | :x:  |         |             |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_table_8_3.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_table_8_3.py
@@ -1,0 +1,285 @@
+"""Testing table 8.3 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.table_8_3 import (
+    PunchingSupportType,
+    SubTable8Dot3RefinedCoefficientShearForceConcentration,
+    Table8Dot3CoefficientsShearForceConcentration,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestPunchingSupportType:
+    """Validation for the types of support of table 8.3 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("support_type", "expected"),
+        [
+            (PunchingSupportType.INTERNAL_COLUMN, True),
+            (PunchingSupportType.EDGE_COLUMN, True),
+            (PunchingSupportType.CORNER_COLUMN, True),
+            (PunchingSupportType.END_OF_WALL, False),  # the printed cell spans both columns of the table
+            (PunchingSupportType.CORNER_OF_WALL, False),  # the printed cell spans both columns of the table
+        ],
+    )
+    def test_has_refined_value(self, support_type: PunchingSupportType, expected: bool) -> None:
+        """Tests which rows of the table offer a refined coefficient."""
+        assert support_type.has_refined_value is expected
+
+
+class TestTable8Dot3CoefficientsShearForceConcentration:
+    """Validation for table 8.3 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("support_type", "expected"),
+        [
+            (PunchingSupportType.INTERNAL_COLUMN, 1.15),
+            (PunchingSupportType.EDGE_COLUMN, 1.4),
+            (PunchingSupportType.CORNER_COLUMN, 1.5),
+            (PunchingSupportType.END_OF_WALL, 1.4),
+            (PunchingSupportType.CORNER_OF_WALL, 1.2),
+        ],
+    )
+    def test_beta_e_approximated(self, support_type: PunchingSupportType, expected: float) -> None:
+        """Tests the approximated coefficient printed per row of the table."""
+        assert Table8Dot3CoefficientsShearForceConcentration(support_type=support_type).beta_e_approximated == pytest.approx(expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("support_type", "e_b_x", "e_b_y", "expected"),
+        [
+            (PunchingSupportType.INTERNAL_COLUMN, 30.0, 40.0, 50.0),  # sqrt(30^2 + 40^2)
+            (PunchingSupportType.EDGE_COLUMN, 30.0, 40.0, 55.0),  # 0.5 * 30 + 40
+            (PunchingSupportType.CORNER_COLUMN, 30.0, 40.0, 18.9),  # 0.27 * (30 + 40)
+            (PunchingSupportType.INTERNAL_COLUMN, -30.0, -40.0, 50.0),  # the sign of the eccentricities does not matter
+            (PunchingSupportType.EDGE_COLUMN, -30.0, -40.0, 55.0),  # the sign of the eccentricities does not matter
+            (PunchingSupportType.CORNER_COLUMN, -30.0, -40.0, 18.9),  # the sign of the eccentricities does not matter
+        ],
+    )
+    def test_e_b(self, support_type: PunchingSupportType, e_b_x: float, e_b_y: float, expected: float) -> None:
+        """Tests the eccentricity combined according to the type of support."""
+        table = Table8Dot3CoefficientsShearForceConcentration(support_type=support_type, e_b_x=e_b_x, e_b_y=e_b_y)
+
+        assert table.e_b == pytest.approx(expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("support_type", "swapped_is_equal"),
+        [
+            (PunchingSupportType.INTERNAL_COLUMN, True),  # a root of squares, so symmetric in the two directions
+            (PunchingSupportType.CORNER_COLUMN, True),  # both absolute values carry the same factor
+            (PunchingSupportType.EDGE_COLUMN, False),  # only the component perpendicular to the slab edge is halved
+        ],
+    )
+    def test_e_b_orientation(self, support_type: PunchingSupportType, swapped_is_equal: bool) -> None:
+        """Tests that x and y are interchangeable except for an edge column, where x is perpendicular to the slab edge."""
+        as_printed = Table8Dot3CoefficientsShearForceConcentration(support_type=support_type, e_b_x=30.0, e_b_y=40.0)
+        swapped = Table8Dot3CoefficientsShearForceConcentration(support_type=support_type, e_b_x=40.0, e_b_y=30.0)
+
+        assert (as_printed.e_b == pytest.approx(swapped.e_b, rel=1e-4)) is swapped_is_equal
+
+    def test_e_b_of_an_edge_column_halves_the_eccentricity_across_the_slab_edge(self) -> None:
+        """Tests that the factor 0,5 sits on the eccentricity perpendicular to the slab edge, per Figure 8.21 a)."""
+        table = Table8Dot3CoefficientsShearForceConcentration(
+            support_type=PunchingSupportType.EDGE_COLUMN,
+            e_b_x=30.0,
+            e_b_y=40.0,
+        )
+
+        # Expected result, manually calculated: 0.5 * 30 + 40, and not 30 + 0.5 * 40 = 50
+        manually_calculated_result = 55.0  # mm
+
+        assert table.e_b == pytest.approx(manually_calculated_result, rel=1e-4)
+
+    def test_b_b(self) -> None:
+        """Tests the geometric mean of the two overall widths of the control perimeter."""
+        table = Table8Dot3CoefficientsShearForceConcentration(
+            support_type=PunchingSupportType.INTERNAL_COLUMN,
+            b_b_min=400.0,
+            b_b_max=900.0,
+        )
+
+        # Expected result, manually calculated
+        manually_calculated_result = 600.0  # mm, sqrt(400 * 900)
+
+        assert table.b_b == pytest.approx(manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("support_type", "expected"),
+        [
+            # e_b = 50.0 mm and b_b = 600.0 mm, so 1 + 1.1 * 50 / 600 = 1.0916667, above the lower bound
+            (PunchingSupportType.INTERNAL_COLUMN, 1.0916667),
+            # e_b = 55.0 mm and b_b = 600.0 mm, so 1 + 1.1 * 55 / 600 = 1.1008333, above the lower bound
+            (PunchingSupportType.EDGE_COLUMN, 1.1008333),
+            # e_b = 18.9 mm and b_b = 600.0 mm, so 1 + 1.1 * 18.9 / 600 = 1.034650, below the lower bound of 1.05
+            (PunchingSupportType.CORNER_COLUMN, 1.05),
+        ],
+    )
+    def test_beta_e_refined(self, support_type: PunchingSupportType, expected: float) -> None:
+        """Tests the refined coefficient, including the lower bound the table prints."""
+        table = Table8Dot3CoefficientsShearForceConcentration(
+            support_type=support_type,
+            e_b_x=30.0,
+            e_b_y=40.0,
+            b_b_min=400.0,
+            b_b_max=900.0,
+        )
+
+        assert table.beta_e_refined == pytest.approx(expected, rel=1e-4)
+
+    def test_beta_e_refined_carries_a_latex_representation(self) -> None:
+        """Tests that the refined coefficient is a formula and not a bare float."""
+        table = Table8Dot3CoefficientsShearForceConcentration(
+            support_type=PunchingSupportType.INTERNAL_COLUMN,
+            e_b_x=30.0,
+            e_b_y=40.0,
+            b_b_min=400.0,
+            b_b_max=900.0,
+        )
+
+        assert table.beta_e_refined.latex().short == r"\beta_e = 1.092 \ -"
+
+    @pytest.mark.parametrize("support_type", [PunchingSupportType.END_OF_WALL, PunchingSupportType.CORNER_OF_WALL])
+    def test_raise_error_when_refined_route_is_asked_for_a_wall(self, support_type: PunchingSupportType) -> None:
+        """Test that the two rows without a refined cell reject the refined route."""
+        table = Table8Dot3CoefficientsShearForceConcentration(
+            support_type=support_type,
+            e_b_x=30.0,
+            e_b_y=40.0,
+            b_b_min=400.0,
+            b_b_max=900.0,
+        )
+
+        with pytest.raises(ValueError, match="no refined coefficient"):
+            _ = table.e_b
+        with pytest.raises(ValueError, match="no refined coefficient"):
+            _ = table.b_b
+
+    @pytest.mark.parametrize(
+        ("e_b_x", "e_b_y"),
+        [
+            (None, 40.0),  # e_b_x is missing
+            (30.0, None),  # e_b_y is missing
+        ],
+    )
+    def test_raise_error_when_an_eccentricity_is_missing(self, e_b_x: float | None, e_b_y: float | None) -> None:
+        """Test that the refined route rejects an incomplete pair of eccentricities."""
+        table = Table8Dot3CoefficientsShearForceConcentration(
+            support_type=PunchingSupportType.INTERNAL_COLUMN,
+            e_b_x=e_b_x,
+            e_b_y=e_b_y,
+        )
+
+        with pytest.raises(ValueError, match="e_b_x and e_b_y"):
+            _ = table.e_b
+
+    @pytest.mark.parametrize(
+        ("b_b_min", "b_b_max"),
+        [
+            (None, 900.0),  # b_b_min is missing
+            (400.0, None),  # b_b_max is missing
+        ],
+    )
+    def test_raise_error_when_a_width_is_missing(self, b_b_min: float | None, b_b_max: float | None) -> None:
+        """Test that the refined route rejects an incomplete pair of widths."""
+        table = Table8Dot3CoefficientsShearForceConcentration(
+            support_type=PunchingSupportType.INTERNAL_COLUMN,
+            b_b_min=b_b_min,
+            b_b_max=b_b_max,
+        )
+
+        with pytest.raises(ValueError, match="b_b_min and b_b_max"):
+            _ = table.b_b
+
+    @pytest.mark.parametrize(
+        ("b_b_min", "b_b_max"),
+        [
+            (-400.0, 900.0),  # b_b_min is negative
+            (0.0, 900.0),  # b_b_min is zero
+            (400.0, -900.0),  # b_b_max is negative
+            (400.0, 0.0),  # b_b_max is zero
+        ],
+    )
+    def test_raise_error_when_a_width_is_invalid(self, b_b_min: float, b_b_max: float) -> None:
+        """Test invalid widths."""
+        table = Table8Dot3CoefficientsShearForceConcentration(
+            support_type=PunchingSupportType.INTERNAL_COLUMN,
+            b_b_min=b_b_min,
+            b_b_max=b_b_max,
+        )
+
+        with pytest.raises(LessOrEqualToZeroError):
+            _ = table.b_b
+
+
+class TestSubTable8Dot3RefinedCoefficientShearForceConcentration:
+    """Validation for the refined coefficient of table 8.3 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        e_b = 50.0
+        b_b = 600.0
+
+        # Object to test
+        formula = SubTable8Dot3RefinedCoefficientShearForceConcentration(e_b=e_b, b_b=b_b)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1.0916667  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_on_the_lower_bound(self) -> None:
+        """Tests that the lower bound the table prints governs a small eccentricity."""
+        # Object to test
+        formula = SubTable8Dot3RefinedCoefficientShearForceConcentration(e_b=10.0, b_b=600.0)
+
+        # Expected result, manually calculated: 1 + 1.1 * 10 / 600 = 1.0183333, below the lower bound of 1.05
+        manually_calculated_result = 1.05  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("e_b", "b_b"),
+        [
+            (-50.0, 600.0),  # e_b is negative
+            (50.0, -600.0),  # b_b is negative
+            (50.0, 0.0),  # b_b is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, e_b: float, b_b: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            SubTable8Dot3RefinedCoefficientShearForceConcentration(e_b=e_b, b_b=b_b)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\beta_e = \max\left(1 + 1.1 \cdot \frac{e_b}{b_b}, 1.05\right) = "
+                    r"\max\left(1 + 1.1 \cdot \frac{50.000}{600.000}, 1.05\right) = 1.092 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\beta_e = \max\left(1 + 1.1 \cdot \frac{e_b}{b_b}, 1.05\right) = "
+                    r"\max\left(1 + 1.1 \cdot \frac{50.000 \ mm}{600.000 \ mm}, 1.05\right) = 1.092 \ -"
+                ),
+            ),
+            ("short", r"\beta_e = 1.092 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = SubTable8Dot3RefinedCoefficientShearForceConcentration(e_b=50.0, b_b=600.0).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
Adds Table 8.3 of FprEN 1992-1-1:2023, the coefficients `beta_e` accounting for concentrations of the shear forces. It sits in the "where" list of 8.4.2(6) and supplies the coefficient that Formula (8.92) needs, so until now the most important input of that formula had to be copied out of the standard by hand.

The table is more than a lookup. Per type of support it offers an approximated value, a single printed number, and a refined route with the expression `1 + 1,1 e_b / b_b >= 1,05`, in which only the eccentricity `e_b` is defined per type. Footnote a adds the definition of `b_b` as the geometric mean of two widths.

Implemented as `PunchingSupportType`, the five row headings, plus a frozen dataclass `Table8Dot3CoefficientsShearForceConcentration` following the shape of `Table8Dot2CoefficientsSurfaceRoughness`.

## Decisions a reviewer has to weigh

**`e_b_x` and `e_b_y` are not interchangeable for an edge column, and nothing in the types can say so.** Figure 8.21 a) draws the slab edge as a straight line with `e_b,x` measured across it and `e_b,y` along it, so x is perpendicular to the slab edge and y parallel to it. The edge column row reads `e_b = 0,5|e_b,x| + |e_b,y|`, which halves the perpendicular component only. Passing the two the other way round raises no error and changes the answer: for 30 mm and 40 mm it is 55 mm as printed against 65 mm swapped. The class docstring, the parameter descriptions and the `e_b` property all say which direction is which now, and two tests pin the behaviour, one asserting that swapping is a no-op for internal and corner columns and changes the result for an edge column, one asserting that the 0,5 sits on the perpendicular term. This is the single most likely place for two implementations of this table to diverge.

**The refined coefficient is a `Formula`, reached through a property.** `beta_e_refined` returns a `SubTable8Dot3RefinedCoefficientShearForceConcentration`, which subclasses float, so it can be handed straight to Formula (8.92) while still carrying a `latex()` for the printed expression. `Table8Dot2CoefficientsSurfaceRoughness` needs nothing of the sort, because that table is a pure lookup with no algebra in it.

**The expression is implemented as a maximum against 1,05,** where the table prints `1 + 1,1 e_b / b_b >= 1,05`. This follows the existing reading in this chapter that a relation which assigns a value with a bound is a `Formula` with a `max`, as in Formula (8.27), and not a comparison. The rendered LaTeX therefore shows `\max(..., 1.05)` rather than the printed `>= 1,05`.

**Ends of walls and corners of walls have one value and no refined route.** Their cells span both columns of the table, so 1,4 and 1,2 are not approximations with a refined counterpart. Asking those two rows for `e_b`, `b_b` or `beta_e_refined` raises rather than falling back on the approximated number, since returning it would present a value as refined that never was. The name `beta_e_approximated` is a slight misnomer for those two rows and is documented as such; it is kept so that every row answers the same property. The four conditions of 8.4.2(6) that gate the approximated values name only columns, so they do not gate the wall values either.

**Both routes are exposed, and neither is picked for the caller.** 8.4.2(6) allows the approximated values for columns only if all four of its conditions hold, and allows the refined values in every case. Those conditions are about the structure, not about this table, so choosing between the two routes stays with the caller.

**The refined inputs are optional and validated on use.** `e_b_x`, `e_b_y`, `b_b_min` and `b_b_max` default to None, because the approximated route needs none of them and the wall rows have no refined route at all. Asking for a refined quantity without them raises with a message naming the missing pair. The eccentricities are deliberately not guarded against negative values, since every definition of `e_b` takes either a square or an absolute value; the widths are guarded at zero, being the two factors under the root that produces a denominator.

**`b_b_min` and `b_b_max` rather than `b_b`.** Figure 8.21 b) dimensions those two, and the footnote defines `b_b` as their geometric mean, so those are the quantities a designer measures. The footnote's rule that the overall width may not be reduced where straight segments are limited to `3 d_v` according to 8.4.2(3) is about how they are measured and is stated in the docstring rather than applied.

## The table as implemented

`beta_e` is dimensionless, `e_b`, `b_b`, `b_b,min` and `b_b,max` are in mm.

| Support | `beta_e` approximated | `e_b` for the refined route |
|---|---|---|
| internal columns | 1,15 | $\sqrt{e_{b,x}^2 + e_{b,y}^2}$ |
| edge columns | 1,4 | $0.5 \left\vert e_{b,x} \right\vert + \left\vert e_{b,y} \right\vert$ |
| corner columns | 1,5 | $0.27 \left( \left\vert e_{b,x} \right\vert + \left\vert e_{b,y} \right\vert \right)$ |
| ends of walls | 1,4 | no refined route |
| corners of walls | 1,2 | no refined route |

$$
b_b = \sqrt{b_{b,min} \cdot b_{b,max}}
$$

**Refined coefficient**, `SubTable8Dot3RefinedCoefficientShearForceConcentration`

`equation`

$$
\max\left(1 + 1.1 \cdot \frac{e_b}{b_b}, 1.05\right)
$$

`complete`

$$
\beta_e = \max\left(1 + 1.1 \cdot \frac{e_b}{b_b}, 1.05\right) = \max\left(1 + 1.1 \cdot \frac{50.000}{600.000}, 1.05\right) = 1.092 \ -
$$

`complete_with_units`

$$
\beta_e = \max\left(1 + 1.1 \cdot \frac{e_b}{b_b}, 1.05\right) = \max\left(1 + 1.1 \cdot \frac{50.000 \ mm}{600.000 \ mm}, 1.05\right) = 1.092 \ -
$$

The substituted values are an internal column with `e_b,x` = 30 mm and `e_b,y` = 40 mm, giving `e_b` = 50 mm, and `b_b,min` = 400 mm with `b_b,max` = 900 mm, giving `b_b` = 600 mm.

Contributes to #1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Eurocode Table 8.3 shear-force concentration coefficients.
  * Added approximated and refined calculations based on support type, eccentricity, and control-perimeter dimensions.
  * Added formula output and validation for incomplete or invalid calculation inputs.

* **Documentation**
  * Marked Table 8.3 as implemented and documented its related calculation objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->