### PR TITLE
feat: add formulas 8.104 to 8.107 from FprEN 1992-1-1:2023 clause 8.4.4

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_104.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_104.py
@@ -1,0 +1,105 @@
+"""Formula 8.104 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot104PunchingShearStressResistanceWithShearReinforcement(Formula):
+    r"""Class representing formula 8.104 for the calculation of the shear stress resistance of planar members
+    with shear reinforcement subjected to concentrated forces.
+
+    The standard writes this as an expression bounded from below by [$\rho_w \cdot f_{ywd}$], which is
+    implemented as the maximum of the two.
+    """
+
+    label = "8.104"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        eta_c: DIMENSIONLESS,
+        tau_rd_c: MPA,
+        eta_s: DIMENSIONLESS,
+        rho_w: DIMENSIONLESS,
+        f_ywd: MPA,
+    ) -> None:
+        r"""[$\tau_{Rd,cs}$] Shear stress resistance of planar members with shear reinforcement subjected to
+        concentrated forces [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.4(1) - Formula (8.104)
+
+        Parameters
+        ----------
+        eta_c : DIMENSIONLESS
+            [$\eta_c$] Strength reduction coefficient for shear resistance [$\tau_{Rd,c}$] according to
+            Formula (8.105), see Form8Dot105StrengthReductionCoefficientForShearResistance [$-$].
+        tau_rd_c : MPA
+            [$\tau_{Rd,c}$] Punching shear stress resistance of slabs without shear reinforcement according to
+            Formula (8.94) [$MPa$].
+        eta_s : DIMENSIONLESS
+            [$\eta_s$] Strength reduction coefficient for the contribution of the shear reinforcement
+            according to Formula (8.106), see Form8Dot106StrengthReductionCoefficientForShearReinforcement
+            [$-$].
+        rho_w : DIMENSIONLESS
+            [$\rho_w$] Shear reinforcement ratio at the investigated control perimeter according to
+            Formula (8.107), see Form8Dot107ShearReinforcementRatio [$-$].
+        f_ywd : MPA
+            [$f_{ywd}$] Design yield strength of the shear reinforcement [$MPa$].
+        """
+        super().__init__()
+        self.eta_c = eta_c
+        self.tau_rd_c = tau_rd_c
+        self.eta_s = eta_s
+        self.rho_w = rho_w
+        self.f_ywd = f_ywd
+
+    @staticmethod
+    def _evaluate(
+        eta_c: DIMENSIONLESS,
+        tau_rd_c: MPA,
+        eta_s: DIMENSIONLESS,
+        rho_w: DIMENSIONLESS,
+        f_ywd: MPA,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(eta_c=eta_c, tau_rd_c=tau_rd_c, eta_s=eta_s, rho_w=rho_w, f_ywd=f_ywd)
+
+        return max(eta_c * tau_rd_c + eta_s * rho_w * f_ywd, rho_w * f_ywd)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.104."""
+        _equation: str = r"\max\left(\eta_c \cdot \tau_{Rd,c} + \eta_s \cdot \rho_w \cdot f_{ywd}, \rho_w \cdot f_{ywd}\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\eta_c": f"{self.eta_c:.{n}f}",
+                r"\tau_{Rd,c}": f"{self.tau_rd_c:.{n}f}",
+                r"\eta_s": f"{self.eta_s:.{n}f}",
+                r"\rho_w": f"{self.rho_w:.{n}f}",
+                r"f_{ywd}": f"{self.f_ywd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\eta_c": f"{self.eta_c:.{n}f}",
+                r"\tau_{Rd,c}": rf"{self.tau_rd_c:.{n}f} \ MPa",
+                r"\eta_s": f"{self.eta_s:.{n}f}",
+                r"\rho_w": f"{self.rho_w:.{n}f}",
+                r"f_{ywd}": rf"{self.f_ywd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rd,cs}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_105.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_105.py
@@ -1,0 +1,78 @@
+"""Formula 8.105 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot105StrengthReductionCoefficientForShearResistance(Formula):
+    r"""Class representing formula 8.105 for the calculation of the strength reduction coefficient for the
+    shear resistance [$\tau_{Rd,c}$].
+    """
+
+    label = "8.105"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        tau_rd_c: MPA,
+        tau_ed: MPA,
+    ) -> None:
+        r"""[$\eta_c$] Strength reduction coefficient for shear resistance [$\tau_{Rd,c}$] [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.4(1) - Formula (8.105)
+
+        Parameters
+        ----------
+        tau_rd_c : MPA
+            [$\tau_{Rd,c}$] Punching shear stress resistance of slabs without shear reinforcement according to
+            Formula (8.94) [$MPa$].
+        tau_ed : MPA
+            [$\tau_{Ed}$] Design punching shear stress at the control perimeter, according to Formula (8.92)
+            or (8.93) [$MPa$].
+        """
+        super().__init__()
+        self.tau_rd_c = tau_rd_c
+        self.tau_ed = tau_ed
+
+    @staticmethod
+    def _evaluate(
+        tau_rd_c: MPA,
+        tau_ed: MPA,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(tau_rd_c=tau_rd_c)
+        raise_if_less_or_equal_to_zero(tau_ed=tau_ed)
+
+        return tau_rd_c / tau_ed
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.105."""
+        _equation: str = r"\frac{\tau_{Rd,c}}{\tau_{Ed}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Rd,c}": f"{self.tau_rd_c:.{n}f}",
+                r"\tau_{Ed}": f"{self.tau_ed:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\tau_{Rd,c}": rf"{self.tau_rd_c:.{n}f} \ MPa",
+                r"\tau_{Ed}": rf"{self.tau_ed:.{n}f} \ MPa",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\eta_c",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_106.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_106.py
@@ -1,0 +1,114 @@
+"""Formula 8.106 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot106StrengthReductionCoefficientForShearReinforcement(Formula):
+    r"""Class representing formula 8.106 for the calculation of the strength reduction coefficient for the
+    contribution of the shear reinforcement.
+
+    The standard writes this as an expression bounded from above by [$0,8$], which is implemented as a
+    minimum.
+    """
+
+    label = "8.106"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        d_v: MM,
+        phi_w: MM,
+        d_dg: MM,
+        eta_c: DIMENSIONLESS,
+        k_pb: DIMENSIONLESS,
+    ) -> None:
+        r"""[$\eta_s$] Strength reduction coefficient for the contribution of the shear reinforcement [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.4(1) - Formula (8.106)
+
+        Parameters
+        ----------
+        d_v : MM
+            [$d_v$] Shear-resisting effective depth of the slab according to Formula (8.91) [$mm$].
+        phi_w : MM
+            [$\phi_w$] Diameter of the punching shear reinforcement [$mm$].
+        d_dg : MM
+            [$d_{dg}$] Size parameter describing the failure zone roughness, which depends on the concrete type
+            and its aggregate properties. The standard gives it as [$16 + D_{lower} \leq 40$] for concrete with
+            [$f_{ck} \leq 60$] MPa, and as [$16 + D_{lower} \cdot \left(60/f_{ck}\right)^2 \leq 40$] for concrete
+            with [$f_{ck} > 60$] MPa, both in millimetres. [$D_{lower}$] is the smallest value of the upper sieve
+            size [$D$] in an aggregate for the coarsest fraction of aggregates in the concrete permitted by the
+            specification of concrete according to EN 206; where [$D_{max}$] is known it may replace
+            [$D_{lower}$], see the NOTE 2 to 8.2.1(4) [$mm$].
+        eta_c : DIMENSIONLESS
+            [$\eta_c$] Strength reduction coefficient for shear resistance [$\tau_{Rd,c}$] according to
+            Formula (8.105), see Form8Dot105StrengthReductionCoefficientForShearResistance [$-$].
+        k_pb : DIMENSIONLESS
+            [$k_{pb}$] Punching shear gradient enhancement coefficient according to Formula (8.96), see
+            Form8Dot96PunchingShearGradientEnhancementCoefficient [$-$].
+        """
+        super().__init__()
+        self.d_v = d_v
+        self.phi_w = phi_w
+        self.d_dg = d_dg
+        self.eta_c = eta_c
+        self.k_pb = k_pb
+
+    @staticmethod
+    def _evaluate(
+        d_v: MM,
+        phi_w: MM,
+        d_dg: MM,
+        eta_c: DIMENSIONLESS,
+        k_pb: DIMENSIONLESS,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(d_dg=d_dg)
+        raise_if_less_or_equal_to_zero(d_v=d_v, phi_w=phi_w, eta_c=eta_c, k_pb=k_pb)
+
+        return min(
+            d_v / (150 * phi_w) + (15 * d_dg / d_v) ** (1 / 2) * (1 / (eta_c * k_pb)) ** (3 / 2),
+            0.8,
+        )
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.106."""
+        _equation: str = (
+            r"\min\left(\frac{d_v}{150 \cdot \phi_w} + \left(15 \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{2}} \cdot "
+            r"\left(\frac{1}{\eta_c \cdot k_{pb}}\right)^{\frac{3}{2}}, 0.8\right)"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\phi_w": f"{self.phi_w:.{n}f}",
+                r"d_{dg}": f"{self.d_dg:.{n}f}",
+                r"d_v": f"{self.d_v:.{n}f}",
+                r"\eta_c": f"{self.eta_c:.{n}f}",
+                r"k_{pb}": f"{self.k_pb:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\phi_w": rf"{self.phi_w:.{n}f} \ mm",
+                r"d_{dg}": rf"{self.d_dg:.{n}f} \ mm",
+                r"d_v": rf"{self.d_v:.{n}f} \ mm",
+                r"\eta_c": f"{self.eta_c:.{n}f}",
+                r"k_{pb}": f"{self.k_pb:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\eta_s",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_107.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_107.py
@@ -1,0 +1,86 @@
+"""Formula 8.107 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM, MM2
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot107ShearReinforcementRatio(Formula):
+    r"""Class representing formula 8.107 for the calculation of the shear reinforcement ratio at the
+    investigated control perimeter.
+    """
+
+    label = "8.107"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a_sw: MM2,
+        s_r: MM,
+        s_t: MM,
+    ) -> None:
+        r"""[$\rho_w$] Shear reinforcement ratio at the investigated control perimeter [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.4(1) - Formula (8.107)
+
+        Parameters
+        ----------
+        a_sw : MM2
+            [$A_{sw}$] Area of one leg of shear reinforcement [$mm^2$].
+        s_r : MM
+            [$s_r$] Radial spacing of shear reinforcement, [$s_r = \max(s_0 + s_1/2; s_1)$] where [$s_0$] and
+            [$s_1$] are defined in Figure 8.23 a) and should comply with 12.5.1 [$mm$].
+        s_t : MM
+            [$s_t$] Average tangential spacing of perimeters of shear reinforcement measured at the
+            investigated control perimeter, the length of the investigated control perimeter divided by the
+            number of shear reinforcement bars arranged on it or near to it [$mm$].
+        """
+        super().__init__()
+        self.a_sw = a_sw
+        self.s_r = s_r
+        self.s_t = s_t
+
+    @staticmethod
+    def _evaluate(
+        a_sw: MM2,
+        s_r: MM,
+        s_t: MM,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_sw=a_sw)
+        raise_if_less_or_equal_to_zero(s_r=s_r, s_t=s_t)
+
+        return a_sw / (s_r * s_t)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.107."""
+        _equation: str = r"\frac{A_{sw}}{s_r \cdot s_t}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_{sw}": f"{self.a_sw:.{n}f}",
+                r"s_r": f"{self.s_r:.{n}f}",
+                r"s_t": f"{self.s_t:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_{sw}": rf"{self.a_sw:.{n}f} \ mm^2",
+                r"s_r": rf"{self.s_r:.{n}f} \ mm",
+                r"s_t": rf"{self.s_t:.{n}f} \ mm",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\rho_w",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -165,10 +165,10 @@ Total of 602 formulas present.
 |     8.101      |        :x:         |         |                                                                    |
 |     8.102      |        :x:         |         |                                                                    |
 |     8.103      |        :x:         |         |                                                                    |
-|     8.104      |        :x:         |         |                                                                    |
-|     8.105      |        :x:         |         |                                                                    |
-|     8.106      |        :x:         |         |                                                                    |
-|     8.107      |        :x:         |         |                                                                    |
+|     8.104      | :heavy_check_mark: |         | Form8Dot104PunchingShearStressResistanceWithShearReinforcement     |
+|     8.105      | :heavy_check_mark: |         | Form8Dot105StrengthReductionCoefficientForShearResistance          |
+|     8.106      | :heavy_check_mark: |         | Form8Dot106StrengthReductionCoefficientForShearReinforcement       |
+|     8.107      | :heavy_check_mark: |         | Form8Dot107ShearReinforcementRatio                                  |
 |     8.108      |        :x:         |         |                                                                    |
 |     8.109      |        :x:         |         |                                                                    |
 |     8.110      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_104.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_104.py
@@ -1,0 +1,98 @@
+"""Testing formula 8.104 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_104 import (
+    Form8Dot104PunchingShearStressResistanceWithShearReinforcement,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot104PunchingShearStressResistanceWithShearReinforcement:
+    """Validation for formula 8.104 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression governs."""
+        # Example values
+        eta_c = 0.725
+        tau_rd_c = 0.87
+        eta_s = 0.763536
+        rho_w = 0.002617
+        f_ywd = 435.0
+
+        # Object to test
+        formula = Form8Dot104PunchingShearStressResistanceWithShearReinforcement(
+            eta_c=eta_c, tau_rd_c=tau_rd_c, eta_s=eta_s, rho_w=rho_w, f_ywd=f_ywd
+        )
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1.499956  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_lower_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the lower bound of rho_w * f_ywd governs."""
+        # Example values, with eta_c and eta_s small enough for the expression to fall below the bound
+        formula = Form8Dot104PunchingShearStressResistanceWithShearReinforcement(eta_c=0.01, tau_rd_c=0.87, eta_s=0.01, rho_w=0.002617, f_ywd=435.0)
+
+        # Expected result, manually calculated: the expression yields 0.020084, so the bound rho_w * f_ywd governs
+        manually_calculated_result = 1.138395  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("eta_c", "tau_rd_c", "eta_s", "rho_w", "f_ywd"),
+        [
+            (-0.725, 0.87, 0.763536, 0.002617, 435.0),  # eta_c is negative
+            (0.725, -0.87, 0.763536, 0.002617, 435.0),  # tau_rd_c is negative
+            (0.725, 0.87, -0.763536, 0.002617, 435.0),  # eta_s is negative
+            (0.725, 0.87, 0.763536, -0.002617, 435.0),  # rho_w is negative
+            (0.725, 0.87, 0.763536, 0.002617, -435.0),  # f_ywd is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, eta_c: float, tau_rd_c: float, eta_s: float, rho_w: float, f_ywd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot104PunchingShearStressResistanceWithShearReinforcement(eta_c=eta_c, tau_rd_c=tau_rd_c, eta_s=eta_s, rho_w=rho_w, f_ywd=f_ywd)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\tau_{Rd,cs} = \max\left(\eta_c \cdot \tau_{Rd,c} + \eta_s \cdot \rho_w \cdot f_{ywd}, \rho_w \cdot f_{ywd}\right) = "
+                    r"\max\left(0.725 \cdot 0.870 + 0.764 \cdot 0.003 \cdot 435.000, 0.003 \cdot 435.000\right) = 1.500 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\tau_{Rd,cs} = \max\left(\eta_c \cdot \tau_{Rd,c} + \eta_s \cdot \rho_w \cdot f_{ywd}, \rho_w \cdot f_{ywd}\right) = "
+                    r"\max\left(0.725 \cdot 0.870 \ MPa + 0.764 \cdot 0.003 \cdot 435.000 \ MPa, 0.003 \cdot 435.000 \ MPa\right) = 1.500 \ MPa"
+                ),
+            ),
+            ("short", r"\tau_{Rd,cs} = 1.500 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        eta_c = 0.725
+        tau_rd_c = 0.87
+        eta_s = 0.763536
+        rho_w = 0.002617
+        f_ywd = 435.0
+
+        # Object to test
+        latex = Form8Dot104PunchingShearStressResistanceWithShearReinforcement(
+            eta_c=eta_c, tau_rd_c=tau_rd_c, eta_s=eta_s, rho_w=rho_w, f_ywd=f_ywd
+        ).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_105.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_105.py
@@ -1,0 +1,70 @@
+"""Testing formula 8.105 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_105 import (
+    Form8Dot105StrengthReductionCoefficientForShearResistance,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot105StrengthReductionCoefficientForShearResistance:
+    """Validation for formula 8.105 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        tau_rd_c = 0.87
+        tau_ed = 1.2
+
+        # Object to test
+        formula = Form8Dot105StrengthReductionCoefficientForShearResistance(tau_rd_c=tau_rd_c, tau_ed=tau_ed)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.725  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("tau_rd_c", "tau_ed"),
+        [
+            (-0.87, 1.2),  # tau_rd_c is negative
+            (0.87, -1.2),  # tau_ed is negative
+            (0.87, 0.0),  # tau_ed is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, tau_rd_c: float, tau_ed: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot105StrengthReductionCoefficientForShearResistance(tau_rd_c=tau_rd_c, tau_ed=tau_ed)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\eta_c = \frac{\tau_{Rd,c}}{\tau_{Ed}} = \frac{0.870}{1.200} = 0.725 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"\eta_c = \frac{\tau_{Rd,c}}{\tau_{Ed}} = \frac{0.870 \ MPa}{1.200 \ MPa} = 0.725 \ -",
+            ),
+            ("short", r"\eta_c = 0.725 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        tau_rd_c = 0.87
+        tau_ed = 1.2
+
+        # Object to test
+        latex = Form8Dot105StrengthReductionCoefficientForShearResistance(tau_rd_c=tau_rd_c, tau_ed=tau_ed).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_106.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_106.py
@@ -1,0 +1,103 @@
+"""Testing formula 8.106 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_106 import (
+    Form8Dot106StrengthReductionCoefficientForShearReinforcement,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot106StrengthReductionCoefficientForShearReinforcement:
+    """Validation for formula 8.106 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result when the expression governs."""
+        # Example values
+        d_v = 250.0
+        phi_w = 12.0
+        d_dg = 16.0
+        eta_c = 0.9
+        k_pb = 1.5
+
+        # Object to test
+        formula = Form8Dot106StrengthReductionCoefficientForShearReinforcement(d_v=d_v, phi_w=phi_w, d_dg=d_dg, eta_c=eta_c, k_pb=k_pb)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.763536  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_when_the_upper_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the upper bound of 0.8 governs."""
+        # Example values, with a small d_v and phi_w and a small eta_c * k_pb for the expression to exceed 0.8
+        formula = Form8Dot106StrengthReductionCoefficientForShearReinforcement(d_v=50.0, phi_w=6.0, d_dg=32.0, eta_c=0.3, k_pb=1.0)
+
+        # Expected result, manually calculated: the expression yields 18.911736, so the upper bound of 0.8 governs
+        manually_calculated_result = 0.8  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("d_v", "phi_w", "d_dg", "eta_c", "k_pb"),
+        [
+            (-250.0, 12.0, 16.0, 0.9, 1.5),  # d_v is negative
+            (0.0, 12.0, 16.0, 0.9, 1.5),  # d_v is zero
+            (250.0, -12.0, 16.0, 0.9, 1.5),  # phi_w is negative
+            (250.0, 0.0, 16.0, 0.9, 1.5),  # phi_w is zero
+            (250.0, 12.0, -16.0, 0.9, 1.5),  # d_dg is negative
+            (250.0, 12.0, 16.0, -0.9, 1.5),  # eta_c is negative
+            (250.0, 12.0, 16.0, 0.0, 1.5),  # eta_c is zero
+            (250.0, 12.0, 16.0, 0.9, -1.5),  # k_pb is negative
+            (250.0, 12.0, 16.0, 0.9, 0.0),  # k_pb is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, d_v: float, phi_w: float, d_dg: float, eta_c: float, k_pb: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot106StrengthReductionCoefficientForShearReinforcement(d_v=d_v, phi_w=phi_w, d_dg=d_dg, eta_c=eta_c, k_pb=k_pb)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\eta_s = \min\left(\frac{d_v}{150 \cdot \phi_w} + \left(15 \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{2}} \cdot "
+                    r"\left(\frac{1}{\eta_c \cdot k_{pb}}\right)^{\frac{3}{2}}, 0.8\right) = "
+                    r"\min\left(\frac{250.000}{150 \cdot 12.000} + \left(15 \cdot \frac{16.000}{250.000}\right)^{\frac{1}{2}} \cdot "
+                    r"\left(\frac{1}{0.900 \cdot 1.500}\right)^{\frac{3}{2}}, 0.8\right) = 0.764 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\eta_s = \min\left(\frac{d_v}{150 \cdot \phi_w} + \left(15 \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{2}} \cdot "
+                    r"\left(\frac{1}{\eta_c \cdot k_{pb}}\right)^{\frac{3}{2}}, 0.8\right) = "
+                    r"\min\left(\frac{250.000 \ mm}{150 \cdot 12.000 \ mm} + "
+                    r"\left(15 \cdot \frac{16.000 \ mm}{250.000 \ mm}\right)^{\frac{1}{2}} \cdot "
+                    r"\left(\frac{1}{0.900 \cdot 1.500}\right)^{\frac{3}{2}}, 0.8\right) = 0.764 \ -"
+                ),
+            ),
+            ("short", r"\eta_s = 0.764 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        d_v = 250.0
+        phi_w = 12.0
+        d_dg = 16.0
+        eta_c = 0.9
+        k_pb = 1.5
+
+        # Object to test
+        latex = Form8Dot106StrengthReductionCoefficientForShearReinforcement(d_v=d_v, phi_w=phi_w, d_dg=d_dg, eta_c=eta_c, k_pb=k_pb).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_107.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_107.py
@@ -1,0 +1,72 @@
+"""Testing formula 8.107 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_107 import Form8Dot107ShearReinforcementRatio
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot107ShearReinforcementRatio:
+    """Validation for formula 8.107 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_sw = 78.5
+        s_r = 150.0
+        s_t = 200.0
+
+        # Object to test
+        formula = Form8Dot107ShearReinforcementRatio(a_sw=a_sw, s_r=s_r, s_t=s_t)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 0.0026167  # -
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_sw", "s_r", "s_t"),
+        [
+            (-78.5, 150.0, 200.0),  # a_sw is negative
+            (78.5, -150.0, 200.0),  # s_r is negative
+            (78.5, 0.0, 200.0),  # s_r is zero
+            (78.5, 150.0, -200.0),  # s_t is negative
+            (78.5, 150.0, 0.0),  # s_t is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_sw: float, s_r: float, s_t: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot107ShearReinforcementRatio(a_sw=a_sw, s_r=s_r, s_t=s_t)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\rho_w = \frac{A_{sw}}{s_r \cdot s_t} = \frac{78.500}{150.000 \cdot 200.000} = 0.003 \ -",
+            ),
+            (
+                "complete_with_units",
+                r"\rho_w = \frac{A_{sw}}{s_r \cdot s_t} = \frac{78.500 \ mm^2}{150.000 \ mm \cdot 200.000 \ mm} = 0.003 \ -",
+            ),
+            ("short", r"\rho_w = 0.003 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_sw = 78.5
+        s_r = 150.0
+        s_t = 200.0
+
+        # Object to test
+        latex = Form8Dot107ShearReinforcementRatio(a_sw=a_sw, s_r=s_r, s_t=s_t).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Summary

Adds all four numbered formulas of clause 8.4.4(1) from FprEN 1992-1-1:2023 (E), page 146: the shear stress resistance of planar members with shear reinforcement subjected to concentrated forces.

- Formula (8.104): [$\tau_{Rd,cs}$], the combined resistance from the concrete term and the shear reinforcement term, bounded from below by the shear reinforcement term alone.
- Formula (8.105): [$\eta_c$], the strength reduction coefficient for the shear resistance [$\tau_{Rd,c}$].
- Formula (8.106): [$\eta_s$], the strength reduction coefficient for the contribution of the shear reinforcement, bounded from above by 0,8.
- Formula (8.107): [$\rho_w$], the shear reinforcement ratio at the investigated control perimeter.

This batches all four formulas of the paragraph into one pull request rather than the usual cap of three formula classes, since they form one coherent unit: the main resistance formula and the three coefficients it is built from, all printed together on a single page.

## Decisions for the reviewer

- (8.104) prints a lower bound [$\geq \rho_w \cdot f_{ywd}$], implemented as `max(...)`, following the existing convention in this track for an assignment with a bound rather than a verification.
- (8.106) prints an upper bound of 0,8, implemented as `min(...)`.
- (8.106) guards [$\eta_c \cdot k_{pb}$] and [$d_v$] as denominators (the term is raised to the power 3/2, so both factors of the product must be strictly positive), even though the standard states no explicit range for [$\eta_c$] on this page.
- [$\phi_w$] (diameter of the punching shear reinforcement) is not defined in the "where" list of this clause. Its description is copied from the standard's own symbol list (3.2 Symbols and abbreviations, Greek lower-case letters), where it reads "Diameter of punching shear reinforcement".
- [$\tau_{Ed}$] in (8.105) is documented as the design punching shear stress according to Formula (8.92) or (8.93), matching how the same quantity is described in the already-open pull request for clause 8.4.2.

## Formulas as implemented

**Formula (8.104)**, `Form8Dot104PunchingShearStressResistanceWithShearReinforcement`

`equation`

$$
\tau_{Rd,cs} = \max\left(\eta_c \cdot \tau_{Rd,c} + \eta_s \cdot \rho_w \cdot f_{ywd}, \rho_w \cdot f_{ywd}\right)
$$

`complete`

$$
\tau_{Rd,cs} = \max\left(\eta_c \cdot \tau_{Rd,c} + \eta_s \cdot \rho_w \cdot f_{ywd}, \rho_w \cdot f_{ywd}\right) = \max\left(0.725 \cdot 0.870 + 0.764 \cdot 0.003 \cdot 435.000, 0.003 \cdot 435.000\right) = 1.500 \ MPa
$$

`complete_with_units`

$$
\tau_{Rd,cs} = \max\left(\eta_c \cdot \tau_{Rd,c} + \eta_s \cdot \rho_w \cdot f_{ywd}, \rho_w \cdot f_{ywd}\right) = \max\left(0.725 \cdot 0.870 \ MPa + 0.764 \cdot 0.003 \cdot 435.000 \ MPa, 0.003 \cdot 435.000 \ MPa\right) = 1.500 \ MPa
$$

**Formula (8.105)**, `Form8Dot105StrengthReductionCoefficientForShearResistance`

`equation`

$$
\eta_c = \frac{\tau_{Rd,c}}{\tau_{Ed}}
$$

`complete`

$$
\eta_c = \frac{\tau_{Rd,c}}{\tau_{Ed}} = \frac{0.870}{1.200} = 0.725 \ -
$$

`complete_with_units`

$$
\eta_c = \frac{\tau_{Rd,c}}{\tau_{Ed}} = \frac{0.870 \ MPa}{1.200 \ MPa} = 0.725 \ -
$$

**Formula (8.106)**, `Form8Dot106StrengthReductionCoefficientForShearReinforcement`

`equation`

$$
\eta_s = \min\left(\frac{d_v}{150 \cdot \phi_w} + \left(15 \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{2}} \cdot \left(\frac{1}{\eta_c \cdot k_{pb}}\right)^{\frac{3}{2}}, 0.8\right)
$$

`complete`

$$
\eta_s = \min\left(\frac{d_v}{150 \cdot \phi_w} + \left(15 \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{2}} \cdot \left(\frac{1}{\eta_c \cdot k_{pb}}\right)^{\frac{3}{2}}, 0.8\right) = \min\left(\frac{250.000}{150 \cdot 12.000} + \left(15 \cdot \frac{16.000}{250.000}\right)^{\frac{1}{2}} \cdot \left(\frac{1}{0.900 \cdot 1.500}\right)^{\frac{3}{2}}, 0.8\right) = 0.764 \ -
$$

`complete_with_units`

$$
\eta_s = \min\left(\frac{d_v}{150 \cdot \phi_w} + \left(15 \cdot \frac{d_{dg}}{d_v}\right)^{\frac{1}{2}} \cdot \left(\frac{1}{\eta_c \cdot k_{pb}}\right)^{\frac{3}{2}}, 0.8\right) = \min\left(\frac{250.000 \ mm}{150 \cdot 12.000 \ mm} + \left(15 \cdot \frac{16.000 \ mm}{250.000 \ mm}\right)^{\frac{1}{2}} \cdot \left(\frac{1}{0.900 \cdot 1.500}\right)^{\frac{3}{2}}, 0.8\right) = 0.764 \ -
$$

**Formula (8.107)**, `Form8Dot107ShearReinforcementRatio`

`equation`

$$
\rho_w = \frac{A_{sw}}{s_r \cdot s_t}
$$

`complete`

$$
\rho_w = \frac{A_{sw}}{s_r \cdot s_t} = \frac{78.500}{150.000 \cdot 200.000} = 0.003 \ -
$$

`complete_with_units`

$$
\rho_w = \frac{A_{sw}}{s_r \cdot s_t} = \frac{78.500 \ mm^2}{150.000 \ mm \cdot 200.000 \ mm} = 0.003 \ -
$$

Contributes to #1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2 formulas 8.104–8.107 for punching shear resistance, strength reduction coefficients, and shear reinforcement ratio calculations.
  * Added symbolic, numerical, and unit-aware formula representations.
* **Documentation**
  * Updated the formula tracking table to mark formulas 8.104–8.107 as implemented.
* **Tests**
  * Added coverage for calculations, validation rules, bounds, and formula representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->