### PR TITLE
feat: add formulas 8.108 to 8.111 from FprEN 1992-1-1:2023 clause 8.4.4

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_108.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_108.py
@@ -1,0 +1,83 @@
+"""Formula 8.108 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot108ShearResistingEffectiveDepthOuterShearReinforcement(Formula):
+    r"""Class representing formula 8.108 for the calculation of the shear-resisting effective depth of the
+    outer shear reinforcement.
+    """
+
+    label = "8.108"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        d_x: MM,
+        d_y: MM,
+        c_v: MM,
+    ) -> None:
+        r"""[$d_{v,out}$] Shear-resisting effective depth of the outer shear reinforcement, see 8.4.4(4) [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.4(4), NOTE - Formula (8.108)
+
+        Parameters
+        ----------
+        d_x : MM
+            [$d_x$] Effective depth in the x direction [$mm$].
+        d_y : MM
+            [$d_y$] Effective depth in the y direction [$mm$].
+        c_v : MM
+            [$c_v$] Distance defined in Figure 8.23, unless the National Annex gives a different value [$mm$].
+        """
+        super().__init__()
+        self.d_x = d_x
+        self.d_y = d_y
+        self.c_v = c_v
+
+    @staticmethod
+    def _evaluate(
+        d_x: MM,
+        d_y: MM,
+        c_v: MM,
+    ) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(d_x=d_x, d_y=d_y)
+        raise_if_negative(c_v=c_v)
+
+        return (d_x + d_y) / 2 - c_v
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.108."""
+        _equation: str = r"\frac{d_x + d_y}{2} - c_v"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"d_x": f"{self.d_x:.{n}f}",
+                r"d_y": f"{self.d_y:.{n}f}",
+                r"c_v": f"{self.c_v:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"d_x": rf"{self.d_x:.{n}f} \ mm",
+                r"d_y": rf"{self.d_y:.{n}f} \ mm",
+                r"c_v": rf"{self.c_v:.{n}f} \ mm",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"d_{v,out}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_109.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_109.py
@@ -1,0 +1,76 @@
+"""Formula 8.109 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot109MaximumPunchingShearResistance(Formula):
+    r"""Class representing formula 8.109 for the calculation of the maximum punching shear resistance."""
+
+    label = "8.109"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        eta_sys: DIMENSIONLESS,
+        tau_rd_c: MPA,
+    ) -> None:
+        r"""[$\tau_{Rd,max}$] Maximum punching shear resistance [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.4(5) - Formula (8.109)
+
+        Parameters
+        ----------
+        eta_sys : DIMENSIONLESS
+            [$\eta_{sys}$] Coefficient accounting for the performance of punching shear reinforcing systems,
+            according to Formula (8.110) or (8.111), see
+            Form8Dot110To111CoefficientForPunchingShearReinforcingSystem [$-$].
+        tau_rd_c : MPA
+            [$\tau_{Rd,c}$] Punching shear stress resistance of slabs without shear reinforcement according to
+            Formula (8.94) [$MPa$].
+        """
+        super().__init__()
+        self.eta_sys = eta_sys
+        self.tau_rd_c = tau_rd_c
+
+    @staticmethod
+    def _evaluate(
+        eta_sys: DIMENSIONLESS,
+        tau_rd_c: MPA,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(eta_sys=eta_sys, tau_rd_c=tau_rd_c)
+
+        return eta_sys * tau_rd_c
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.109."""
+        _equation: str = r"\eta_{sys} \cdot \tau_{Rd,c}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\eta_{sys}": f"{self.eta_sys:.{n}f}",
+                r"\tau_{Rd,c}": f"{self.tau_rd_c:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\eta_{sys}": f"{self.eta_sys:.{n}f}",
+                r"\tau_{Rd,c}": rf"{self.tau_rd_c:.{n}f} \ MPa",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\tau_{Rd,max}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_110_111.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_110_111.py
@@ -1,0 +1,92 @@
+"""Formula 8.110 and 8.111 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot110To111CoefficientForPunchingShearReinforcingSystem(Formula):
+    r"""Class representing formulas 8.110 and 8.111 for the calculation of the coefficient [$\eta_{sys}$]
+    accounting for the performance of punching shear reinforcing systems, unless the National Annex gives
+    different values.
+
+    The standard writes each branch as an expression bounded from below by [$1,0$], which is implemented as
+    the maximum of the two.
+    """
+
+    label = "8.110/8.111"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        b_0: MM,
+        d_v: MM,
+        is_stud: bool,
+    ) -> None:
+        r"""[$\eta_{sys}$] Coefficient accounting for the performance of punching shear reinforcing systems
+        [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.4(5), NOTE - Formula (8.110) and (8.111)
+
+        Parameters
+        ----------
+        b_0 : MM
+            [$b_0$] Length of the perimeter at the face of the supporting area, see Formula (8.96) [$mm$].
+        d_v : MM
+            [$d_v$] Shear-resisting effective depth of the slab according to Formula (8.91) [$mm$].
+        is_stud : bool
+            True for shear reinforcement in the form of studs, which selects Formula (8.110). False for shear
+            reinforcement in the form of links and stirrups, which selects Formula (8.111).
+        """
+        super().__init__()
+        self.b_0 = b_0
+        self.d_v = d_v
+        self.is_stud = is_stud
+
+    @staticmethod
+    def _evaluate(
+        b_0: MM,
+        d_v: MM,
+        is_stud: bool,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(b_0=b_0)
+        raise_if_less_or_equal_to_zero(d_v=d_v)
+
+        base = 0.70 if is_stud else 0.50
+        return max(base + 0.63 * (b_0 / d_v) ** (1 / 4), 1.0)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formulas 8.110 and 8.111."""
+        _equation: str = (
+            r"\begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & "
+            r"\text{if studs} \\ \max\left(0.50 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & "
+            r"\text{if links and stirrups} \end{cases}"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_0": f"{self.b_0:.{n}f}",
+                r"d_v": f"{self.d_v:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_0": rf"{self.b_0:.{n}f} \ mm",
+                r"d_v": rf"{self.d_v:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\eta_{sys}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -169,10 +169,10 @@ Total of 602 formulas present.
 |     8.105      |        :x:         |         |                                                                    |
 |     8.106      |        :x:         |         |                                                                    |
 |     8.107      |        :x:         |         |                                                                    |
-|     8.108      |        :x:         |         |                                                                    |
-|     8.109      |        :x:         |         |                                                                    |
-|     8.110      |        :x:         |         |                                                                    |
-|     8.111      |        :x:         |         |                                                                    |
+|     8.108      | :heavy_check_mark: |         | Form8Dot108ShearResistingEffectiveDepthOuterShearReinforcement     |
+|     8.109      | :heavy_check_mark: |         | Form8Dot109MaximumPunchingShearResistance                          |
+|     8.110      | :heavy_check_mark: |         | Form8Dot110To111CoefficientForPunchingShearReinforcingSystem       |
+|     8.111      | :heavy_check_mark: |         | Form8Dot110To111CoefficientForPunchingShearReinforcingSystem       |
 |     8.112      |        :x:         |         |                                                                    |
 |     8.113      |        :x:         |         |                                                                    |
 |     8.114      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_108.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_108.py
@@ -1,0 +1,74 @@
+"""Testing formula 8.108 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_108 import (
+    Form8Dot108ShearResistingEffectiveDepthOuterShearReinforcement,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot108ShearResistingEffectiveDepthOuterShearReinforcement:
+    """Validation for formula 8.108 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        d_x = 250.0
+        d_y = 230.0
+        c_v = 20.0
+
+        # Object to test
+        formula = Form8Dot108ShearResistingEffectiveDepthOuterShearReinforcement(d_x=d_x, d_y=d_y, c_v=c_v)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 220.0  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("d_x", "d_y", "c_v"),
+        [
+            (-250.0, 230.0, 20.0),  # d_x is negative
+            (0.0, 230.0, 20.0),  # d_x is zero
+            (250.0, -230.0, 20.0),  # d_y is negative
+            (250.0, 0.0, 20.0),  # d_y is zero
+            (250.0, 230.0, -20.0),  # c_v is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, d_x: float, d_y: float, c_v: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot108ShearResistingEffectiveDepthOuterShearReinforcement(d_x=d_x, d_y=d_y, c_v=c_v)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"d_{v,out} = \frac{d_x + d_y}{2} - c_v = \frac{250.000 + 230.000}{2} - 20.000 = 220.000 \ mm",
+            ),
+            (
+                "complete_with_units",
+                r"d_{v,out} = \frac{d_x + d_y}{2} - c_v = \frac{250.000 \ mm + 230.000 \ mm}{2} - 20.000 \ mm = 220.000 \ mm",
+            ),
+            ("short", r"d_{v,out} = 220.000 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        d_x = 250.0
+        d_y = 230.0
+        c_v = 20.0
+
+        # Object to test
+        latex = Form8Dot108ShearResistingEffectiveDepthOuterShearReinforcement(d_x=d_x, d_y=d_y, c_v=c_v).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_109.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_109.py
@@ -1,0 +1,69 @@
+"""Testing formula 8.109 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_109 import (
+    Form8Dot109MaximumPunchingShearResistance,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot109MaximumPunchingShearResistance:
+    """Validation for formula 8.109 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        eta_sys = 1.15
+        tau_rd_c = 0.87
+
+        # Object to test
+        formula = Form8Dot109MaximumPunchingShearResistance(eta_sys=eta_sys, tau_rd_c=tau_rd_c)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 1.0005  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("eta_sys", "tau_rd_c"),
+        [
+            (-1.15, 0.87),  # eta_sys is negative
+            (1.15, -0.87),  # tau_rd_c is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, eta_sys: float, tau_rd_c: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot109MaximumPunchingShearResistance(eta_sys=eta_sys, tau_rd_c=tau_rd_c)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\tau_{Rd,max} = \eta_{sys} \cdot \tau_{Rd,c} = 1.150 \cdot 0.870 = 1.000 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                r"\tau_{Rd,max} = \eta_{sys} \cdot \tau_{Rd,c} = 1.150 \cdot 0.870 \ MPa = 1.000 \ MPa",
+            ),
+            ("short", r"\tau_{Rd,max} = 1.000 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        eta_sys = 1.15
+        tau_rd_c = 0.87
+
+        # Object to test
+        latex = Form8Dot109MaximumPunchingShearResistance(eta_sys=eta_sys, tau_rd_c=tau_rd_c).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_110_111.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_110_111.py
@@ -1,0 +1,85 @@
+"""Testing formulas 8.110 and 8.111 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_110_111 import (
+    Form8Dot110To111CoefficientForPunchingShearReinforcingSystem,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot110To111CoefficientForPunchingShearReinforcingSystem:
+    """Validation for formulas 8.110 and 8.111 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("b_0", "d_v", "is_stud", "expected"),
+        [
+            (600.0, 200.0, True, 1.529127),  # studs, formula (8.110), expression governs
+            (600.0, 200.0, False, 1.329127),  # links and stirrups, formula (8.111), expression governs
+            (1.0, 1000.0, False, 1.0),  # links and stirrups, the lower bound of 1.0 governs
+        ],
+    )
+    def test_evaluation(self, b_0: float, d_v: float, is_stud: bool, expected: float) -> None:
+        """Tests the evaluation of the result."""
+        formula = Form8Dot110To111CoefficientForPunchingShearReinforcingSystem(b_0=b_0, d_v=d_v, is_stud=is_stud)
+
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("b_0", "d_v", "is_stud"),
+        [
+            (-600.0, 200.0, True),  # b_0 is negative
+            (600.0, -200.0, True),  # d_v is negative
+            (600.0, 0.0, True),  # d_v is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, b_0: float, d_v: float, is_stud: bool) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot110To111CoefficientForPunchingShearReinforcingSystem(b_0=b_0, d_v=d_v, is_stud=is_stud)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\eta_{sys} = \begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & "
+                    r"\text{if studs} \\ \max\left(0.50 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & "
+                    r"\text{if links and stirrups} \end{cases} = "
+                    r"\begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{600.000}{200.000}\right)^{\frac{1}{4}}, 1.0\right) & "
+                    r"\text{if studs} \\ \max\left(0.50 + 0.63 \cdot \left(\frac{600.000}{200.000}\right)^{\frac{1}{4}}, 1.0\right) & "
+                    r"\text{if links and stirrups} \end{cases} = 1.529 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\eta_{sys} = \begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & "
+                    r"\text{if studs} \\ \max\left(0.50 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & "
+                    r"\text{if links and stirrups} \end{cases} = "
+                    r"\begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{600.000 \ mm}{200.000 \ mm}\right)^{\frac{1}{4}}, 1.0\right) & "
+                    r"\text{if studs} \\ \max\left(0.50 + 0.63 \cdot \left(\frac{600.000 \ mm}{200.000 \ mm}\right)^{\frac{1}{4}}, 1.0\right) & "
+                    r"\text{if links and stirrups} \end{cases} = 1.529 \ -"
+                ),
+            ),
+            ("short", r"\eta_{sys} = 1.529 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        b_0 = 600.0
+        d_v = 200.0
+        is_stud = True
+
+        # Object to test
+        latex = Form8Dot110To111CoefficientForPunchingShearReinforcingSystem(b_0=b_0, d_v=d_v, is_stud=is_stud).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Summary

Adds the four numbered formulas of clause 8.4.4(4) and 8.4.4(5) from FprEN 1992-1-1:2023 (E), page 147.

- Formula (8.108): [$d_{v,out}$], the shear-resisting effective depth of the outer shear reinforcement, from the NOTE under paragraph (4).
- Formula (8.109): [$\tau_{Rd,max}$], the maximum punching shear resistance, from paragraph (5).
- Formulas (8.110) and (8.111): [$\eta_{sys}$], the coefficient accounting for the performance of punching shear reinforcing systems, from the NOTE under paragraph (5). Implemented together as one casus class, since they are the two branches of a single rule (studs vs. links and stirrups).

## Decisions for the reviewer

- (8.110) and (8.111) each print their own lower bound of 1,0. Both are implemented with the same `max(...)` clamp inside the one casus class, rather than as a bound applied once after the branch.
- (8.108) sits under a NOTE, not directly under a numbered paragraph, but the standard still numbers it, so it is implemented like any other formula in this track. [$c_v$] is documented as "defined in Figure 8.23", which is the full extent of its definition on this page; no fuller description exists elsewhere to copy in.
- (8.109) takes [$\eta_{sys}$] as a direct float input rather than computing it internally from (8.110)/(8.111), matching the existing pattern in this track of a formula consuming an already-evaluated quantity from another numbered formula.

## Formulas as implemented

**Formula (8.108)**, `Form8Dot108ShearResistingEffectiveDepthOuterShearReinforcement`

`equation`

$$
d_{v,out} = \frac{d_x + d_y}{2} - c_v
$$

`complete`

$$
d_{v,out} = \frac{d_x + d_y}{2} - c_v = \frac{250.000 + 230.000}{2} - 20.000 = 220.000 \ mm
$$

`complete_with_units`

$$
d_{v,out} = \frac{d_x + d_y}{2} - c_v = \frac{250.000 \ mm + 230.000 \ mm}{2} - 20.000 \ mm = 220.000 \ mm
$$

**Formula (8.109)**, `Form8Dot109MaximumPunchingShearResistance`

`equation`

$$
\tau_{Rd,max} = \eta_{sys} \cdot \tau_{Rd,c}
$$

`complete`

$$
\tau_{Rd,max} = \eta_{sys} \cdot \tau_{Rd,c} = 1.150 \cdot 0.870 = 1.000 \ MPa
$$

`complete_with_units`

$$
\tau_{Rd,max} = \eta_{sys} \cdot \tau_{Rd,c} = 1.150 \cdot 0.870 \ MPa = 1.000 \ MPa
$$

**Formulas (8.110)/(8.111)**, `Form8Dot110To111CoefficientForPunchingShearReinforcingSystem`

`equation`

$$
\eta_{sys} = \begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & \text{if studs} \ \max\left(0.50 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & \text{if links and stirrups} \end{cases}
$$

`complete`

$$
\eta_{sys} = \begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & \text{if studs} \ \max\left(0.50 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & \text{if links and stirrups} \end{cases} = \begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{600.000}{200.000}\right)^{\frac{1}{4}}, 1.0\right) & \text{if studs} \ \max\left(0.50 + 0.63 \cdot \left(\frac{600.000}{200.000}\right)^{\frac{1}{4}}, 1.0\right) & \text{if links and stirrups} \end{cases} = 1.529 \ -
$$

`complete_with_units`

$$
\eta_{sys} = \begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & \text{if studs} \ \max\left(0.50 + 0.63 \cdot \left(\frac{b_0}{d_v}\right)^{\frac{1}{4}}, 1.0\right) & \text{if links and stirrups} \end{cases} = \begin{cases} \max\left(0.70 + 0.63 \cdot \left(\frac{600.000 \ mm}{200.000 \ mm}\right)^{\frac{1}{4}}, 1.0\right) & \text{if studs} \ \max\left(0.50 + 0.63 \cdot \left(\frac{600.000 \ mm}{200.000 \ mm}\right)^{\frac{1}{4}}, 1.0\right) & \text{if links and stirrups} \end{cases} = 1.529 \ -
$$

Contributes to #1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2 formulas 8.108–8.111 for shear-resisting depth, maximum punching shear resistance, and punching shear reinforcement coefficients.
  * Added support for stud, link, and stirrup reinforcement calculations, including input validation and LaTeX representations.

* **Documentation**
  * Updated the Eurocode 2 formula tracking table to mark formulas 8.108–8.111 as implemented.

* **Tests**
  * Added coverage for calculations, validation, boundary behavior, units, and LaTeX output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->