### PR TITLE
feat: add formulas 8.115 to 8.120 from FprEN 1992-1-1:2023 clause 8.5.2

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_115_116_117_118.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_115_116_117_118.py
@@ -1,0 +1,83 @@
+"""Formula 8.115, 8.116, 8.117 and 8.118 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG, DIMENSIONLESS
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form8Dot115To118StrengthReductionFactorCrossedByTie(Formula):
+    """Class representing formulas 8.115, 8.116, 8.117 and 8.118 for the calculation of the strength reduction factor
+    for compression fields and struts crossed or deviated by a tie at an angle.
+    """
+
+    label = "8.115/8.116/8.117/8.118"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        theta_cs: DEG,
+    ) -> None:
+        r"""[$\nu$] Strength reduction factor for compression fields and struts crossed or deviated by a tie at an
+        angle [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.2(4) - Formula (8.115), (8.116), (8.117) and (8.118)
+
+        Parameters
+        ----------
+        theta_cs : DEG
+            [$\theta_{cs}$] Smallest angle between the strut representing the resultant of the compression field
+            and any of the ties that cross with the strut, as defined in Figure 8.26 [$degrees$].
+        """
+        super().__init__()
+        self.theta_cs = theta_cs
+
+    @staticmethod
+    def _evaluate(
+        theta_cs: DEG,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(theta_cs=theta_cs)
+
+        if 20 <= theta_cs < 30:
+            return 0.4
+        if 30 <= theta_cs < 40:
+            return 0.55
+        if 40 <= theta_cs < 60:
+            return 0.7
+        if 60 <= theta_cs < 90:
+            return 0.85
+        raise ValueError(f"theta_cs of {theta_cs} degrees is outside the range covered by formulas (8.115) to (8.118): 20 <= theta_cs < 90 degrees.")
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formulas 8.115, 8.116, 8.117 and 8.118."""
+        _equation: str = (
+            r"\begin{cases} 0.4 & \text{if } 20^\circ \leq \theta_{cs} < 30^\circ \\ "
+            r"0.55 & \text{if } 30^\circ \leq \theta_{cs} < 40^\circ \\ "
+            r"0.7 & \text{if } 40^\circ \leq \theta_{cs} < 60^\circ \\ "
+            r"0.85 & \text{if } 60^\circ \leq \theta_{cs} < 90^\circ \end{cases}"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\theta_{cs}": f"{self.theta_cs:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\theta_{cs}": rf"{self.theta_cs:.{n}f} ^\circ",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\nu",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_119.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_119.py
@@ -1,0 +1,71 @@
+"""Formula 8.119 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG, DIMENSIONLESS
+from blueprints.utils.math_helpers import cot
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form8Dot119StrengthReductionFactorCrossedByTieRefined(Formula):
+    """Class representing formula 8.119 for the calculation of the strength reduction factor for compression
+    fields and struts crossed or deviated by a tie at an angle, as an alternative to formulas (8.115) to (8.118).
+    """
+
+    label = "8.119"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        theta_cs: DEG,
+    ) -> None:
+        r"""[$\nu$] Strength reduction factor for compression fields and struts crossed or deviated by a tie at an
+        angle [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.2(4) - Formula (8.119)
+
+        Parameters
+        ----------
+        theta_cs : DEG
+            [$\theta_{cs}$] Smallest angle between the strut representing the resultant of the compression field
+            and any of the ties that cross with the strut, as defined in Figure 8.26 [$degrees$].
+        """
+        super().__init__()
+        self.theta_cs = theta_cs
+
+    @staticmethod
+    def _evaluate(
+        theta_cs: DEG,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(theta_cs=theta_cs)
+        cot_theta_cs = cot(theta_cs)
+        return 1 / (1.11 + 0.22 * cot_theta_cs**2)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.119."""
+        _equation: str = r"\frac{1}{1.11 + 0.22 \cdot \left(\cot(\theta_{cs})\right)^2}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\theta_{cs}": f"{self.theta_cs:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\theta_{cs}": rf"{self.theta_cs:.{n}f} ^\circ",
+            },
+            unique_symbol_check=True,
+        )
+        return LatexFormula(
+            return_symbol=r"\nu",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_120.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_120.py
@@ -1,0 +1,40 @@
+"""Formula 8.120 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula
+from blueprints.type_alias import DIMENSIONLESS
+
+
+class Form8Dot120StrengthReductionFactorUncrackedStrut(Formula):
+    """Class representing formula 8.120 for the calculation of the strength reduction factor for compression
+    fields and struts in a region without transverse cracking.
+    """
+
+    label = "8.120"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self) -> None:
+        r"""[$\nu$] Strength reduction factor for compression fields and struts in a region without transverse
+        cracking, for example when transverse compressive stresses are present [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.2(4) - Formula (8.120)
+        """
+        super().__init__()
+
+    @staticmethod
+    def _evaluate() -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        return 1.0
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.120."""
+        return LatexFormula(
+            return_symbol=r"\nu",
+            result=f"{self:.{n}f}",
+            equation=r"1.0",
+            numeric_equation=r"1.0",
+            numeric_equation_with_units=r"1.0",
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -176,12 +176,12 @@ Total of 602 formulas present.
 |     8.112      |        :x:         |         |                                                                    |
 |     8.113      |        :x:         |         |                                                                    |
 |     8.114      |        :x:         |         |                                                                    |
-|     8.115      |        :x:         |         |                                                                    |
-|     8.116      |        :x:         |         |                                                                    |
-|     8.117      |        :x:         |         |                                                                    |
-|     8.118      |        :x:         |         |                                                                    |
-|     8.119      |        :x:         |         |                                                                    |
-|     8.120      |        :x:         |         |                                                                    |
+|     8.115      | :heavy_check_mark: |         | Form8Dot115To118StrengthReductionFactorCrossedByTie               |
+|     8.116      | :heavy_check_mark: |         | Form8Dot115To118StrengthReductionFactorCrossedByTie               |
+|     8.117      | :heavy_check_mark: |         | Form8Dot115To118StrengthReductionFactorCrossedByTie               |
+|     8.118      | :heavy_check_mark: |         | Form8Dot115To118StrengthReductionFactorCrossedByTie               |
+|     8.119      | :heavy_check_mark: |         | Form8Dot119StrengthReductionFactorCrossedByTieRefined              |
+|     8.120      | :heavy_check_mark: |         | Form8Dot120StrengthReductionFactorUncrackedStrut                  |
 |     8.121      |        :x:         |         |                                                                    |
 |     8.122      |        :x:         |         |                                                                    |
 |     8.123      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_115_116_117_118.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_115_116_117_118.py
@@ -1,0 +1,106 @@
+"""Testing formulas 8.115, 8.116, 8.117 and 8.118 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_115_116_117_118 import (
+    Form8Dot115To118StrengthReductionFactorCrossedByTie,
+)
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm8Dot115To118StrengthReductionFactorCrossedByTie:
+    """Validation for formulas 8.115, 8.116, 8.117 and 8.118 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("theta_cs", "expected"),
+        [
+            (20.0, 0.4),  # lower boundary of the first range
+            (25.0, 0.4),  # inside the first range
+            (29.999, 0.4),  # just below the second boundary
+            (30.0, 0.55),  # lower boundary of the second range
+            (35.0, 0.55),  # inside the second range
+            (39.999, 0.55),  # just below the third boundary
+            (40.0, 0.7),  # lower boundary of the third range
+            (50.0, 0.7),  # inside the third range
+            (59.999, 0.7),  # just below the fourth boundary
+            (60.0, 0.85),  # lower boundary of the fourth range
+            (75.0, 0.85),  # inside the fourth range
+            (89.999, 0.85),  # just below the upper boundary
+        ],
+    )
+    def test_evaluation(self, theta_cs: float, expected: float) -> None:
+        """Tests the evaluation of the result."""
+        assert Form8Dot115To118StrengthReductionFactorCrossedByTie(theta_cs=theta_cs) == pytest.approx(expected=expected, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        "theta_cs",
+        [
+            0.0,  # zero
+            -5.0,  # negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, theta_cs: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot115To118StrengthReductionFactorCrossedByTie(theta_cs=theta_cs)
+
+    @pytest.mark.parametrize(
+        "theta_cs",
+        [
+            10.0,  # below the range covered by the formulas
+            90.0,  # at the excluded upper boundary
+            95.0,  # above the range covered by the formulas
+        ],
+    )
+    def test_raise_error_when_theta_cs_outside_covered_range(self, theta_cs: float) -> None:
+        """Test values of theta_cs outside the range covered by formulas (8.115) to (8.118)."""
+        with pytest.raises(ValueError, match="outside the range covered by formulas"):
+            Form8Dot115To118StrengthReductionFactorCrossedByTie(theta_cs=theta_cs)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\nu = \begin{cases} 0.4 & \text{if } 20^\circ \leq \theta_{cs} < 30^\circ \\ "
+                    r"0.55 & \text{if } 30^\circ \leq \theta_{cs} < 40^\circ \\ "
+                    r"0.7 & \text{if } 40^\circ \leq \theta_{cs} < 60^\circ \\ "
+                    r"0.85 & \text{if } 60^\circ \leq \theta_{cs} < 90^\circ \end{cases} = "
+                    r"\begin{cases} 0.4 & \text{if } 20^\circ \leq 45.000 < 30^\circ \\ "
+                    r"0.55 & \text{if } 30^\circ \leq 45.000 < 40^\circ \\ "
+                    r"0.7 & \text{if } 40^\circ \leq 45.000 < 60^\circ \\ "
+                    r"0.85 & \text{if } 60^\circ \leq 45.000 < 90^\circ \end{cases} = 0.700 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\nu = \begin{cases} 0.4 & \text{if } 20^\circ \leq \theta_{cs} < 30^\circ \\ "
+                    r"0.55 & \text{if } 30^\circ \leq \theta_{cs} < 40^\circ \\ "
+                    r"0.7 & \text{if } 40^\circ \leq \theta_{cs} < 60^\circ \\ "
+                    r"0.85 & \text{if } 60^\circ \leq \theta_{cs} < 90^\circ \end{cases} = "
+                    r"\begin{cases} 0.4 & \text{if } 20^\circ \leq 45.000 ^\circ < 30^\circ \\ "
+                    r"0.55 & \text{if } 30^\circ \leq 45.000 ^\circ < 40^\circ \\ "
+                    r"0.7 & \text{if } 40^\circ \leq 45.000 ^\circ < 60^\circ \\ "
+                    r"0.85 & \text{if } 60^\circ \leq 45.000 ^\circ < 90^\circ \end{cases} = 0.700 \ -"
+                ),
+            ),
+            ("short", r"\nu = 0.700 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example value
+        theta_cs = 45.0
+
+        # Object to test
+        latex = Form8Dot115To118StrengthReductionFactorCrossedByTie(theta_cs=theta_cs).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_119.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_119.py
@@ -1,0 +1,81 @@
+"""Testing formula 8.119 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_119 import (
+    Form8Dot119StrengthReductionFactorCrossedByTieRefined,
+)
+from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError
+
+# Angle chosen so that its cotangent is a round number, which keeps the hand calculation readable
+THETA_COT_2 = 26.565051177078  # cot(theta) = 2
+
+
+class TestForm8Dot119StrengthReductionFactorCrossedByTieRefined:
+    """Validation for formula 8.119 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example value
+        theta_cs = THETA_COT_2
+
+        # Object to test
+        formula = Form8Dot119StrengthReductionFactorCrossedByTieRefined(theta_cs=theta_cs)
+
+        # Expected result, manually calculated: 1 / (1.11 + 0.22 * 2**2) = 1 / 1.99
+        manually_calculated_result = 0.5025125628140705
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        "theta_cs",
+        [
+            0.0,  # zero
+            -5.0,  # negative
+        ],
+    )
+    def test_raise_error_when_theta_cs_is_less_or_equal_to_zero(self, theta_cs: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot119StrengthReductionFactorCrossedByTieRefined(theta_cs=theta_cs)
+
+    def test_raise_error_when_theta_cs_is_greater_than_90(self) -> None:
+        """Test invalid value beyond the valid range of the cotangent."""
+        with pytest.raises(GreaterThan90Error):
+            Form8Dot119StrengthReductionFactorCrossedByTieRefined(theta_cs=95.0)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\nu = \frac{1}{1.11 + 0.22 \cdot \left(\cot(\theta_{cs})\right)^2} = "
+                    r"\frac{1}{1.11 + 0.22 \cdot \left(\cot(26.565)\right)^2} = 0.503 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\nu = \frac{1}{1.11 + 0.22 \cdot \left(\cot(\theta_{cs})\right)^2} = "
+                    r"\frac{1}{1.11 + 0.22 \cdot \left(\cot(26.565 ^\circ)\right)^2} = 0.503 \ -"
+                ),
+            ),
+            ("short", r"\nu = 0.503 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example value
+        theta_cs = THETA_COT_2
+
+        # Object to test
+        latex = Form8Dot119StrengthReductionFactorCrossedByTieRefined(theta_cs=theta_cs).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_120.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_120.py
@@ -1,0 +1,28 @@
+"""Testing formula 8.120 of FprEN 1992-1-1:2023."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_120 import (
+    Form8Dot120StrengthReductionFactorUncrackedStrut,
+)
+
+
+class TestForm8Dot120StrengthReductionFactorUncrackedStrut:
+    """Validation for formula 8.120 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Object to test
+        formula = Form8Dot120StrengthReductionFactorUncrackedStrut()
+
+        # Expected result, as printed in the standard
+        manually_calculated_result = 1.0
+
+        assert formula == manually_calculated_result
+
+    def test_latex(self) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot120StrengthReductionFactorUncrackedStrut().latex()
+
+        assert latex.complete == r"\nu = 1.0 = 1.0 = 1.000 \ -"
+        assert latex.complete_with_units == r"\nu = 1.0 = 1.0 = 1.000 \ -"
+        assert latex.short == r"\nu = 1.000 \ -"


### PR DESCRIPTION
Adds formulas (8.115) to (8.120) from clause 8.5.2(4) of FprEN 1992-1-1:2023, which sets out the strength reduction factor nu used in the compressive stress check of Formula (8.114).

Item a) covers compression fields and struts crossed or deviated by a tie at an angle: a stepped table over four angle ranges, formulas (8.115) to (8.118), plus a continuous alternative formula, (8.119). Item b) covers compression fields and struts in a region without transverse cracking: a fixed value, formula (8.120).

## Decisions a reviewer has to weigh

- **(8.115) to (8.118) as one class.** The four formulas are the bullet points of a single lettered item a), each a step of the same lookup table over the angle theta_cs. They are implemented as one class, `Form8Dot115To118StrengthReductionFactorCrossedByTie`, following the same grouping rule already used elsewhere in this track for numbered formulas that are branches of a single rule.
- **theta_cs outside 20 to 90 degrees raises a plain `ValueError`.** The standard's table only covers 20 <= theta_cs < 90 degrees; it gives no value below 20 degrees or at/above 90 degrees for this branch. Rather than silently extrapolating, an out-of-range angle raises with a message naming the covered range.
- **(8.119) as a separate class from (8.115) to (8.118).** Although (8.119) computes the same physical quantity for the same case a), it is a distinct algebraic expression with its own formula number, introduced by "Alternatively, the value of factor nu may be determined as". Following the precedent of (8.27) and (8.33), a distinct formula number with a distinct expression gets its own class rather than being folded into the stepped one via a flag.
- **(8.120) takes no parameters at all.** The standard prints nu = 1,0 for item b) with no variables on the right-hand side. `Form8Dot120StrengthReductionFactorUncrackedStrut` therefore has a parameterless `__init__`. This is the first formula in the package with no inputs; flagging it in case a reviewer would rather see it modelled differently (for example as a module-level constant rather than a `Formula` subclass).

