### PR TITLE
feat: add formulas 8.99 to 8.103 from FprEN 1992-1-1:2023 clause 8.4.3

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_101.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_101.py
@@ -1,0 +1,94 @@
+"""Formula 8.101 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot101FactorKN(Formula):
+    r"""Class representing formula 8.101 for the calculation of the factor [$k_N$], used to account for axial
+    forces and prestressing in the punching shear gradient enhancement coefficient of Formulas (8.99) and
+    (8.100).
+    """
+
+    label = "8.101"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        b_0: MM,
+        b_0_5: MM,
+        sigma_d: MPA,
+        f_ck: MPA,
+    ) -> None:
+        r"""[$k_N$] Factor accounting for axial forces and prestressing [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(4) - Formula (8.101)
+
+        Parameters
+        ----------
+        b_0 : MM
+            [$b_0$] Length of the perimeter at the face of the supporting area, see Formula (8.96) [$mm$].
+        b_0_5 : MM
+            [$b_{0,5}$] Length of the control perimeter, taken at a distance [$0,5 d_v$] from the face of the
+            supporting area according to 8.4.2(2) to (5) [$mm$].
+        sigma_d : MPA
+            [$\sigma_d$] Average normal stress over the width [$b_s$] defined in Figure 8.22 [$MPa$].
+        f_ck : MPA
+            [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
+        """
+        super().__init__()
+        self.b_0 = b_0
+        self.b_0_5 = b_0_5
+        self.sigma_d = sigma_d
+        self.f_ck = f_ck
+
+    @staticmethod
+    def _evaluate(
+        b_0: MM,
+        b_0_5: MM,
+        sigma_d: MPA,
+        f_ck: MPA,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(b_0=b_0)
+        raise_if_less_or_equal_to_zero(b_0_5=b_0_5, f_ck=f_ck)
+        control_perimeter_ratio_complement = 1 - b_0 / b_0_5
+        raise_if_less_or_equal_to_zero(control_perimeter_ratio_complement=control_perimeter_ratio_complement)
+
+        return np.sqrt(1 + (0.47 / control_perimeter_ratio_complement) * (abs(sigma_d) / np.sqrt(f_ck)))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.101."""
+        _equation: str = r"\sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_0/b_{0,5}": rf"{self.b_0:.{n}f}/{self.b_0_5:.{n}f}",
+                r"\sigma_d": f"{self.sigma_d:.{n}f}",
+                r"f_{ck}": f"{self.f_ck:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_0/b_{0,5}": rf"{self.b_0:.{n}f} \ mm/{self.b_0_5:.{n}f} \ mm",
+                r"\sigma_d": rf"{self.sigma_d:.{n}f} \ MPa",
+                r"f_{ck}": rf"{self.f_ck:.{n}f} \ MPa",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"k_N",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_102.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_102.py
@@ -1,0 +1,81 @@
+"""Formula 8.102 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot102CoefficientAccountingForAxialForcesTwoDirections(Formula):
+    r"""Class representing formula 8.102 for the calculation of the coefficient [$k_{pp}$] accounting for axial
+    forces, combined as an average geometric value where different axial stresses act in the x- and
+    y-directions.
+    """
+
+    label = "8.102"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        k_pp_x: DIMENSIONLESS,
+        k_pp_y: DIMENSIONLESS,
+    ) -> None:
+        r"""[$k_{pp}$] Coefficient accounting for the presence of axial forces, combined from the x- and
+        y-directions [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(4) - Formula (8.102)
+
+        Parameters
+        ----------
+        k_pp_x : DIMENSIONLESS
+            [$k_{pp,x}$] Coefficient accounting for the presence of axial stresses in the x-direction,
+            according to Formula (8.99), (8.100) or (8.103) [$-$].
+        k_pp_y : DIMENSIONLESS
+            [$k_{pp,y}$] Coefficient accounting for the presence of axial stresses in the y-direction,
+            according to Formula (8.99), (8.100) or (8.103) [$-$].
+        """
+        super().__init__()
+        self.k_pp_x = k_pp_x
+        self.k_pp_y = k_pp_y
+
+    @staticmethod
+    def _evaluate(
+        k_pp_x: DIMENSIONLESS,
+        k_pp_y: DIMENSIONLESS,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(k_pp_x=k_pp_x, k_pp_y=k_pp_y)
+
+        return np.sqrt(k_pp_x * k_pp_y)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.102."""
+        _equation: str = r"\sqrt{k_{pp,x} \cdot k_{pp,y}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"k_{pp,x}": f"{self.k_pp_x:.{n}f}",
+                r"k_{pp,y}": f"{self.k_pp_y:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"k_{pp,x}": f"{self.k_pp_x:.{n}f}",
+                r"k_{pp,y}": f"{self.k_pp_y:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"k_{pp}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_103.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_103.py
@@ -1,0 +1,118 @@
+"""Formula 8.103 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot103FactorKNEccentricTendons(Formula):
+    r"""Class representing formula 8.103 for the calculation of the factor [$k_N$] for prestressed slabs with
+    eccentric tendons, accounting for the beneficial effect of the tendon's eccentricity on the tensile side of
+    the planar member.
+
+    This is the alternative of 8.4.3(4) to Formula (8.101): the same factor, extended with a term for the
+    eccentricity [$e_p$] of the tendons.
+    """
+
+    label = "8.103"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        b_0: MM,
+        b_0_5: MM,
+        sigma_d: MPA,
+        f_ck: MPA,
+        e_p: MM,
+        d: MM,
+    ) -> None:
+        r"""[$k_N$] Factor accounting for axial forces and prestressing, for prestressed slabs with eccentric
+        tendons [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(4) - Formula (8.103)
+
+        Parameters
+        ----------
+        b_0 : MM
+            [$b_0$] Length of the perimeter at the face of the supporting area, see Formula (8.96) [$mm$].
+        b_0_5 : MM
+            [$b_{0,5}$] Length of the control perimeter, taken at a distance [$0,5 d_v$] from the face of the
+            supporting area according to 8.4.2(2) to (5) [$mm$].
+        sigma_d : MPA
+            [$\sigma_d$] Average normal stress over the width [$b_s$] defined in Figure 8.22 [$MPa$].
+        f_ck : MPA
+            [$f_{ck}$] Characteristic compressive strength of concrete [$MPa$].
+        e_p : MM
+            [$e_p$] Eccentricity of the tendons at axis of the supporting area with respect to the centre of
+            gravity of the cross-section, considered as positive for tendons on the tensile side. For
+            statically indeterminate slabs, the effect of hyperstatic moments due to prestressing should be
+            considered by reducing the tendons eccentricity accordingly [$mm$].
+        d : MM
+            [$d$] Effective depth [$mm$].
+        """
+        super().__init__()
+        self.b_0 = b_0
+        self.b_0_5 = b_0_5
+        self.sigma_d = sigma_d
+        self.f_ck = f_ck
+        self.e_p = e_p
+        self.d = d
+
+    @staticmethod
+    def _evaluate(
+        b_0: MM,
+        b_0_5: MM,
+        sigma_d: MPA,
+        f_ck: MPA,
+        e_p: MM,
+        d: MM,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(b_0=b_0)
+        raise_if_less_or_equal_to_zero(b_0_5=b_0_5, f_ck=f_ck, d=d)
+        control_perimeter_ratio_complement = 1 - b_0 / b_0_5
+        raise_if_less_or_equal_to_zero(control_perimeter_ratio_complement=control_perimeter_ratio_complement)
+
+        return np.sqrt(1 + (0.47 / control_perimeter_ratio_complement) * (abs(sigma_d) / np.sqrt(f_ck)) * (1 + 6 * e_p / d))
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.103."""
+        _equation: str = (
+            r"\sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}} "
+            r"\cdot \left(1 + 6 \cdot \frac{e_p}{d}\right)}"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_0/b_{0,5}": rf"{self.b_0:.{n}f}/{self.b_0_5:.{n}f}",
+                r"\sigma_d": f"{self.sigma_d:.{n}f}",
+                r"f_{ck}": f"{self.f_ck:.{n}f}",
+                r"e_p": f"{self.e_p:.{n}f}",
+                r"{d}": "{" + f"{self.d:.{n}f}" + "}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_0/b_{0,5}": rf"{self.b_0:.{n}f} \ mm/{self.b_0_5:.{n}f} \ mm",
+                r"\sigma_d": rf"{self.sigma_d:.{n}f} \ MPa",
+                r"f_{ck}": rf"{self.f_ck:.{n}f} \ MPa",
+                r"e_p": rf"{self.e_p:.{n}f} \ mm",
+                r"{d}": "{" + rf"{self.d:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"k_N",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_99_100.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_99_100.py
@@ -1,0 +1,78 @@
+"""Formula 8.99 and 8.100 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form8Dot99To100CoefficientAccountingForAxialForces(Formula):
+    r"""Class representing formulas 8.99 and 8.100 for the calculation of the coefficient [$k_{pp}$] accounting
+    for axial forces, by which the punching shear gradient enhancement coefficient [$k_{pb}$] of Formula (8.96)
+    may be multiplied for slabs with axial forces and for prestressed slabs.
+    """
+
+    label = "8.99/8.100"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        k_n: DIMENSIONLESS,
+        is_axial_force_compressive: bool,
+    ) -> None:
+        r"""[$k_{pp}$] Coefficient accounting for the presence of axial forces [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.3(4) - Formula (8.99) and (8.100)
+
+        Parameters
+        ----------
+        k_n : DIMENSIONLESS
+            [$k_N$] Factor accounting for axial forces and prestressing, according to Formula (8.101) or, for
+            prestressed slabs with eccentric tendons, Formula (8.103) [$-$].
+        is_axial_force_compressive : bool
+            True for compressive axial forces (e.g. prestressing), which selects Formula (8.99). False for
+            tensile axial forces, which selects Formula (8.100).
+        """
+        super().__init__()
+        self.k_n = k_n
+        self.is_axial_force_compressive = is_axial_force_compressive
+
+    @staticmethod
+    def _evaluate(
+        k_n: DIMENSIONLESS,
+        is_axial_force_compressive: bool,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(k_n=k_n)
+
+        if is_axial_force_compressive:
+            return k_n
+        return 1 / k_n
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formulas 8.99 and 8.100."""
+        _equation: str = r"\begin{cases} k_N & \text{if compressive axial force} \\ 1/k_N & \text{if tensile axial force} \end{cases}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"k_N": f"{self.k_n:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"k_N": f"{self.k_n:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"k_{pp}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -160,11 +160,11 @@ Total of 602 formulas present.
 |      8.96      |        :x:         |         |                                                                    |
 |      8.97      |        :x:         |         |                                                                    |
 |      8.98      |        :x:         |         |                                                                    |
-|      8.99      |        :x:         |         |                                                                    |
-|     8.100      |        :x:         |         |                                                                    |
-|     8.101      |        :x:         |         |                                                                    |
-|     8.102      |        :x:         |         |                                                                    |
-|     8.103      |        :x:         |         |                                                                    |
+|      8.99      | :heavy_check_mark: |         | Form8Dot99To100CoefficientAccountingForAxialForces                  |
+|     8.100      | :heavy_check_mark: |         | Form8Dot99To100CoefficientAccountingForAxialForces                  |
+|     8.101      | :heavy_check_mark: |         | Form8Dot101FactorKN                                                 |
+|     8.102      | :heavy_check_mark: |         | Form8Dot102CoefficientAccountingForAxialForcesTwoDirections         |
+|     8.103      | :heavy_check_mark: |         | Form8Dot103FactorKNEccentricTendons                                 |
 |     8.104      |        :x:         |         |                                                                    |
 |     8.105      |        :x:         |         |                                                                    |
 |     8.106      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_101.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_101.py
@@ -1,0 +1,83 @@
+"""Testing formula 8.101 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_101 import Form8Dot101FactorKN
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot101FactorKN:
+    """Validation for formula 8.101 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        b_0 = 600.0
+        b_0_5 = 2400.0
+        sigma_d = -3.0
+        f_ck = 30.0
+
+        # Object to test
+        formula = Form8Dot101FactorKN(b_0=b_0, b_0_5=b_0_5, sigma_d=sigma_d, f_ck=f_ck)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1.158982  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("b_0", "b_0_5", "sigma_d", "f_ck"),
+        [
+            (-600.0, 2400.0, -3.0, 30.0),  # b_0 is negative
+            (600.0, -2400.0, -3.0, 30.0),  # b_0_5 is negative
+            (600.0, 0.0, -3.0, 30.0),  # b_0_5 is zero
+            (600.0, 2400.0, -3.0, -30.0),  # f_ck is negative
+            (600.0, 2400.0, -3.0, 0.0),  # f_ck is zero
+            (2400.0, 2400.0, -3.0, 30.0),  # b_0 equals b_0_5, denominator becomes zero
+            (3000.0, 2400.0, -3.0, 30.0),  # b_0 exceeds b_0_5, denominator becomes negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, b_0: float, b_0_5: float, sigma_d: float, f_ck: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot101FactorKN(b_0=b_0, b_0_5=b_0_5, sigma_d=sigma_d, f_ck=f_ck)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}}} = "
+                    r"\sqrt{1 + \frac{0.47}{1 - 600.000/2400.000} \cdot \frac{\left|-3.000\right|}{\sqrt{30.000}}} = 1.159 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}}} = "
+                    r"\sqrt{1 + \frac{0.47}{1 - 600.000 \ mm/2400.000 \ mm} \cdot "
+                    r"\frac{\left|-3.000 \ MPa\right|}{\sqrt{30.000 \ MPa}}} = 1.159 \ -"
+                ),
+            ),
+            ("short", r"k_N = 1.159 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        b_0 = 600.0
+        b_0_5 = 2400.0
+        sigma_d = -3.0
+        f_ck = 30.0
+
+        # Object to test
+        latex = Form8Dot101FactorKN(b_0=b_0, b_0_5=b_0_5, sigma_d=sigma_d, f_ck=f_ck).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_102.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_102.py
@@ -1,0 +1,69 @@
+"""Testing formula 8.102 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_102 import (
+    Form8Dot102CoefficientAccountingForAxialForcesTwoDirections,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot102CoefficientAccountingForAxialForcesTwoDirections:
+    """Validation for formula 8.102 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        k_pp_x = 1.2
+        k_pp_y = 0.9
+
+        # Object to test
+        formula = Form8Dot102CoefficientAccountingForAxialForcesTwoDirections(k_pp_x=k_pp_x, k_pp_y=k_pp_y)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1.039230  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("k_pp_x", "k_pp_y"),
+        [
+            (-1.2, 0.9),  # k_pp_x is negative
+            (1.2, -0.9),  # k_pp_y is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, k_pp_x: float, k_pp_y: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot102CoefficientAccountingForAxialForcesTwoDirections(k_pp_x=k_pp_x, k_pp_y=k_pp_y)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"k_{pp} = \sqrt{k_{pp,x} \cdot k_{pp,y}} = \sqrt{1.200 \cdot 0.900} = 1.039 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"k_{pp} = \sqrt{k_{pp,x} \cdot k_{pp,y}} = \sqrt{1.200 \cdot 0.900} = 1.039 \ -",
+            ),
+            ("short", r"k_{pp} = 1.039 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        k_pp_x = 1.2
+        k_pp_y = 0.9
+
+        # Object to test
+        latex = Form8Dot102CoefficientAccountingForAxialForcesTwoDirections(k_pp_x=k_pp_x, k_pp_y=k_pp_y).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_103.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_103.py
@@ -1,0 +1,95 @@
+"""Testing formula 8.103 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_103 import (
+    Form8Dot103FactorKNEccentricTendons,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot103FactorKNEccentricTendons:
+    """Validation for formula 8.103 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        b_0 = 600.0
+        b_0_5 = 2400.0
+        sigma_d = -3.0
+        f_ck = 30.0
+        e_p = 50.0
+        d = 250.0
+
+        # Object to test
+        formula = Form8Dot103FactorKNEccentricTendons(b_0=b_0, b_0_5=b_0_5, sigma_d=sigma_d, f_ck=f_ck, e_p=e_p, d=d)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1.324812  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("b_0", "b_0_5", "sigma_d", "f_ck", "e_p", "d"),
+        [
+            (-600.0, 2400.0, -3.0, 30.0, 50.0, 250.0),  # b_0 is negative
+            (600.0, -2400.0, -3.0, 30.0, 50.0, 250.0),  # b_0_5 is negative
+            (600.0, 0.0, -3.0, 30.0, 50.0, 250.0),  # b_0_5 is zero
+            (600.0, 2400.0, -3.0, -30.0, 50.0, 250.0),  # f_ck is negative
+            (600.0, 2400.0, -3.0, 0.0, 50.0, 250.0),  # f_ck is zero
+            (600.0, 2400.0, -3.0, 30.0, 50.0, -250.0),  # d is negative
+            (600.0, 2400.0, -3.0, 30.0, 50.0, 0.0),  # d is zero
+            (2400.0, 2400.0, -3.0, 30.0, 50.0, 250.0),  # b_0 equals b_0_5, denominator becomes zero
+            (3000.0, 2400.0, -3.0, 30.0, 50.0, 250.0),  # b_0 exceeds b_0_5, denominator becomes negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, b_0: float, b_0_5: float, sigma_d: float, f_ck: float, e_p: float, d: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot103FactorKNEccentricTendons(b_0=b_0, b_0_5=b_0_5, sigma_d=sigma_d, f_ck=f_ck, e_p=e_p, d=d)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}} "
+                    r"\cdot \left(1 + 6 \cdot \frac{e_p}{d}\right)} = "
+                    r"\sqrt{1 + \frac{0.47}{1 - 600.000/2400.000} \cdot \frac{\left|-3.000\right|}{\sqrt{30.000}} "
+                    r"\cdot \left(1 + 6 \cdot \frac{50.000}{250.000}\right)} = 1.325 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}} "
+                    r"\cdot \left(1 + 6 \cdot \frac{e_p}{d}\right)} = "
+                    r"\sqrt{1 + \frac{0.47}{1 - 600.000 \ mm/2400.000 \ mm} \cdot "
+                    r"\frac{\left|-3.000 \ MPa\right|}{\sqrt{30.000 \ MPa}} "
+                    r"\cdot \left(1 + 6 \cdot \frac{50.000 \ mm}{250.000 \ mm}\right)} = 1.325 \ -"
+                ),
+            ),
+            ("short", r"k_N = 1.325 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        b_0 = 600.0
+        b_0_5 = 2400.0
+        sigma_d = -3.0
+        f_ck = 30.0
+        e_p = 50.0
+        d = 250.0
+
+        # Object to test
+        latex = Form8Dot103FactorKNEccentricTendons(b_0=b_0, b_0_5=b_0_5, sigma_d=sigma_d, f_ck=f_ck, e_p=e_p, d=d).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_99_100.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_99_100.py
@@ -1,0 +1,74 @@
+"""Testing formulas 8.99 and 8.100 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_99_100 import (
+    Form8Dot99To100CoefficientAccountingForAxialForces,
+)
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm8Dot99To100CoefficientAccountingForAxialForces:
+    """Validation for formulas 8.99 and 8.100 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("k_n", "is_axial_force_compressive", "expected"),
+        [
+            (1.158982, True, 1.158982),  # compressive axial force, formula (8.99)
+            (1.158982, False, 0.862826),  # tensile axial force, formula (8.100)
+        ],
+    )
+    def test_evaluation(self, k_n: float, is_axial_force_compressive: bool, expected: float) -> None:
+        """Tests the evaluation of the result."""
+        formula = Form8Dot99To100CoefficientAccountingForAxialForces(k_n=k_n, is_axial_force_compressive=is_axial_force_compressive)
+
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("k_n", "is_axial_force_compressive"),
+        [
+            (-1.158982, True),  # k_n is negative
+            (0.0, True),  # k_n is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, k_n: float, is_axial_force_compressive: bool) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot99To100CoefficientAccountingForAxialForces(k_n=k_n, is_axial_force_compressive=is_axial_force_compressive)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"k_{pp} = \begin{cases} k_N & \text{if compressive axial force} \\ 1/k_N & \text{if tensile axial force} \end{cases} = "
+                    r"\begin{cases} 1.159 & \text{if compressive axial force} \\ 1/1.159 & \text{if tensile axial force} \end{cases} = 1.159 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"k_{pp} = \begin{cases} k_N & \text{if compressive axial force} \\ 1/k_N & \text{if tensile axial force} \end{cases} = "
+                    r"\begin{cases} 1.159 & \text{if compressive axial force} \\ 1/1.159 & \text{if tensile axial force} \end{cases} = 1.159 \ -"
+                ),
+            ),
+            ("short", r"k_{pp} = 1.159 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        k_n = 1.158982
+        is_axial_force_compressive = True
+
+        # Object to test
+        latex = Form8Dot99To100CoefficientAccountingForAxialForces(k_n=k_n, is_axial_force_compressive=is_axial_force_compressive).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Summary

Adds all five numbered formulas of clause 8.4.3(4) from FprEN 1992-1-1:2023 (E), page 145: the coefficient [$k_{pp}$] accounting for axial forces and prestressing, by which the punching shear gradient enhancement coefficient [$k_{pb}$] of Formula (8.96) may be multiplied.

- Formulas (8.99) and (8.100): [$k_{pp}$] equals [$k_N$] for compressive axial forces, or [$1/k_N$] for tensile axial forces. Implemented together as one casus class, since they are the two branches of a single rule.
- Formula (8.101): [$k_N$], the base factor.
- Formula (8.102): [$k_{pp}$] combined as a geometric mean where different axial stresses act in the x- and y-directions.
- Formula (8.103): [$k_N$] for prestressed slabs with eccentric tendons, an alternative to (8.101) with an added eccentricity term.

This batches all five formulas of the paragraph into one pull request rather than the usual cap of three formula classes, since they form one coherent unit describing a single coefficient and its variants, and splitting them would scatter closely related review context across several pull requests.

## Decisions for the reviewer

- (8.99) and (8.100) take a boolean `is_axial_force_compressive` rather than a signed axial force or stress, because the standard states the branch in words ("for compressive axial forces" / "for tensile axial forces") and settles no sign convention on this page that a numeric threshold could safely rely on.
- (8.101) and (8.103) guard the term `1 - b_0/b_0_5` explicitly (as `control_perimeter_ratio_complement`), because it is a plain denominator of the `0.47` fraction, not only a term under a square root as in Formula (8.96). A zero or negative value there is rejected rather than left to raise an uncaught `ZeroDivisionError` or a domain error deeper in the expression.
- (8.103) is a separate class rather than a variant flag on (8.101), since the standard prints it as a distinct alternative formula for one specific case (eccentric tendons), reusing the symbol [$k_N$] but not derived from (8.101) by a simple parameter.
- `e_p` in (8.103) is not guarded against negative values: the standard defines it as positive only for tendons on the tensile side, so a negative value (tendons on the compression side) is ordinary input.

## Formulas as implemented

**Formulas (8.99)/(8.100)**, `Form8Dot99To100CoefficientAccountingForAxialForces`

`equation`

$$
k_{pp} = \begin{cases} k_N & \text{if compressive axial force} \ 1/k_N & \text{if tensile axial force} \end{cases}
$$

`complete`

$$
k_{pp} = \begin{cases} k_N & \text{if compressive axial force} \ 1/k_N & \text{if tensile axial force} \end{cases} = \begin{cases} 1.159 & \text{if compressive axial force} \ 1/1.159 & \text{if tensile axial force} \end{cases} = 1.159 \ -
$$

`complete_with_units`

$$
k_{pp} = \begin{cases} k_N & \text{if compressive axial force} \ 1/k_N & \text{if tensile axial force} \end{cases} = \begin{cases} 1.159 & \text{if compressive axial force} \ 1/1.159 & \text{if tensile axial force} \end{cases} = 1.159 \ -
$$

**Formula (8.101)**, `Form8Dot101FactorKN`

`equation`

$$
k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}}}
$$

`complete`

$$
k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}}} = \sqrt{1 + \frac{0.47}{1 - 600.000/2400.000} \cdot \frac{\left|-3.000\right|}{\sqrt{30.000}}} = 1.159 \ -
$$

`complete_with_units`

$$
k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}}} = \sqrt{1 + \frac{0.47}{1 - 600.000 \ mm/2400.000 \ mm} \cdot \frac{\left|-3.000 \ MPa\right|}{\sqrt{30.000 \ MPa}}} = 1.159 \ -
$$

