### PR TITLE
feat: add formulas 8.113 and 8.114 from FprEN 1992-1-1:2023 clause 8.5.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_113.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_113.py
@@ -1,0 +1,82 @@
+"""Formula 8.113 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MPA, N
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form8Dot113CompressiveStressInStrutOrCompressionField(Formula):
+    r"""Class representing formula 8.113 for the calculation of the compressive stress in a strut or in a
+    compression field, assumed uniformly distributed over its cross-section.
+    """
+
+    label = "8.113"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        f_cd: N,
+        b_c: MM,
+        t: MM,
+    ) -> None:
+        r"""[$\sigma_{cd}$] Compressive stress in a strut or in a compression field [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.2(2) - Formula (8.113)
+
+        Parameters
+        ----------
+        f_cd : N
+            [$F_{cd}$] Compressive force of the strut [$N$].
+        b_c : MM
+            [$b_c$] Width of the strut at the considered location [$mm$].
+        t : MM
+            [$t$] Thickness of the strut, which can be limited by the thickness of the member [$mm$].
+        """
+        super().__init__()
+        self.f_cd = f_cd
+        self.b_c = b_c
+        self.t = t
+
+    @staticmethod
+    def _evaluate(
+        f_cd: N,
+        b_c: MM,
+        t: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(b_c=b_c, t=t)
+
+        return abs(f_cd) / (b_c * t)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.113."""
+        _equation: str = r"\frac{\left|F_{cd}\right|}{b_c \cdot t}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"F_{cd}": f"{self.f_cd:.{n}f}",
+                r"b_c": f"{self.b_c:.{n}f}",
+                r"\cdot t": rf"\cdot {self.t:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"F_{cd}": rf"{self.f_cd:.{n}f} \ N",
+                r"b_c": rf"{self.b_c:.{n}f} \ mm",
+                r"\cdot t": rf"\cdot {self.t:.{n}f} \ mm",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\sigma_{cd}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_114.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_114.py
@@ -1,0 +1,91 @@
+"""Formula 8.114 from FprEN 1992-1-1:2023: Chapter 8 - Ultimate Limit State."""
+
+import operator
+from collections.abc import Callable
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import ComparisonFormula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot114CheckCompressiveStressInStrutOrCompressionField(ComparisonFormula):
+    r"""Class representing formula 8.114 for the verification of the compressive stress in a strut or in a
+    compression field developing within the concrete.
+    """
+
+    label = "8.114"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, sigma_cd: MPA, nu: DIMENSIONLESS, f_cd: MPA) -> None:
+        r"""Check whether the compressive stress in a strut or in a compression field does not exceed its
+        limit.
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.2(3) - Formula (8.114)
+
+        Parameters
+        ----------
+        sigma_cd : MPA
+            [$\sigma_{cd}$] Compressive stress in a strut or in a compression field developing within the
+            concrete, according to Formula (8.113), see
+            Form8Dot113CompressiveStressInStrutOrCompressionField [$MPa$].
+        nu : DIMENSIONLESS
+            [$\nu$] Strength reduction factor, defined in 8.5.2(4) and (5) [$-$].
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        """
+        super().__init__()
+        self.sigma_cd = sigma_cd
+        self.nu = nu
+        self.f_cd = f_cd
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        """Returns the comparison operator for the formula."""
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(sigma_cd: MPA, *_args, **_kwargs) -> float:
+        """Evaluates the compressive stress, for more information see the __init__ method."""
+        raise_if_negative(sigma_cd=sigma_cd)
+
+        return float(sigma_cd)
+
+    @staticmethod
+    def _evaluate_rhs(nu: DIMENSIONLESS, f_cd: MPA, *_args, **_kwargs) -> float:
+        """Evaluates the limit on the compressive stress, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(nu=nu, f_cd=f_cd)
+
+        return float(nu * f_cd)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.114."""
+        _equation: str = r"\sigma_{cd} \leq \nu \cdot f_{cd}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\sigma_{cd}": f"{self.sigma_cd:.{n}f}",
+                r"\nu": f"{self.nu:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\sigma_{cd}": rf"{self.sigma_cd:.{n}f} \ MPa",
+                r"\nu": f"{self.nu:.{n}f}",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label=r"\to",
+            unit="",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -174,8 +174,8 @@ Total of 602 formulas present.
 |     8.110      |        :x:         |         |                                                                    |
 |     8.111      |        :x:         |         |                                                                    |
 |     8.112      |        :x:         |         |                                                                    |