## Formulas as implemented

**Formulas (8.115), (8.116), (8.117), (8.118)**, `Form8Dot115To118StrengthReductionFactorCrossedByTie`

`equation`

$$
\nu = \begin{cases} 0.4 & \text{if } 20^\circ \leq \theta_{cs} < 30^\circ \\ 0.55 & \text{if } 30^\circ \leq \theta_{cs} < 40^\circ \\ 0.7 & \text{if } 40^\circ \leq \theta_{cs} < 60^\circ \\ 0.85 & \text{if } 60^\circ \leq \theta_{cs} < 90^\circ \end{cases}
$$

`complete`

$$
\nu = \begin{cases} 0.4 & \text{if } 20^\circ \leq \theta_{cs} < 30^\circ \\ 0.55 & \text{if } 30^\circ \leq \theta_{cs} < 40^\circ \\ 0.7 & \text{if } 40^\circ \leq \theta_{cs} < 60^\circ \\ 0.85 & \text{if } 60^\circ \leq \theta_{cs} < 90^\circ \end{cases} = \begin{cases} 0.4 & \text{if } 20^\circ \leq 45.000 < 30^\circ \\ 0.55 & \text{if } 30^\circ \leq 45.000 < 40^\circ \\ 0.7 & \text{if } 40^\circ \leq 45.000 < 60^\circ \\ 0.85 & \text{if } 60^\circ \leq 45.000 < 90^\circ \end{cases} = 0.700 \ -
$$

