### PR TITLE
feat: add formulas 8.121 and 8.122 from FprEN 1992-1-1:2023

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_121.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_121.py
@@ -1,0 +1,67 @@
+"""Formula 8.121 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot121StrengthReductionFactorCrackedZone(Formula):
+    """Class representing formula 8.121 for the calculation of the strength reduction factor for compression
+    fields in cracked zones, based on the principal tensile strain.
+    """
+
+    label = "8.121"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        epsilon_1: DIMENSIONLESS,
+    ) -> None:
+        r"""[$\nu$] Strength reduction factor for compression fields in cracked zones [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.2(5) - Formula (8.121)
+
+        The standard writes this as an expression bounded from above by 1,0, which is implemented as the
+        minimum of the two.
+
+        Parameters
+        ----------
+        epsilon_1 : DIMENSIONLESS
+            [$\varepsilon_1$] Value of the maximum principal tensile strain [$-$].
+        """
+        super().__init__()
+        self.epsilon_1 = epsilon_1
+
+    @staticmethod
+    def _evaluate(
+        epsilon_1: DIMENSIONLESS,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(epsilon_1=epsilon_1)
+
+        # For epsilon_1 >= 0 the denominator is >= 1.0, so the raw expression never exceeds 1.0 and the
+        # bound is tight only at epsilon_1 = 0. The min is kept to match the standard's printed condition.
+        return min(1 / (1.0 + 110 * epsilon_1), 1.0)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.121."""
+        _equation: str = r"\min\left(\frac{1}{1.0 + 110 \cdot \varepsilon_1}, 1.0\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\varepsilon_1": f"{self.epsilon_1:.{n}f}",
+            },
+            unique_symbol_check=True,
+        )
+        _numeric_equation_with_units: str = _numeric_equation
+        return LatexFormula(
+            return_symbol=r"\nu",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_122.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_122.py
@@ -1,0 +1,101 @@
+"""Formula 8.122 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import operator
+from collections.abc import Callable
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import ComparisonFormula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM2, MPA, N
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot122CheckTieResistance(ComparisonFormula):
+    r"""Class representing formula 8.122 for the verification of the resistance of a tie.
+
+    8.5.3(1) introduces this as "The resistance of a tie [$F_{Rd}$] shall fulfil the following condition",
+    so the relation is a verification that passes or fails and not a value to be clamped.
+    """
+
+    label = "8.122"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, f_td: N, a_s: MM2, f_yd: MPA, a_p: MM2, f_pd: MPA) -> None:
+        r"""Verify the design tensile force in a tie against its resistance.
+
+        FprEN 1992-1-1:2023 (E) art 8.5.3 (1) - Formula (8.122)
+
+        Parameters
+        ----------
+        f_td : N
+            [$F_{td}$] Design value of the tensile force in the tie [$N$].
+        a_s : MM2
+            [$A_s$] Cross-sectional area of the reinforcement of the tie [$mm^2$].
+        f_yd : MPA
+            [$f_{yd}$] Design value of the yield strength of the reinforcement [$MPa$].
+        a_p : MM2
+            [$A_p$] Cross-sectional area of the prestressed reinforcement of the tie [$mm^2$].
+        f_pd : MPA
+            [$f_{pd}$] Design value of the strength of the prestressed reinforcement. If prestressed
+            reinforcement is considered as an external action, [$f_{pd}$] should be replaced by
+            [$f_{pd} - \sigma_{pd}$] according to 7.6.5(1) [$MPa$].
+        """
+        super().__init__()
+        self.f_td = f_td
+        self.a_s = a_s
+        self.f_yd = f_yd
+        self.a_p = a_p
+        self.f_pd = f_pd
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(f_td: N, *_args, **_kwargs) -> float:
+        """Evaluates the design tensile force, for more information see the __init__ method."""
+        raise_if_negative(f_td=f_td)
+
+        return float(f_td)
+
+    @staticmethod
+    def _evaluate_rhs(a_s: MM2, f_yd: MPA, a_p: MM2, f_pd: MPA, *_args, **_kwargs) -> float:
+        """Evaluates the resistance of the tie, for more information see the __init__ method."""
+        raise_if_negative(a_s=a_s, f_yd=f_yd, a_p=a_p, f_pd=f_pd)
+
+        return float(a_s * f_yd + a_p * f_pd)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.122."""
+        _equation: str = r"F_{td} \leq A_s \cdot f_{yd} + A_p \cdot f_{pd}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"F_{td}": f"{self.f_td:.{n}f}",
+                r"A_s": f"{self.a_s:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+                r"A_p": f"{self.a_p:.{n}f}",
+                r"f_{pd}": f"{self.f_pd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"F_{td}": rf"{self.f_td:.{n}f} \ N",
+                r"A_s": rf"{self.a_s:.{n}f} \ mm^2",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+                r"A_p": rf"{self.a_p:.{n}f} \ mm^2",
+                r"f_{pd}": rf"{self.f_pd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label=r"\to",
+            unit="",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -182,8 +182,8 @@ Total of 602 formulas present.
 |     8.118      |        :x:         |         |                                                                    |
 |     8.119      |        :x:         |         |                                                                    |
 |     8.120      |        :x:         |         |                                                                    |
-|     8.121      |        :x:         |         |                                                                    |
-|     8.122      |        :x:         |         |                                                                    |
+|     8.121      | :heavy_check_mark: |         | Form8Dot121StrengthReductionFactorCrackedZone                     |
+|     8.122      | :heavy_check_mark: |         | Form8Dot122CheckTieResistance                                     |
 |     8.123      |        :x:         |         |                                                                    |
 |     8.124      |        :x:         |         |                                                                    |
 |     8.125      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_121.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_121.py
@@ -1,0 +1,79 @@
+"""Testing formula 8.121 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_121 import (
+    Form8Dot121StrengthReductionFactorCrackedZone,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot121StrengthReductionFactorCrackedZone:
+    """Validation for formula 8.121 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example value
+        epsilon_1 = 0.005
+
+        # Object to test
+        formula = Form8Dot121StrengthReductionFactorCrackedZone(epsilon_1=epsilon_1)
+
+        # Expected result, manually calculated: 1 / (1.0 + 110 * 0.005) = 1 / 1.55
+        manually_calculated_result = 0.6451612903225806
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_bound_governs(self) -> None:
+        """Tests the evaluation of the result when the upper bound of 1,0 governs."""
+        # Example value
+        epsilon_1 = 0.0
+
+        # Object to test
+        formula = Form8Dot121StrengthReductionFactorCrackedZone(epsilon_1=epsilon_1)
+
+        # Expected result, manually calculated: 1 / (1.0 + 110 * 0.0) = 1.0
+        manually_calculated_result = 1.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_raise_error_when_epsilon_1_is_negative(self) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot121StrengthReductionFactorCrackedZone(epsilon_1=-0.001)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\nu = \min\left(\frac{1}{1.0 + 110 \cdot \varepsilon_1}, 1.0\right) = "
+                    r"\min\left(\frac{1}{1.0 + 110 \cdot 0.005}, 1.0\right) = 0.645 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\nu = \min\left(\frac{1}{1.0 + 110 \cdot \varepsilon_1}, 1.0\right) = "
+                    r"\min\left(\frac{1}{1.0 + 110 \cdot 0.005}, 1.0\right) = 0.645 \ -"
+                ),
+            ),
+            ("short", r"\nu = 0.645 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example value
+        epsilon_1 = 0.005
+
+        # Object to test
+        latex = Form8Dot121StrengthReductionFactorCrackedZone(epsilon_1=epsilon_1).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_122.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_122.py
@@ -1,0 +1,76 @@
+"""Testing formula 8.122 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_122 import (
+    Form8Dot122CheckTieResistance,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot122CheckTieResistance:
+    """Validation for formula 8.122 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("f_td", "a_s", "f_yd", "a_p", "f_pd", "expected"),
+        [
+            (200000.0, 300.0, 500.0, 100.0, 1000.0, True),  # the tie resists the tensile force
+            (250000.0, 300.0, 500.0, 100.0, 1000.0, True),  # exactly on the boundary, which the standard includes
+            (300000.0, 300.0, 500.0, 100.0, 1000.0, False),  # the tie does not resist the tensile force
+            (100000.0, 500.0, 435.0, 0.0, 0.0, True),  # no prestressed reinforcement
+        ],
+    )
+    def test_evaluation(self, f_td: float, a_s: float, f_yd: float, a_p: float, f_pd: float, expected: bool) -> None:
+        """Tests the evaluation of the result."""
+        assert bool(Form8Dot122CheckTieResistance(f_td=f_td, a_s=a_s, f_yd=f_yd, a_p=a_p, f_pd=f_pd)) is expected
+
+    @pytest.mark.parametrize(
+        ("f_td", "a_s", "f_yd", "a_p", "f_pd"),
+        [
+            (-200000.0, 300.0, 500.0, 100.0, 1000.0),  # f_td is negative
+            (200000.0, -300.0, 500.0, 100.0, 1000.0),  # a_s is negative
+            (200000.0, 300.0, -500.0, 100.0, 1000.0),  # f_yd is negative
+            (200000.0, 300.0, 500.0, -100.0, 1000.0),  # a_p is negative
+            (200000.0, 300.0, 500.0, 100.0, -1000.0),  # f_pd is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, f_td: float, a_s: float, f_yd: float, a_p: float, f_pd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot122CheckTieResistance(f_td=f_td, a_s=a_s, f_yd=f_yd, a_p=a_p, f_pd=f_pd)
+
+    @pytest.mark.parametrize(
+        ("f_td", "representation", "expected"),
+        [
+            (
+                200000.0,
+                "complete",
+                (
+                    r"CHECK \to F_{td} \leq A_s \cdot f_{yd} + A_p \cdot f_{pd} \to "
+                    r"200000.000 \leq 300.000 \cdot 500.000 + 100.000 \cdot 1000.000 \to OK"
+                ),
+            ),
+            (
+                200000.0,
+                "complete_with_units",
+                (
+                    r"CHECK \to F_{td} \leq A_s \cdot f_{yd} + A_p \cdot f_{pd} \to "
+                    r"200000.000 \ N \leq 300.000 \ mm^2 \cdot 500.000 \ MPa + 100.000 \ mm^2 \cdot 1000.000 \ MPa \to OK"
+                ),
+            ),
+            (200000.0, "short", r"CHECK \to OK"),
+            (300000.0, "short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex(self, f_td: float, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot122CheckTieResistance(f_td=f_td, a_s=300.0, f_yd=500.0, a_p=100.0, f_pd=1000.0).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
Adds formula (8.121) from clause 8.5.2(5) of FprEN 1992-1-1:2023, and formula (8.122) from clause 8.5.3(1). Both are printed on page 153 and follow directly on the struts and compression fields work of the previous pull requests in this clause.

Formula (8.121) is the refined, strain-based alternative for the strength reduction factor nu in cracked zones, offered by paragraph (5) as a more accurate option than the angle-based factor of paragraph (4). Formula (8.122) opens the next clause, 8.5.3 "Ties", with the resistance check for a tie.

## Decisions a reviewer has to weigh

- **(8.121) as `Formula`, not `ComparisonFormula`.** The standard prints "nu = 1 / (1,0 + 110*epsilon_1) <= 1,0", an assignment with an upper bound on the computed value, not a pass/fail check. It is implemented as `min(expression, 1.0)`, following the same pattern already used for (8.27).
- **The bound in (8.121) is never actually reached for valid input.** For epsilon_1 >= 0, the denominator is always >= 1.0, so the raw expression never exceeds 1.0; the bound is tight only at epsilon_1 = 0. The `min` is kept regardless, to match the standard's printed condition, and a code comment explains why it never binds.
- **(8.122) as `ComparisonFormula`.** Clause 8.5.3(1) introduces it with "The resistance of a tie F_Rd shall fulfil the following condition", which is a genuine verification (action <= resistance), not a bounded assignment.
- **The prestressing substitution of 7.6.5(1) is left to the caller.** The standard notes that f_pd may need to be replaced by (f_pd - sigma_pd) when prestressed reinforcement is considered as an external action. That substitution is documented in the parameter docstring but not enforced, consistent with how similar substitutions are handled elsewhere in this track.

## Formulas as implemented

**Formula (8.121)**, `Form8Dot121StrengthReductionFactorCrackedZone`

`equation`

$$
\nu = \min\left(\frac{1}{1.0 + 110 \cdot \varepsilon_1}, 1.0\right)
$$

`complete`

$$
\nu = \min\left(\frac{1}{1.0 + 110 \cdot \varepsilon_1}, 1.0\right) = \min\left(\frac{1}{1.0 + 110 \cdot 0.005}, 1.0\right) = 0.645 \ -
$$

`complete_with_units`

$$
\nu = \min\left(\frac{1}{1.0 + 110 \cdot \varepsilon_1}, 1.0\right) = \min\left(\frac{1}{1.0 + 110 \cdot 0.005}, 1.0\right) = 0.645 \ -
$$

**Formula (8.122)**, `Form8Dot122CheckTieResistance`

`equation`

$$
F_{td} \leq A_s \cdot f_{yd} + A_p \cdot f_{pd}
$$

`complete`

$$
CHECK \to F_{td} \leq A_s \cdot f_{yd} + A_p \cdot f_{pd} \to 200000.000 \leq 300.000 \cdot 500.000 + 100.000 \cdot 1000.000 \to OK
$$

`complete_with_units`

$$
CHECK \to F_{td} \leq A_s \cdot f_{yd} + A_p \cdot f_{pd} \to 200000.000 \ N \leq 300.000 \ mm^2 \cdot 500.000 \ MPa + 100.000 \ mm^2 \cdot 1000.000 \ MPa \to OK
$$

Contributes to #1083.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Eurocode 2 formula 8.121 for calculating the strength reduction factor in cracked compression zones.
  - Added formula 8.122 for checking tie resistance against the design tensile force.

- **Documentation**
  - Updated the Eurocode formula tracking table to mark formulas 8.121 and 8.122 as implemented.

- **Tests**
  - Added coverage for calculations, input validation, boundary conditions, and LaTeX output for both formulas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->