-|     8.113      |        :x:         |         |                                                                    |
-|     8.114      |        :x:         |         |                                                                    |
+|     8.113      | :heavy_check_mark: |         | Form8Dot113CompressiveStressInStrutOrCompressionField              |
+|     8.114      | :heavy_check_mark: |         | Form8Dot114CheckCompressiveStressInStrutOrCompressionField         |
 |     8.115      |        :x:         |         |                                                                    |
 |     8.116      |        :x:         |         |                                                                    |
 |     8.117      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_113.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_113.py
@@ -1,0 +1,91 @@
+"""Testing formula 8.113 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_113 import (
+    Form8Dot113CompressiveStressInStrutOrCompressionField,
+)
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm8Dot113CompressiveStressInStrutOrCompressionField:
+    """Validation for formula 8.113 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        f_cd = 150000.0
+        b_c = 300.0
+        t = 200.0
+
+        # Object to test
+        formula = Form8Dot113CompressiveStressInStrutOrCompressionField(f_cd=f_cd, b_c=b_c, t=t)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 2.5  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_with_negative_force(self) -> None:
+        """Tests the evaluation of the result when the compressive force is given as a negative value."""
+        # Example values
+        f_cd = -150000.0
+        b_c = 300.0
+        t = 200.0
+
+        # Object to test
+        formula = Form8Dot113CompressiveStressInStrutOrCompressionField(f_cd=f_cd, b_c=b_c, t=t)
+
+        # Expected result, manually calculated
+        manually_calculated_result = 2.5  # MPa
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("f_cd", "b_c", "t"),
+        [
+            (150000.0, -300.0, 200.0),  # b_c is negative
+            (150000.0, 0.0, 200.0),  # b_c is zero
+            (150000.0, 300.0, -200.0),  # t is negative
+            (150000.0, 300.0, 0.0),  # t is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, f_cd: float, b_c: float, t: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot113CompressiveStressInStrutOrCompressionField(f_cd=f_cd, b_c=b_c, t=t)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"\sigma_{cd} = \frac{\left|F_{cd}\right|}{b_c \cdot t} = \frac{\left|150000.000\right|}{300.000 \cdot 200.000} = 2.500 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\sigma_{cd} = \frac{\left|F_{cd}\right|}{b_c \cdot t} = "
+                    r"\frac{\left|150000.000 \ N\right|}{300.000 \ mm \cdot 200.000 \ mm} = 2.500 \ MPa"
+                ),
+            ),
+            ("short", r"\sigma_{cd} = 2.500 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        f_cd = 150000.0
+        b_c = 300.0
+        t = 200.0
+
+        # Object to test
+        latex = Form8Dot113CompressiveStressInStrutOrCompressionField(f_cd=f_cd, b_c=b_c, t=t).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_114.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_114.py
@@ -1,0 +1,65 @@
+"""Testing formula 8.114 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_114 import (
+    Form8Dot114CheckCompressiveStressInStrutOrCompressionField,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot114CheckCompressiveStressInStrutOrCompressionField:
+    """Validation for formula 8.114 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("sigma_cd", "nu", "f_cd", "expected"),
+        [
+            (2.5, 0.7, 25.0, True),  # the strut resists the compressive stress
+            (17.5, 0.7, 25.0, True),  # exactly on the boundary, which the standard includes
+            (20.0, 0.7, 25.0, False),  # the strut does not resist the compressive stress
+        ],
+    )
+    def test_evaluation(self, sigma_cd: float, nu: float, f_cd: float, expected: bool) -> None:
+        """Tests the evaluation of the result."""
+        assert bool(Form8Dot114CheckCompressiveStressInStrutOrCompressionField(sigma_cd=sigma_cd, nu=nu, f_cd=f_cd)) is expected
+
+    @pytest.mark.parametrize(
+        ("sigma_cd", "nu", "f_cd"),
+        [
+            (-2.5, 0.7, 25.0),  # sigma_cd is negative
+            (2.5, -0.7, 25.0),  # nu is negative
+            (2.5, 0.0, 25.0),  # nu is zero
+            (2.5, 0.7, -25.0),  # f_cd is negative
+            (2.5, 0.7, 0.0),  # f_cd is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, sigma_cd: float, nu: float, f_cd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, LessOrEqualToZeroError)):
+            Form8Dot114CheckCompressiveStressInStrutOrCompressionField(sigma_cd=sigma_cd, nu=nu, f_cd=f_cd)
+
+    @pytest.mark.parametrize(
+        ("sigma_cd", "representation", "expected"),
+        [
+            (2.5, "complete", r"CHECK \to \sigma_{cd} \leq \nu \cdot f_{cd} \to 2.500 \leq 0.700 \cdot 25.000 \to OK"),
+            (
+                2.5,
+                "complete_with_units",
+                r"CHECK \to \sigma_{cd} \leq \nu \cdot f_{cd} \to 2.500 \ MPa \leq 0.700 \cdot 25.000 \ MPa \to OK",
+            ),
+            (2.5, "short", r"CHECK \to OK"),
+            (20.0, "short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex(self, sigma_cd: float, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot114CheckCompressiveStressInStrutOrCompressionField(sigma_cd=sigma_cd, nu=0.7, f_cd=25.0).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
## Summary

Adds formulas (8.113) and (8.114) from FprEN 1992-1-1:2023 (E), clause 8.5.2 "Struts and compression fields", page 151-152. This is the first clause of section 8.5 on strut-and-tie models and stress fields.

- Formula (8.113): [$\sigma_{cd}$], the compressive stress in a strut or in a compression field, assumed uniformly distributed over its cross-section.
- Formula (8.114): the verification that this stress does not exceed its limit [$\nu \cdot f_{cd}$].

## Decisions for the reviewer

- (8.114) is implemented as a `ComparisonFormula`, not a plain `Formula` with a clamp: the standard introduces it with "the compressive stress ... shall fulfil the following condition", which is a pass/fail verification rather than an assignment with a bound. This follows the existing convention in this track (see e.g. formula 8.73 and 8.60) for telling the two shapes apart.
- (8.113) prints [$F_{cd}$] (capital F, the compressive force of the strut in N) and (8.114) prints [$f_{cd}$] (lowercase f, the design compressive strength of concrete in MPa). Both are named `f_cd` in their respective `__init__` signatures, with the type alias (`N` vs `MPA`) and the docstring carrying the distinction. This mirrors the existing precedent for `v_ed`/`V_Ed` in formulas 8.18/8.19, rather than introducing a suffix, since the two symbols never appear together in one class.
- [$\nu$] in (8.114) is a direct float input rather than computed internally; its own definition spans six further formulas (8.115) to (8.120) in paragraphs (4) and (5) of this clause, which are out of scope for this pull request.

## Formulas as implemented

**Formula (8.113)**, `Form8Dot113CompressiveStressInStrutOrCompressionField`

`equation`

$$
\sigma_{cd} = \frac{\left|F_{cd}\right|}{b_c \cdot t}
$$

`complete`

$$
\sigma_{cd} = \frac{\left|F_{cd}\right|}{b_c \cdot t} = \frac{\left|150000.000\right|}{300.000 \cdot 200.000} = 2.500 \ MPa
$$

`complete_with_units`

$$
\sigma_{cd} = \frac{\left|F_{cd}\right|}{b_c \cdot t} = \frac{\left|150000.000 \ N\right|}{300.000 \ mm \cdot 200.000 \ mm} = 2.500 \ MPa
$$

**Formula (8.114)**, `Form8Dot114CheckCompressiveStressInStrutOrCompressionField`

`equation`

$$
\sigma_{cd} \leq \nu \cdot f_{cd}
$$

`complete`

$$
CHECK \to \sigma_{cd} \leq \nu \cdot f_{cd} \to 2.500 \leq 0.700 \cdot 25.000 \to OK
$$

`complete_with_units`

$$
CHECK \to \sigma_{cd} \leq \nu \cdot f_{cd} \to 2.500 \ MPa \leq 0.700 \cdot 25.000 \ MPa \to OK
$$

Contributes to #1083
