### PR TITLE
feat: add formulas 8.94 to 8.96 from FprEN 1992-1-1:2023 clause 8.4.3

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_94.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_94.py
@@ -1,0 +1,123 @@
+"""Formula 8.94 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot94PunchingShearStressResistance(Formula):
+    r"""Class representing formula 8.94 for the calculation of the design punching shear stress resistance of
+    slabs without shear reinforcement.
+
+    The standard writes this as an expression bounded from above, which is implemented as a minimum of the two.
+    """
+
+    label = "8.94"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        gamma_v: DIMENSIONLESS,
+        k_pb: DIMENSIONLESS,
+        rho_l: DIMENSIONLESS,
+        f_ck: MPA,
+        d_dg: MM,
+        d_v: MM,
+    ) -> None:
+        r"""[$\tau_{Rd,c}$] Design punching shear stress resistance of slabs without shear reinforcement [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(1) - Formula (8.94)
+
+        Parameters
+        ----------
+        gamma_v : DIMENSIONLESS
+            [$\gamma_V$] Partial factor for shear design according to Table 4.3 (NDP) or Tables A.1 (NDP)
+            and A.2 (NDP) [$-$].
+        k_pb : DIMENSIONLESS
+            [$k_{pb}$] Punching shear gradient enhancement coefficient according to Formula (8.96), see
+            Form8Dot96PunchingShearGradientEnhancementCoefficient [$-$].
+        rho_l : DIMENSIONLESS
+            [$\rho_l$] Longitudinal reinforcement ratio at the control perimeter according to Formula (8.95),
+            see Form8Dot95LongitudinalReinforcementRatioPunchingShear [$-$].
+        f_ck : MPA
+            [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
+        d_dg : MM
+            [$d_{dg}$] Size parameter describing the failure zone roughness, which depends on the concrete type
+            and its aggregate properties. The standard gives it as [$16 + D_{lower} \leq 40$] for concrete with
+            [$f_{ck} \leq 60$] MPa, and as [$16 + D_{lower} \cdot \left(60/f_{ck}\right)^2 \leq 40$] for concrete
+            with [$f_{ck} > 60$] MPa, both in millimetres. [$D_{lower}$] is the smallest value of the upper sieve
+            size [$D$] in an aggregate for the coarsest fraction of aggregates in the concrete permitted by the
+            specification of concrete according to EN 206; where [$D_{max}$] is known it may replace
+            [$D_{lower}$], see the NOTE 2 to 8.2.1(4) [$mm$].
+        d_v : MM
+            [$d_v$] Shear-resisting effective depth of the slab according to Formula (8.91) [$mm$].
+        """
+        super().__init__()
+        self.gamma_v = gamma_v
+        self.k_pb = k_pb
+        self.rho_l = rho_l
+        self.f_ck = f_ck
+        self.d_dg = d_dg
+        self.d_v = d_v
+
+    @staticmethod
+    def _evaluate(
+        gamma_v: DIMENSIONLESS,
+        k_pb: DIMENSIONLESS,
+        rho_l: DIMENSIONLESS,
+        f_ck: MPA,
+        d_dg: MM,
+        d_v: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(k_pb=k_pb, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg)
+        raise_if_less_or_equal_to_zero(gamma_v=gamma_v, d_v=d_v)
+
+        return min(
+            (0.6 / gamma_v) * k_pb * (100 * rho_l * f_ck * (d_dg / d_v)) ** (1 / 3),
+            (0.5 / gamma_v) * np.sqrt(f_ck),
+        )
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.94."""
+        _equation: str = (
+            r"\min\left(\frac{0.6}{\gamma_V} \cdot k_{pb} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot "
+            r"\frac{d_{dg}}{d_v}\right)^{\frac{1}{3}}, \frac{0.5}{\gamma_V} \cdot \sqrt{f_{ck}}\right)"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\gamma_V": f"{self.gamma_v:.{n}f}",
+                r"k_{pb}": f"{self.k_pb:.{n}f}",
+                r"\rho_l": f"{self.rho_l:.{n}f}",
+                r"f_{ck}": f"{self.f_ck:.{n}f}",
+                r"d_{dg}": f"{self.d_dg:.{n}f}",
+                r"d_v": f"{self.d_v:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\gamma_V": f"{self.gamma_v:.{n}f}",
+                r"k_{pb}": f"{self.k_pb:.{n}f}",
+                r"\rho_l": f"{self.rho_l:.{n}f}",
+                r"f_{ck}": rf"{self.f_ck:.{n}f} \ MPa",
+                r"d_{dg}": rf"{self.d_dg:.{n}f} \ mm",
+                r"d_v": rf"{self.d_v:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rd,c}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_95.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_95.py
@@ -1,0 +1,83 @@
+"""Formula 8.95 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot95LongitudinalReinforcementRatioPunchingShear(Formula):
+    r"""Class representing formula 8.95 for the calculation of the longitudinal reinforcement ratio at a
+    punching shear control perimeter, combined from the two reinforcement directions.
+    """
+
+    label = "8.95"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        rho_l_x: DIMENSIONLESS,
+        rho_l_y: DIMENSIONLESS,
+    ) -> None:
+        r"""[$\rho_l$] Longitudinal reinforcement ratio at the control perimeter [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(1) - Formula (8.95)
+
+        Parameters
+        ----------
+        rho_l_x : DIMENSIONLESS
+            [$\rho_{l,x}$] Reinforcement ratio of bonded flexural reinforcement in the x-direction. The value
+            should be calculated as a mean value over the width [$b_s$] defined in Figure 8.22. Reinforcement
+            that does not extend at least [$2,5 d_v + 20 \phi$] beyond the control perimeter [$b_{0,5}$] or
+            [$20 \phi$] beyond the line of contraflexure should not be considered [$-$].
+        rho_l_y : DIMENSIONLESS
+            [$\rho_{l,y}$] Reinforcement ratio of bonded flexural reinforcement in the y-direction. The value
+            should be calculated as a mean value over the width [$b_s$] defined in Figure 8.22. Reinforcement
+            that does not extend at least [$2,5 d_v + 20 \phi$] beyond the control perimeter [$b_{0,5}$] or
+            [$20 \phi$] beyond the line of contraflexure should not be considered [$-$].
+        """
+        super().__init__()
+        self.rho_l_x = rho_l_x
+        self.rho_l_y = rho_l_y
+
+    @staticmethod
+    def _evaluate(
+        rho_l_x: DIMENSIONLESS,
+        rho_l_y: DIMENSIONLESS,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(rho_l_x=rho_l_x, rho_l_y=rho_l_y)
+
+        return np.sqrt(rho_l_x * rho_l_y)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.95."""
+        _equation: str = r"\sqrt{\rho_{l,x} \cdot \rho_{l,y}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\rho_{l,x}": f"{self.rho_l_x:.{n}f}",
+                r"\rho_{l,y}": f"{self.rho_l_y:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\rho_{l,x}": f"{self.rho_l_x:.{n}f}",
+                r"\rho_{l,y}": f"{self.rho_l_y:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\rho_l",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_96.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_96.py
@@ -1,0 +1,85 @@
+"""Formula 8.96 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot96PunchingShearGradientEnhancementCoefficient(Formula):
+    r"""Class representing formula 8.96 for the calculation of the punching shear gradient enhancement
+    coefficient.
+
+    The standard prints this as an expression bounded both below and above, [$1 \leq k_{pb} \leq 2,5$], which is
+    implemented as a minimum of a maximum.
+    """
+
+    label = "8.96"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        b_0: MM,
+        b_0_5: MM,
+    ) -> None:
+        r"""[$k_{pb}$] Punching shear gradient enhancement coefficient [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(1) - Formula (8.96)
+
+        Parameters
+        ----------
+        b_0 : MM
+            [$b_0$] Length of the perimeter at the face of the supporting area (see Figure 8.18). Near to
+            re-entrant corners of the supporting area and close to slab edges, the perimeter [$b_0$] should be
+            placed parallel to [$b_{0,5}$] (see Figures 8.18c)-(e)). For large supporting areas, wall ends, wall
+            corners, slabs with openings and with inserts, the rules of 8.4.2(3) apply (see Figure 8.19) [$mm$].
+        b_0_5 : MM
+            [$b_{0,5}$] Length of the control perimeter, taken at a distance [$0,5 d_v$] from the face of the
+            supporting area according to 8.4.2(2) to (5) [$mm$].
+        """
+        super().__init__()
+        self.b_0 = b_0
+        self.b_0_5 = b_0_5
+
+    @staticmethod
+    def _evaluate(
+        b_0: MM,
+        b_0_5: MM,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(b_0=b_0)
+        raise_if_less_or_equal_to_zero(b_0_5=b_0_5)
+
+        return min(max(3.6 * np.sqrt(1 - b_0 / b_0_5), 1), 2.5)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.96."""
+        _equation: str = r"\min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{b_0}{b_{0,5}}}, 1\right), 2.5\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_0": f"{self.b_0:.{n}f}",
+                r"b_{0,5}": f"{self.b_0_5:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_0": rf"{self.b_0:.{n}f} \ mm",
+                r"b_{0,5}": rf"{self.b_0_5:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"k_{pb}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -155,9 +155,9 @@ Total of 602 formulas present.
 |      8.91      |        :x:         |         |                                                                    |
 |      8.92      |        :x:         |         |                                                                    |
 |      8.93      |        :x:         |         |                                                                    |
-|      8.94      |        :x:         |         |                                                                    |
-|      8.95      |        :x:         |         |                                                                    |
-|      8.96      |        :x:         |         |                                                                    |
+|      8.94      | :heavy_check_mark: |         | Form8Dot94PunchingShearStressResistance                            |
+|      8.95      | :heavy_check_mark: |         | Form8Dot95LongitudinalReinforcementRatioPunchingShear               |
+|      8.96      | :heavy_check_mark: |         | Form8Dot96PunchingShearGradientEnhancementCoefficient               |
 |      8.97      |        :x:         |         |                                                                    |
 |      8.98      |        :x:         |         |                                                                    |
 |      8.99      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_94.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_94.py
@@ -1,0 +1,103 @@
+"""Testing formula 8.94 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_94 import (
+    Form8Dot94PunchingShearStressResistance,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot94PunchingShearStressResistance:
+    """Validation for formula 8.94 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression governs."""
+        # Example values
+        gamma_v = 1.4
+        k_pb = 1.2
+        rho_l = 0.01
+        f_ck = 30.0
+        d_dg = 32.0
+        d_v = 200.0
+
+        # Object to test
+        formula = Form8Dot94PunchingShearStressResistance(gamma_v=gamma_v, k_pb=k_pb, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d_v=d_v)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.867531  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_upper_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the upper bound governs."""
+        # Example values, with k_pb and rho_l large enough for the expression to exceed the upper bound
+        formula = Form8Dot94PunchingShearStressResistance(gamma_v=1.4, k_pb=2.5, rho_l=0.02, f_ck=30.0, d_dg=32.0, d_v=200.0)
+
+        # Expected result, manually calculated: the expression yields 2.277126, so the upper bound of 1.956152 governs
+        manually_calculated_result = 1.956152  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("gamma_v", "k_pb", "rho_l", "f_ck", "d_dg", "d_v"),
+        [
+            (1.4, -1.2, 0.01, 30.0, 32.0, 200.0),  # k_pb is negative
+            (1.4, 1.2, -0.01, 30.0, 32.0, 200.0),  # rho_l is negative
+            (1.4, 1.2, 0.01, -30.0, 32.0, 200.0),  # f_ck is negative
+            (1.4, 1.2, 0.01, 30.0, -32.0, 200.0),  # d_dg is negative
+            (-1.4, 1.2, 0.01, 30.0, 32.0, 200.0),  # gamma_v is negative
+            (0.0, 1.2, 0.01, 30.0, 32.0, 200.0),  # gamma_v is zero
+            (1.4, 1.2, 0.01, 30.0, 32.0, -200.0),  # d_v is negative
+            (1.4, 1.2, 0.01, 30.0, 32.0, 0.0),  # d_v is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, gamma_v: float, k_pb: float, rho_l: float, f_ck: float, d_dg: float, d_v: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot94PunchingShearStressResistance(gamma_v=gamma_v, k_pb=k_pb, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d_v=d_v)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\tau_{Rd,c} = \min\left(\frac{0.6}{\gamma_V} \cdot k_{pb} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot "
+                    r"\frac{d_{dg}}{d_v}\right)^{\frac{1}{3}}, \frac{0.5}{\gamma_V} \cdot \sqrt{f_{ck}}\right) = "
+                    r"\min\left(\frac{0.6}{1.400} \cdot 1.200 \cdot \left(100 \cdot 0.010 \cdot 30.000 \cdot "
+                    r"\frac{32.000}{200.000}\right)^{\frac{1}{3}}, \frac{0.5}{1.400} \cdot \sqrt{30.000}\right) = 0.868 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\tau_{Rd,c} = \min\left(\frac{0.6}{\gamma_V} \cdot k_{pb} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot "
+                    r"\frac{d_{dg}}{d_v}\right)^{\frac{1}{3}}, \frac{0.5}{\gamma_V} \cdot \sqrt{f_{ck}}\right) = "
+                    r"\min\left(\frac{0.6}{1.400} \cdot 1.200 \cdot \left(100 \cdot 0.010 \cdot 30.000 \ MPa \cdot "
+                    r"\frac{32.000 \ mm}{200.000 \ mm}\right)^{\frac{1}{3}}, \frac{0.5}{1.400} \cdot \sqrt{30.000 \ MPa}\right) = 0.868 \ MPa"
+                ),
+            ),
+            ("short", r"\tau_{Rd,c} = 0.868 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        gamma_v = 1.4
+        k_pb = 1.2
+        rho_l = 0.01
+        f_ck = 30.0
+        d_dg = 32.0
+        d_v = 200.0
+
+        # Object to test
+        latex = Form8Dot94PunchingShearStressResistance(gamma_v=gamma_v, k_pb=k_pb, rho_l=rho_l, f_ck=f_ck, d_dg=d_dg, d_v=d_v).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_95.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_95.py
@@ -1,0 +1,69 @@
+"""Testing formula 8.95 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_95 import (
+    Form8Dot95LongitudinalReinforcementRatioPunchingShear,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot95LongitudinalReinforcementRatioPunchingShear:
+    """Validation for formula 8.95 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        rho_l_x = 0.012
+        rho_l_y = 0.008
+
+        # Object to test
+        formula = Form8Dot95LongitudinalReinforcementRatioPunchingShear(rho_l_x=rho_l_x, rho_l_y=rho_l_y)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.009798  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("rho_l_x", "rho_l_y"),
+        [
+            (-0.012, 0.008),  # rho_l_x is negative
+            (0.012, -0.008),  # rho_l_y is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, rho_l_x: float, rho_l_y: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot95LongitudinalReinforcementRatioPunchingShear(rho_l_x=rho_l_x, rho_l_y=rho_l_y)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\rho_l = \sqrt{\rho_{l,x} \cdot \rho_{l,y}} = \sqrt{0.012 \cdot 0.008} = 0.010 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"\rho_l = \sqrt{\rho_{l,x} \cdot \rho_{l,y}} = \sqrt{0.012 \cdot 0.008} = 0.010 \ -",
+            ),
+            ("short", r"\rho_l = 0.010 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        rho_l_x = 0.012
+        rho_l_y = 0.008
+
+        # Object to test
+        latex = Form8Dot95LongitudinalReinforcementRatioPunchingShear(rho_l_x=rho_l_x, rho_l_y=rho_l_y).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_96.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_96.py
@@ -1,0 +1,96 @@
+"""Testing formula 8.96 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_96 import (
+    Form8Dot96PunchingShearGradientEnhancementCoefficient,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot96PunchingShearGradientEnhancementCoefficient:
+    """Validation for formula 8.96 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression governs."""
+        # Example values
+        b_0 = 1500.0
+        b_0_5 = 2400.0
+
+        # Object to test
+        formula = Form8Dot96PunchingShearGradientEnhancementCoefficient(b_0=b_0, b_0_5=b_0_5)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 2.204541  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_lower_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the lower bound of 1 governs."""
+        # Example values, with b_0 close enough to b_0_5 for the expression to fall below 1
+        formula = Form8Dot96PunchingShearGradientEnhancementCoefficient(b_0=2350.0, b_0_5=2400.0)
+
+        # Expected result, manually calculated: the expression yields 0.519615, so the lower bound governs
+        manually_calculated_result = 1.0  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_upper_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the upper bound of 2.5 governs."""
+        # Example values, with b_0 small compared to b_0_5 for the expression to exceed 2.5
+        formula = Form8Dot96PunchingShearGradientEnhancementCoefficient(b_0=100.0, b_0_5=2400.0)
+
+        # Expected result, manually calculated: the expression yields 3.524202, so the upper bound governs
+        manually_calculated_result = 2.5  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("b_0", "b_0_5"),
+        [
+            (-1500.0, 2400.0),  # b_0 is negative
+            (1500.0, -2400.0),  # b_0_5 is negative
+            (1500.0, 0.0),  # b_0_5 is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, b_0: float, b_0_5: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot96PunchingShearGradientEnhancementCoefficient(b_0=b_0, b_0_5=b_0_5)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"k_{pb} = \min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{b_0}{b_{0,5}}}, 1\right), 2.5\right) = "
+                    r"\min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{1500.000}{2400.000}}, 1\right), 2.5\right) = 2.205 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"k_{pb} = \min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{b_0}{b_{0,5}}}, 1\right), 2.5\right) = "
+                    r"\min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{1500.000 \ mm}{2400.000 \ mm}}, 1\right), 2.5\right) = 2.205 \ -"
+                ),
+            ),
+            ("short", r"k_{pb} = 2.205 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        b_0 = 1500.0
+        b_0_5 = 2400.0
+
+        # Object to test
+        latex = Form8Dot96PunchingShearGradientEnhancementCoefficient(b_0=b_0, b_0_5=b_0_5).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Summary

Adds formulas (8.94), (8.95) and (8.96) from FprEN 1992-1-1:2023 (E), clause 8.4.3(1) "Punching shear resistance of slabs without shear reinforcement", page 143-144.

- Formula (8.94): the design punching shear stress resistance, bounded from above.
- Formula (8.95): the longitudinal reinforcement ratio at the control perimeter, combined from the x- and y-direction ratios.
- Formula (8.96): the punching shear gradient enhancement coefficient, bounded both below and above.

## Decisions for the reviewer

- The printed inequality `tau_Rd,c <= 0,5/gamma_V * sqrt(f_ck)` in (8.94) is implemented as `min(...)`, and the printed range `1 <= k_pb <= 2,5` in (8.96) is implemented as `min(max(...))`. Both are assignments with a bound, not verifications, following the existing convention in this track (see e.g. formula 8.27 and Table 8.3).
- Formula (8.94) takes `rho_l` and `k_pb` as direct float inputs rather than computing them internally from (8.95) and (8.96). This matches the existing pattern in this track, where a formula takes an already-evaluated quantity from another numbered formula rather than calling that formula's class (see formula 8.27, which takes `rho_l` and `tau_rdc_min` the same way).
- The class for (8.95), `Form8Dot95LongitudinalReinforcementRatioPunchingShear`, is named to disambiguate it from `Form8Dot28LongitudinalReinforcementRatio`. Both compute a longitudinal reinforcement ratio, but from different definitions: (8.28) is `A_sl / (b_w * d)` for beam shear in 8.2.2, while (8.95) is the geometric mean of the two in-plane ratios `rho_l,x` and `rho_l,y` for punching shear in 8.4.3.
- `d_dg` and `d_v` are documented as direct inputs, referencing Formula (8.20)/(8.2.1(4)) and Formula (8.91)/(8.4.2(1)) respectively for their full definitions, consistent with how the rest of clause 8.4 handles these two quantities (see formulas 8.92 and 8.93 in open PR #1142).

## Formulas as implemented

**Formula (8.94)**, `Form8Dot94PunchingShearStressResistance`

`equation`

$$
\tau_{Rd,c} = \min\left(\frac{0.6}{\gamma_V} \cdot k_{pb} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{3}}, \frac{0.5}{\gamma_V} \cdot \sqrt{f_{ck}}\right)
$$

`complete`

$$
\tau_{Rd,c} = \min\left(\frac{0.6}{\gamma_V} \cdot k_{pb} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{3}}, \frac{0.5}{\gamma_V} \cdot \sqrt{f_{ck}}\right) = \min\left(\frac{0.6}{1.400} \cdot 1.200 \cdot \left(100 \cdot 0.010 \cdot 30.000 \cdot \frac{32.000}{200.000}\right)^{\frac{1}{3}}, \frac{0.5}{1.400} \cdot \sqrt{30.000}\right) = 0.868 \ MPa
$$

`complete_with_units`

$$
\tau_{Rd,c} = \min\left(\frac{0.6}{\gamma_V} \cdot k_{pb} \cdot \left(100 \cdot \rho_l \cdot f_{ck} \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{3}}, \frac{0.5}{\gamma_V} \cdot \sqrt{f_{ck}}\right) = \min\left(\frac{0.6}{1.400} \cdot 1.200 \cdot \left(100 \cdot 0.010 \cdot 30.000 \ MPa \cdot \frac{32.000 \ mm}{200.000 \ mm}\right)^{\frac{1}{3}}, \frac{0.5}{1.400} \cdot \sqrt{30.000 \ MPa}\right) = 0.868 \ MPa
$$

**Formula (8.95)**, `Form8Dot95LongitudinalReinforcementRatioPunchingShear`

`equation`

$$
\rho_l = \sqrt{\rho_{l,x} \cdot \rho_{l,y}}
$$

`complete`

$$
\rho_l = \sqrt{\rho_{l,x} \cdot \rho_{l,y}} = \sqrt{0.012 \cdot 0.008} = 0.010 \ -
$$

`complete_with_units`

$$
\rho_l = \sqrt{\rho_{l,x} \cdot \rho_{l,y}} = \sqrt{0.012 \cdot 0.008} = 0.010 \ -
$$

**Formula (8.96)**, `Form8Dot96PunchingShearGradientEnhancementCoefficient`

`equation`

$$
k_{pb} = \min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{b_0}{b_{0,5}}}, 1\right), 2.5\right)
$$

`complete`

$$
k_{pb} = \min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{b_0}{b_{0,5}}}, 1\right), 2.5\right) = \min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{1500.000}{2400.000}}, 1\right), 2.5\right) = 2.205 \ -
$$

`complete_with_units`

$$
k_{pb} = \min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{b_0}{b_{0,5}}}, 1\right), 2.5\right) = \min\left(\max\left(3.6 \cdot \sqrt{1 - \frac{1500.000 \ mm}{2400.000 \ mm}}, 1\right), 2.5\right) = 2.205 \ -
$$

Contributes to #1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Eurocode 2 formulas for punching shear design:
    - Shear stress resistance without shear reinforcement
    - Longitudinal reinforcement ratio
    - Punching shear gradient enhancement coefficient
  - Added numeric calculations, input validation, unit-aware results, and LaTeX representations.

- **Documentation**
  - Updated the Eurocode 2 formula tracking documentation to mark formulas 8.94–8.96 as implemented.

- **Tests**
  - Added coverage for calculations, boundary conditions, invalid inputs, and LaTeX output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->