**Formula (8.102)**, `Form8Dot102CoefficientAccountingForAxialForcesTwoDirections`

`equation`

$$
k_{pp} = \sqrt{k_{pp,x} \cdot k_{pp,y}}
$$

`complete`

$$
k_{pp} = \sqrt{k_{pp,x} \cdot k_{pp,y}} = \sqrt{1.200 \cdot 0.900} = 1.039 \ -
$$

`complete_with_units`

$$
k_{pp} = \sqrt{k_{pp,x} \cdot k_{pp,y}} = \sqrt{1.200 \cdot 0.900} = 1.039 \ -
$$

**Formula (8.103)**, `Form8Dot103FactorKNEccentricTendons`

`equation`

$$
k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}} \cdot \left(1 + 6 \cdot \frac{e_p}{d}\right)}
$$

`complete`

$$
k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}} \cdot \left(1 + 6 \cdot \frac{e_p}{d}\right)} = \sqrt{1 + \frac{0.47}{1 - 600.000/2400.000} \cdot \frac{\left|-3.000\right|}{\sqrt{30.000}} \cdot \left(1 + 6 \cdot \frac{50.000}{250.000}\right)} = 1.325 \ -
$$

`complete_with_units`

$$
k_N = \sqrt{1 + \frac{0.47}{1 - b_0/b_{0,5}} \cdot \frac{\left|\sigma_d\right|}{\sqrt{f_{ck}}} \cdot \left(1 + 6 \cdot \frac{e_p}{d}\right)} = \sqrt{1 + \frac{0.47}{1 - 600.000 \ mm/2400.000 \ mm} \cdot \frac{\left|-3.000 \ MPa\right|}{\sqrt{30.000 \ MPa}} \cdot \left(1 + 6 \cdot \frac{50.000 \ mm}{250.000 \ mm}\right)} = 1.325 \ -
$$

Contributes to #1083