`complete_with_units`

$$
\nu = \begin{cases} 0.4 & \text{if } 20^\circ \leq \theta_{cs} < 30^\circ \\ 0.55 & \text{if } 30^\circ \leq \theta_{cs} < 40^\circ \\ 0.7 & \text{if } 40^\circ \leq \theta_{cs} < 60^\circ \\ 0.85 & \text{if } 60^\circ \leq \theta_{cs} < 90^\circ \end{cases} = \begin{cases} 0.4 & \text{if } 20^\circ \leq 45.000 ^\circ < 30^\circ \\ 0.55 & \text{if } 30^\circ \leq 45.000 ^\circ < 40^\circ \\ 0.7 & \text{if } 40^\circ \leq 45.000 ^\circ < 60^\circ \\ 0.85 & \text{if } 60^\circ \leq 45.000 ^\circ < 90^\circ \end{cases} = 0.700 \ -
$$

**Formula (8.119)**, `Form8Dot119StrengthReductionFactorCrossedByTieRefined`

`equation`

$$
\nu = \frac{1}{1.11 + 0.22 \cdot \left(\cot(\theta_{cs})\right)^2}
$$

`complete`

$$
\nu = \frac{1}{1.11 + 0.22 \cdot \left(\cot(\theta_{cs})\right)^2} = \frac{1}{1.11 + 0.22 \cdot \left(\cot(26.565)\right)^2} = 0.503 \ -
$$

`complete_with_units`

$$
\nu = \frac{1}{1.11 + 0.22 \cdot \left(\cot(\theta_{cs})\right)^2} = \frac{1}{1.11 + 0.22 \cdot \left(\cot(26.565 ^\circ)\right)^2} = 0.503 \ -
$$

**Formula (8.120)**, `Form8Dot120StrengthReductionFactorUncrackedStrut`

`equation`

$$
\nu = 1.0
$$

`complete`

$$
\nu = 1.0 = 1.0 = 1.000 \ -
$$

`complete_with_units`

$$
\nu = 1.0 = 1.0 = 1.000 \ -
$$

Contributes to #1083.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Eurocode 2 formulas 8.115–8.120 for strength-reduction factors in tied, refined, and uncracked struts.
  - Added validation for tie-angle inputs, including clear handling of unsupported ranges.
  - Added numeric and symbolic LaTeX representations for the new formulas.

- **Documentation**
  - Updated the Eurocode 2 formula tracking table to mark formulas 8.115–8.120 as implemented.

- **Tests**
  - Added coverage for calculations, input validation, and LaTeX output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->