### PR TITLE
feat: add formulas 8.97 and 8.98 from FprEN 1992-1-1:2023 clause 8.4.3

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_97.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_97.py
@@ -1,0 +1,85 @@
+"""Formula 8.97 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot97ReplacementEffectiveDepth(Formula):
+    r"""Class representing formula 8.97 for the calculation of the replacement value of the shear-resisting
+    effective depth [$d_v$] to be used in Formula (8.94), for a distance to the point of contraflexure
+    smaller than [$8 d_v$].
+    """
+
+    label = "8.97"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a_p: MM,
+        d_v: MM,
+    ) -> None:
+        r"""[$a_{pd}$] Replacement value for [$d_v$] in Formula (8.94) [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(2) - Formula (8.97)
+
+        For distances between the centre of the support area and the point of contraflexure in the
+        considered load combination [$a_p$] smaller than [$8 d_v$], the value of [$d_v$] in Formula (8.94)
+        may be replaced by [$a_{pd}$].
+
+        Parameters
+        ----------
+        a_p : MM
+            [$a_p$] Distance between the centre of the support area and the point of contraflexure in the
+            considered load combination according to Formula (8.98), see
+            Form8Dot98DistanceToPointOfContraflexure [$mm$].
+        d_v : MM
+            [$d_v$] Shear-resisting effective depth of the slab according to Formula (8.91) [$mm$].
+        """
+        super().__init__()
+        self.a_p = a_p
+        self.d_v = d_v
+
+    @staticmethod
+    def _evaluate(
+        a_p: MM,
+        d_v: MM,
+    ) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_p=a_p)
+        raise_if_less_or_equal_to_zero(d_v=d_v)
+
+        return np.sqrt((a_p / 8) * d_v)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.97."""
+        _equation: str = r"\sqrt{\frac{a_p}{8} \cdot d_v}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_p": f"{self.a_p:.{n}f}",
+                r"d_v": f"{self.d_v:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_p": rf"{self.a_p:.{n}f} \ mm",
+                r"d_v": rf"{self.d_v:.{n}f} \ mm",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"a_{pd}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_98.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_98.py
@@ -1,0 +1,103 @@
+"""Formula 8.98 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot98DistanceToPointOfContraflexure(Formula):
+    r"""Class representing formula 8.98 for the calculation of the distance between the centre of the support
+    area and the point of contraflexure.
+
+    The standard writes this as an expression bounded from below by [$d_v$], which is implemented as the
+    maximum of the two.
+    """
+
+    label = "8.98"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a_p_x: MM,
+        a_p_y: MM,
+        d_v: MM,
+    ) -> None:
+        r"""[$a_p$] Distance between the centre of the support area and the point of contraflexure in the
+        considered load combination [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(2) - Formula (8.98)
+
+        Parameters
+        ----------
+        a_p_x : MM
+            [$a_{p,x}$] Maximum distance from the centroid of the control perimeter (which may be simplified
+            according to Figure 8.21a)) to the point on the x-axis where the bending moment [$m_{Ed,x}$] is
+            zero. The distance may be calculated according to 8.4.3(3) or using a linear elastic (uncracked)
+            model. The local coordinate system [$(x,y)$] has its origin at the centre of the supporting area
+            and coincides with the reinforcement directions (principal directions in case of layers which are
+            not orthogonal). In large columns, wall ends and wall corners, the origin of the local coordinate
+            system may be placed inside the supporting area at a distance [$1,5 d_v$] from the relevant column
+            or wall face if it is more favourable [$mm$].
+        a_p_y : MM
+            [$a_{p,y}$] Maximum distance from the centroid of the control perimeter (which may be simplified
+            according to Figure 8.21a)) to the point on the y-axis where the bending moment [$m_{Ed,y}$] is
+            zero. The distance may be calculated according to 8.4.3(3) or using a linear elastic (uncracked)
+            model. The local coordinate system [$(x,y)$] has its origin at the centre of the supporting area
+            and coincides with the reinforcement directions (principal directions in case of layers which are
+            not orthogonal). In large columns, wall ends and wall corners, the origin of the local coordinate
+            system may be placed inside the supporting area at a distance [$1,5 d_v$] from the relevant column
+            or wall face if it is more favourable [$mm$].
+        d_v : MM
+            [$d_v$] Shear-resisting effective depth of the slab according to Formula (8.91) [$mm$].
+        """
+        super().__init__()
+        self.a_p_x = a_p_x
+        self.a_p_y = a_p_y
+        self.d_v = d_v
+
+    @staticmethod
+    def _evaluate(
+        a_p_x: MM,
+        a_p_y: MM,
+        d_v: MM,
+    ) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_p_x=a_p_x, a_p_y=a_p_y)
+        raise_if_less_or_equal_to_zero(d_v=d_v)
+
+        return max(np.sqrt(a_p_x * a_p_y), d_v)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.98."""
+        _equation: str = r"\max\left(\sqrt{a_{p,x} \cdot a_{p,y}}, d_v\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_{p,x}": f"{self.a_p_x:.{n}f}",
+                r"a_{p,y}": f"{self.a_p_y:.{n}f}",
+                r"d_v": f"{self.d_v:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_{p,x}": rf"{self.a_p_x:.{n}f} \ mm",
+                r"a_{p,y}": rf"{self.a_p_y:.{n}f} \ mm",
+                r"d_v": rf"{self.d_v:.{n}f} \ mm",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"a_p",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -158,8 +158,8 @@ Total of 602 formulas present.
 |      8.94      |        :x:         |         |                                                                    |
 |      8.95      |        :x:         |         |                                                                    |
 |      8.96      |        :x:         |         |                                                                    |
