### PR TITLE
feat: add formula 8.112 from FprEN 1992-1-1:2023 clause 8.4.4

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_112.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_112.py
@@ -1,0 +1,93 @@
+"""Formula 8.112 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form8Dot112OuterControlPerimeterWithoutShearReinforcement(Formula):
+    r"""Class representing formula 8.112 for the calculation of the outer control perimeter at which shear
+    reinforcement is not required.
+    """
+
+    label = "8.112"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        b_0_5: MM,
+        d_v: MM,
+        d_v_out: MM,
+        eta_c: DIMENSIONLESS,
+    ) -> None:
+        r"""[$b_{0,5,out}$] Outer control perimeter at which shear reinforcement is not required, see
+        Figure 8.24 [$mm$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.4.4(7) - Formula (8.112)
+
+        Parameters
+        ----------
+        b_0_5 : MM
+            [$b_{0,5}$] Control perimeter located at a distance [$d_v/2$] from the face of the supporting area
+            according to 8.4.2(2) [$mm$].
+        d_v : MM
+            [$d_v$] Shear-resisting effective depth of the slab according to Formula (8.91) [$mm$].
+        d_v_out : MM
+            [$d_{v,out}$] Shear-resisting effective depth of the outer shear reinforcement according to
+            Formula (8.108), see Form8Dot108ShearResistingEffectiveDepthOuterShearReinforcement [$mm$].
+        eta_c : DIMENSIONLESS
+            [$\eta_c$] As defined in Formula (8.105), see
+            Form8Dot105StrengthReductionCoefficientForShearResistance [$-$].
+        """
+        super().__init__()
+        self.b_0_5 = b_0_5
+        self.d_v = d_v
+        self.d_v_out = d_v_out
+        self.eta_c = eta_c
+
+    @staticmethod
+    def _evaluate(
+        b_0_5: MM,
+        d_v: MM,
+        d_v_out: MM,
+        eta_c: DIMENSIONLESS,
+    ) -> MM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(b_0_5=b_0_5, d_v=d_v, d_v_out=d_v_out, eta_c=eta_c)
+
+        return b_0_5 * ((d_v / d_v_out) * (1 / eta_c)) ** 2
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.112."""
+        _equation: str = r"b_{0,5} \cdot \left(\frac{d_v}{d_{v,out}} \cdot \frac{1}{\eta_c}\right)^2"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_{0,5}": f"{self.b_0_5:.{n}f}",
+                r"d_v": f"{self.d_v:.{n}f}",
+                r"d_{v,out}": f"{self.d_v_out:.{n}f}",
+                r"\eta_c": f"{self.eta_c:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"b_{0,5}": rf"{self.b_0_5:.{n}f} \ mm",
+                r"d_v": rf"{self.d_v:.{n}f} \ mm",
+                r"d_{v,out}": rf"{self.d_v_out:.{n}f} \ mm",
+                r"\eta_c": f"{self.eta_c:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"b_{0,5,out}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -173,7 +173,7 @@ Total of 602 formulas present.
 |     8.109      |        :x:         |         |                                                                    |
 |     8.110      |        :x:         |         |                                                                    |
 |     8.111      |        :x:         |         |                                                                    |
-|     8.112      |        :x:         |         |                                                                    |
+|     8.112      | :heavy_check_mark: |         | Form8Dot112OuterControlPerimeterWithoutShearReinforcement          |
 |     8.113      |        :x:         |         |                                                                    |
 |     8.114      |        :x:         |         |                                                                    |
 |     8.115      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_112.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_112.py
@@ -1,0 +1,85 @@
+"""Testing formula 8.112 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_112 import (
+    Form8Dot112OuterControlPerimeterWithoutShearReinforcement,
+)
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm8Dot112OuterControlPerimeterWithoutShearReinforcement:
+    """Validation for formula 8.112 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        b_0_5 = 2400.0
+        d_v = 200.0
+        d_v_out = 180.0
+        eta_c = 0.8
+
+        # Object to test
+        formula = Form8Dot112OuterControlPerimeterWithoutShearReinforcement(b_0_5=b_0_5, d_v=d_v, d_v_out=d_v_out, eta_c=eta_c)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 4629.629630  # mm
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("b_0_5", "d_v", "d_v_out", "eta_c"),
+        [
+            (-2400.0, 200.0, 180.0, 0.8),  # b_0_5 is negative
+            (0.0, 200.0, 180.0, 0.8),  # b_0_5 is zero
+            (2400.0, -200.0, 180.0, 0.8),  # d_v is negative
+            (2400.0, 0.0, 180.0, 0.8),  # d_v is zero
+            (2400.0, 200.0, -180.0, 0.8),  # d_v_out is negative
+            (2400.0, 200.0, 0.0, 0.8),  # d_v_out is zero
+            (2400.0, 200.0, 180.0, -0.8),  # eta_c is negative
+            (2400.0, 200.0, 180.0, 0.0),  # eta_c is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, b_0_5: float, d_v: float, d_v_out: float, eta_c: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot112OuterControlPerimeterWithoutShearReinforcement(b_0_5=b_0_5, d_v=d_v, d_v_out=d_v_out, eta_c=eta_c)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"b_{0,5,out} = b_{0,5} \cdot \left(\frac{d_v}{d_{v,out}} \cdot \frac{1}{\eta_c}\right)^2 = "
+                    r"2400.000 \cdot \left(\frac{200.000}{180.000} \cdot \frac{1}{0.800}\right)^2 = 4629.630 \ mm"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"b_{0,5,out} = b_{0,5} \cdot \left(\frac{d_v}{d_{v,out}} \cdot \frac{1}{\eta_c}\right)^2 = "
+                    r"2400.000 \ mm \cdot \left(\frac{200.000 \ mm}{180.000 \ mm} \cdot \frac{1}{0.800}\right)^2 = 4629.630 \ mm"
+                ),
+            ),
+            ("short", r"b_{0,5,out} = 4629.630 \ mm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        b_0_5 = 2400.0
+        d_v = 200.0
+        d_v_out = 180.0
+        eta_c = 0.8
+
+        # Object to test
+        latex = Form8Dot112OuterControlPerimeterWithoutShearReinforcement(b_0_5=b_0_5, d_v=d_v, d_v_out=d_v_out, eta_c=eta_c).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Summary

Adds formula (8.112) from FprEN 1992-1-1:2023 (E), clause 8.4.4(7), page 148: the outer control perimeter at which shear reinforcement is not required.

## Decisions for the reviewer

- All four inputs are guarded with `raise_if_less_or_equal_to_zero`: `d_v_out` and `eta_c` because they are denominators, and `b_0_5` and `d_v` because they are geometric quantities that are guarded the same way in the other formulas of this clause (e.g. Formula 8.98, 8.106).

## Formulas as implemented

**Formula (8.112)**, `Form8Dot112OuterControlPerimeterWithoutShearReinforcement`

`equation`

$$
b_{0,5,out} = b_{0,5} \cdot \left(\frac{d_v}{d_{v,out}} \cdot \frac{1}{\eta_c}\right)^2
$$

`complete`

$$
b_{0,5,out} = b_{0,5} \cdot \left(\frac{d_v}{d_{v,out}} \cdot \frac{1}{\eta_c}\right)^2 = 2400.000 \cdot \left(\frac{200.000}{180.000} \cdot \frac{1}{0.800}\right)^2 = 4629.630 \ mm
$$

`complete_with_units`

$$
b_{0,5,out} = b_{0,5} \cdot \left(\frac{d_v}{d_{v,out}} \cdot \frac{1}{\eta_c}\right)^2 = 2400.000 \ mm \cdot \left(\frac{200.000 \ mm}{180.000 \ mm} \cdot \frac{1}{0.800}\right)^2 = 4629.630 \ mm
$$

Contributes to #1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Eurocode 2 Formula 8.112, calculating the outer control perimeter where shear reinforcement is not required.
  * Added formatted formula representations with optional units.

* **Documentation**
  * Updated the Eurocode 2 implementation tracking table to mark Formula 8.112 as implemented.

* **Tests**
  * Added coverage for calculations, input validation, and formula formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->