-|      8.97      |        :x:         |         |                                                                    |
-|      8.98      |        :x:         |         |                                                                    |
+|      8.97      | :heavy_check_mark: |         | Form8Dot97ReplacementEffectiveDepth                                 |
+|      8.98      | :heavy_check_mark: |         | Form8Dot98DistanceToPointOfContraflexure                            |
 |      8.99      |        :x:         |         |                                                                    |
 |     8.100      |        :x:         |         |                                                                    |
 |     8.101      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_97.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_97.py
@@ -1,0 +1,70 @@
+"""Testing formula 8.97 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_97 import (
+    Form8Dot97ReplacementEffectiveDepth,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot97ReplacementEffectiveDepth:
+    """Validation for formula 8.97 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_p = 800.0
+        d_v = 200.0
+
+        # Object to test
+        formula = Form8Dot97ReplacementEffectiveDepth(a_p=a_p, d_v=d_v)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 141.421356  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_p", "d_v"),
+        [
+            (-800.0, 200.0),  # a_p is negative
+            (800.0, -200.0),  # d_v is negative
+            (800.0, 0.0),  # d_v is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_p: float, d_v: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot97ReplacementEffectiveDepth(a_p=a_p, d_v=d_v)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"a_{pd} = \sqrt{\frac{a_p}{8} \cdot d_v} = \sqrt{\frac{800.000}{8} \cdot 200.000} = 141.421 \ mm",
+            ),
+            (
+                "complete_with_units",
+                r"a_{pd} = \sqrt{\frac{a_p}{8} \cdot d_v} = \sqrt{\frac{800.000 \ mm}{8} \cdot 200.000 \ mm} = 141.421 \ mm",
+            ),
+            ("short", r"a_{pd} = 141.421 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_p = 800.0
+        d_v = 200.0
+
+        # Object to test
+        latex = Form8Dot97ReplacementEffectiveDepth(a_p=a_p, d_v=d_v).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_98.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_98.py
@@ -1,0 +1,86 @@
+"""Testing formula 8.98 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_98 import (
+    Form8Dot98DistanceToPointOfContraflexure,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot98DistanceToPointOfContraflexure:
+    """Validation for formula 8.98 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression governs."""
+        # Example values
+        a_p_x = 1200.0
+        a_p_y = 800.0
+        d_v = 200.0
+
+        # Object to test
+        formula = Form8Dot98DistanceToPointOfContraflexure(a_p_x=a_p_x, a_p_y=a_p_y, d_v=d_v)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 979.795897  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_lower_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the lower bound of d_v governs."""
+        # Example values, with a_p_x and a_p_y small enough for the expression to fall below d_v
+        formula = Form8Dot98DistanceToPointOfContraflexure(a_p_x=50.0, a_p_y=80.0, d_v=200.0)
+
+        # Expected result, manually calculated: the expression yields 63.245553, so the lower bound d_v governs
+        manually_calculated_result = 200.0  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_p_x", "a_p_y", "d_v"),
+        [
+            (-1200.0, 800.0, 200.0),  # a_p_x is negative
+            (1200.0, -800.0, 200.0),  # a_p_y is negative
+            (1200.0, 800.0, -200.0),  # d_v is negative
+            (1200.0, 800.0, 0.0),  # d_v is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_p_x: float, a_p_y: float, d_v: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot98DistanceToPointOfContraflexure(a_p_x=a_p_x, a_p_y=a_p_y, d_v=d_v)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"a_p = \max\left(\sqrt{a_{p,x} \cdot a_{p,y}}, d_v\right) = \max\left(\sqrt{1200.000 \cdot 800.000}, 200.000\right) = 979.796 \ mm",
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"a_p = \max\left(\sqrt{a_{p,x} \cdot a_{p,y}}, d_v\right) = "
+                    r"\max\left(\sqrt{1200.000 \ mm \cdot 800.000 \ mm}, 200.000 \ mm\right) = 979.796 \ mm"
+                ),
+            ),
+            ("short", r"a_p = 979.796 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_p_x = 1200.0
+        a_p_y = 800.0
+        d_v = 200.0
+
+        # Object to test
+        latex = Form8Dot98DistanceToPointOfContraflexure(a_p_x=a_p_x, a_p_y=a_p_y, d_v=d_v).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Summary

Adds formulas (8.97) and (8.98) from FprEN 1992-1-1:2023 (E), clause 8.4.3(2), page 144-145. This paragraph gives the replacement for the shear-resisting effective depth [$d_v$] used in Formula (8.94), for the case where the distance to the point of contraflexure is smaller than [$8 d_v$].

- Formula (8.98): [$a_p$], the distance between the centre of the support area and the point of contraflexure, the geometric mean of the two in-plane distances [$a_{p,x}$] and [$a_{p,y}$], bounded from below by [$d_v$].
- Formula (8.97): [$a_{pd}$], the replacement value for [$d_v$] in Formula (8.94), built from [$a_p$].

## Decisions for the reviewer

- The printed inequality `a_p = sqrt(a_p,x * a_p,y) >= d_v` in (8.98) is implemented as `max(...)`, an assignment with a lower bound rather than a verification, following the existing convention in this track (see e.g. formula 8.27, Table 8.3 and formulas 8.94/8.96 from #1153).
- Formula (8.97) takes `a_p` as a direct float input rather than computing it internally from (8.98), matching the existing pattern of a formula consuming an already-evaluated quantity from another numbered formula (see formula 8.27, which takes `rho_l` the same way).
- `a_p_x` and `a_p_y` are guarded with `raise_if_negative` rather than `raise_if_less_or_equal_to_zero`: they are not denominators here, and a geometric mean of zero is a legitimate (if degenerate) result rather than an error.

## Formulas as implemented

**Formula (8.97)**, `Form8Dot97ReplacementEffectiveDepth`

`equation`

$$
a_{pd} = \sqrt{\frac{a_p}{8} \cdot d_v}
$$

`complete`

$$
a_{pd} = \sqrt{\frac{a_p}{8} \cdot d_v} = \sqrt{\frac{800.000}{8} \cdot 200.000} = 141.421 \ mm
$$

`complete_with_units`

$$
a_{pd} = \sqrt{\frac{a_p}{8} \cdot d_v} = \sqrt{\frac{800.000 \ mm}{8} \cdot 200.000 \ mm} = 141.421 \ mm
$$

**Formula (8.98)**, `Form8Dot98DistanceToPointOfContraflexure`

`equation`

$$
a_p = \max\left(\sqrt{a_{p,x} \cdot a_{p,y}}, d_v\right)
$$

`complete`

$$
a_p = \max\left(\sqrt{a_{p,x} \cdot a_{p,y}}, d_v\right) = \max\left(\sqrt{1200.000 \cdot 800.000}, 200.000\right) = 979.796 \ mm
$$

`complete_with_units`

$$
a_p = \max\left(\sqrt{a_{p,x} \cdot a_{p,y}}, d_v\right) = \max\left(\sqrt{1200.000 \ mm \cdot 800.000 \ mm}, 200.000 \ mm\right) = 979.796 \ mm
$$

Contributes to #1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Eurocode formulas 8.97 and 8.98, including effective-depth replacement and distance-to-contraflexure calculations.
  * Added validation for invalid input values and formula representations with numeric and unit-inclusive output.

* **Documentation**
  * Updated the formula tracking documentation to mark formulas 8.97 and 8.98 as implemented.

* **Tests**
  * Added coverage for calculations, validation, boundary behavior, and formatted formula output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->