### PR TITLE
feat: add formulas 8.123 to 8.125 from FprEN 1992-1-1:2023 clause 8.5.5

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_123.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_123.py
@@ -1,0 +1,78 @@
+"""Formula 8.123 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG, N
+from blueprints.utils.math_helpers import tan
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot123TransverseTieForceSpreadingForces(Formula):
+    r"""Class representing formula 8.123 for the calculation of the transverse tie force from the spreading of
+    a concentrated force into a member.
+    """
+
+    label = "8.123"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        f_d: N,
+        theta_cf: DEG,
+    ) -> None:
+        r"""[$F_{td}$] Design value of the transverse tie force [$N$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.5(2) - Formula (8.123)
+
+        Parameters
+        ----------
+        f_d : N
+            [$F_d$] Concentrated force applied to the member [$N$].
+        theta_cf : DEG
+            [$\theta_{cf}$] Spreading angle, which may be assumed according to Formula (8.124), see
+            Form8Dot124SpreadingAngleTangent, or derived from an alternative approach fulfilling
+            8.5.2 to 8.5.4 [$degrees$].
+        """
+        super().__init__()
+        self.f_d = f_d
+        self.theta_cf = theta_cf
+
+    @staticmethod
+    def _evaluate(
+        f_d: N,
+        theta_cf: DEG,
+    ) -> N:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(f_d=f_d, theta_cf=theta_cf)
+
+        return (f_d / 2) * tan(theta_cf)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.123."""
+        _equation: str = r"\frac{F_d}{2} \cdot \tan(\theta_{cf})"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"F_d": f"{self.f_d:.{n}f}",
+                r"\theta_{cf}": f"{self.theta_cf:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"F_d": rf"{self.f_d:.{n}f} \ N",
+                r"\theta_{cf}": rf"{self.theta_cf:.{n}f} ^\circ",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"F_{td}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="N",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_124.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_124.py
@@ -1,0 +1,82 @@
+"""Formula 8.124 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot124SpreadingAngleTangent(Formula):
+    r"""Class representing formula 8.124 for the calculation of the tangent of the spreading angle of a
+    concentrated force introduced into a member.
+    """
+
+    label = "8.124"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a: MM,
+        b: MM,
+        h: MM,
+    ) -> None:
+        r"""[$\tan\theta_{cf}$] Tangent of the spreading angle [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.5(2) - Formula (8.124)
+
+        For the wide element case shown in Figures 8.30 c) and d), where [$b > a + H/2$], this formula is
+        replaced by [$\tan\theta_{cf} = 0.5$].
+
+        Parameters
+        ----------
+        a : MM
+            [$a$] Length of the loaded area in the direction considered, as defined in Figure 8.30 a) [$mm$].
+        b : MM
+            [$b$] Width of the member in the direction considered, as defined in Figure 8.30 a) [$mm$].
+        h : MM
+            [$H$] Height of the member over which the concentrated force spreads, as defined in Figure
+            8.30 c) and d) [$mm$].
+        """
+        super().__init__()
+        self.a = a
+        self.b = b
+        self.h = h
+
+    @staticmethod
+    def _evaluate(
+        a: MM,
+        b: MM,
+        h: MM,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a=a, h=h)
+        raise_if_less_or_equal_to_zero(b=b)
+
+        if b > a + h / 2:
+            return 0.5
+        return (1 - a / b) / 2
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.124."""
+        _equation: str = r"\begin{cases} \dfrac{1 - a/b}{2} & \text{if } b \leq a + H/2 \\ 0.5 & \text{if } b > a + H/2 \end{cases}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a/b": f"{self.a:.{n}f}/{self.b:.{n}f}",
+                r"a + H/2": f"{self.a:.{n}f} + {self.h:.{n}f}/2",
+                r"b \leq": f"{self.b:.{n}f} \\leq",
+                r"b >": f"{self.b:.{n}f} >",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = _numeric_equation
+        return LatexFormula(
+            return_symbol=r"\tan\theta_{cf}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_125.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_125.py
@@ -1,0 +1,76 @@
+"""Formula 8.125 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DEG, N
+from blueprints.utils.math_helpers import tan
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot125TransverseTieForceNearEdge(Formula):
+    r"""Class representing formula 8.125 for the calculation of the transverse tie force for a concentrated
+    force acting close to an edge.
+    """
+
+    label = "8.125"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        f_d: N,
+        theta_cf: DEG,
+    ) -> None:
+        r"""[$F_{td}$] Design value of the transverse tie force [$N$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.5.5(3) - Formula (8.125)
+
+        Parameters
+        ----------
+        f_d : N
+            [$F_d$] Concentrated force acting close to an edge [$N$].
+        theta_cf : DEG
+            [$\theta_{cf}$] Spreading angle, where [$\tan\theta_{cf} \geq 1/4$] may be assumed [$degrees$].
+        """
+        super().__init__()
+        self.f_d = f_d
+        self.theta_cf = theta_cf
+
+    @staticmethod
+    def _evaluate(
+        f_d: N,
+        theta_cf: DEG,
+    ) -> N:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(f_d=f_d, theta_cf=theta_cf)
+
+        return f_d * tan(theta_cf)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.125."""
+        _equation: str = r"F_d \cdot \tan(\theta_{cf})"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"F_d": f"{self.f_d:.{n}f}",
+                r"\theta_{cf}": f"{self.theta_cf:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"F_d": rf"{self.f_d:.{n}f} \ N",
+                r"\theta_{cf}": rf"{self.theta_cf:.{n}f} ^\circ",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"F_{td}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="N",
+        )

--- a/blueprints/utils/math_helpers.py
+++ b/blueprints/utils/math_helpers.py
@@ -24,6 +24,24 @@ def cot(x: DEG) -> DIMENSIONLESS:
     return float(1 / np.tan(np.deg2rad(x)))
 
 
+def tan(x: DEG) -> DIMENSIONLESS:
+    """Calculate the tangent of an angle in degrees.
+
+    Parameters
+    ----------
+    x : DEG
+        Angle in degrees.
+
+    Returns
+    -------
+    DIMENSIONLESS
+        Tangent of the angle.
+    """
+    raise_if_negative(x=x)
+    raise_if_greater_than_90(x=x)
+    return float(np.tan(np.deg2rad(x)))
+
+
 def sec(x: DEG) -> DIMENSIONLESS:
     """Calculate the secant of an angle in degrees.
 

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -184,9 +184,9 @@ Total of 602 formulas present.
 |     8.120      |        :x:         |         |                                                                    |
 |     8.121      |        :x:         |         |                                                                    |
 |     8.122      |        :x:         |         |                                                                    |
-|     8.123      |        :x:         |         |                                                                    |
-|     8.124      |        :x:         |         |                                                                    |
-|     8.125      |        :x:         |         |                                                                    |
+|     8.123      | :heavy_check_mark: |         | Form8Dot123TransverseTieForceSpreadingForces                      |
+|     8.124      | :heavy_check_mark: |         | Form8Dot124SpreadingAngleTangent                                  |
+|     8.125      | :heavy_check_mark: |         | Form8Dot125TransverseTieForceNearEdge                             |
 |     8.126      |        :x:         |         |                                                                    |
 |     8.127      |        :x:         |         |                                                                    |
 |     8.128      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_123.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_123.py
@@ -1,0 +1,78 @@
+"""Testing formula 8.123 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_123 import (
+    Form8Dot123TransverseTieForceSpreadingForces,
+)
+from blueprints.validations import NegativeValueError
+
+# Angle chosen so that its tangent is a round number, which keeps the hand calculation readable
+THETA_TAN_0_5 = 26.56505117707799  # tan(theta_cf) = 0.5
+
+
+class TestForm8Dot123TransverseTieForceSpreadingForces:
+    """Validation for formula 8.123 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        f_d = 100000.0
+        theta_cf = THETA_TAN_0_5
+
+        # Object to test
+        formula = Form8Dot123TransverseTieForceSpreadingForces(f_d=f_d, theta_cf=theta_cf)
+
+        # Expected result, manually calculated: (100000 / 2) * 0.5
+        manually_calculated_result = 25000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("f_d", "theta_cf"),
+        [
+            (-100000.0, THETA_TAN_0_5),  # f_d is negative
+            (100000.0, -30.0),  # theta_cf is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, f_d: float, theta_cf: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot123TransverseTieForceSpreadingForces(f_d=f_d, theta_cf=theta_cf)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"F_{td} = \frac{F_d}{2} \cdot \tan(\theta_{cf}) = "
+                    r"\frac{100000.000}{2} \cdot \tan(26.565) = 25000.000 \ N"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"F_{td} = \frac{F_d}{2} \cdot \tan(\theta_{cf}) = "
+                    r"\frac{100000.000 \ N}{2} \cdot \tan(26.565 ^\circ) = 25000.000 \ N"
+                ),
+            ),
+            ("short", r"F_{td} = 25000.000 \ N"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        f_d = 100000.0
+        theta_cf = THETA_TAN_0_5
+
+        # Object to test
+        latex = Form8Dot123TransverseTieForceSpreadingForces(f_d=f_d, theta_cf=theta_cf).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_124.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_124.py
@@ -1,0 +1,108 @@
+"""Testing formula 8.124 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_124 import (
+    Form8Dot124SpreadingAngleTangent,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot124SpreadingAngleTangent:
+    """Validation for formula 8.124 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation_narrow_element(self) -> None:
+        """Tests the evaluation of the result for a narrow element, where the (1 - a/b) / 2 expression governs."""
+        # Example values
+        a = 200.0
+        b = 500.0
+        h = 1000.0
+
+        # Object to test
+        formula = Form8Dot124SpreadingAngleTangent(a=a, b=b, h=h)
+
+        # Expected result, manually calculated: (1 - 200 / 500) / 2
+        manually_calculated_result = 0.3
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_wide_element(self) -> None:
+        """Tests the evaluation of the result for a wide element, where the fixed value of 0,5 governs."""
+        # Example values
+        a = 200.0
+        b = 800.0
+        h = 200.0
+
+        # Object to test
+        formula = Form8Dot124SpreadingAngleTangent(a=a, b=b, h=h)
+
+        # Expected result, as printed in the standard for the wide element case
+        manually_calculated_result = 0.5
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a", "b", "h"),
+        [
+            (-200.0, 500.0, 1000.0),  # a is negative
+            (200.0, 500.0, -1000.0),  # h is negative
+        ],
+    )
+    def test_raise_error_when_a_or_h_is_negative(self, a: float, b: float, h: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot124SpreadingAngleTangent(a=a, b=b, h=h)
+
+    @pytest.mark.parametrize(
+        "b",
+        [
+            -500.0,  # b is negative
+            0.0,  # b is zero
+        ],
+    )
+    def test_raise_error_when_b_is_less_or_equal_to_zero(self, b: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot124SpreadingAngleTangent(a=200.0, b=b, h=1000.0)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\tan\theta_{cf} = \begin{cases} \dfrac{1 - a/b}{2} & \text{if } b \leq a + H/2 \\ "
+                    r"0.5 & \text{if } b > a + H/2 \end{cases} = "
+                    r"\begin{cases} \dfrac{1 - 200.000/500.000}{2} & \text{if } 500.000 \leq 200.000 + 1000.000/2 \\ "
+                    r"0.5 & \text{if } 500.000 > 200.000 + 1000.000/2 \end{cases} = 0.300 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\tan\theta_{cf} = \begin{cases} \dfrac{1 - a/b}{2} & \text{if } b \leq a + H/2 \\ "
+                    r"0.5 & \text{if } b > a + H/2 \end{cases} = "
+                    r"\begin{cases} \dfrac{1 - 200.000/500.000}{2} & \text{if } 500.000 \leq 200.000 + 1000.000/2 \\ "
+                    r"0.5 & \text{if } 500.000 > 200.000 + 1000.000/2 \end{cases} = 0.300 \ -"
+                ),
+            ),
+            ("short", r"\tan\theta_{cf} = 0.300 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a = 200.0
+        b = 500.0
+        h = 1000.0
+
+        # Object to test
+        latex = Form8Dot124SpreadingAngleTangent(a=a, b=b, h=h).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_125.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_125.py
@@ -1,0 +1,72 @@
+"""Testing formula 8.125 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_125 import (
+    Form8Dot125TransverseTieForceNearEdge,
+)
+from blueprints.validations import NegativeValueError
+
+# Angle chosen so that its tangent is a round number, which keeps the hand calculation readable
+THETA_TAN_0_25 = 14.036243467926479  # tan(theta_cf) = 0.25
+
+
+class TestForm8Dot125TransverseTieForceNearEdge:
+    """Validation for formula 8.125 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        f_d = 100000.0
+        theta_cf = THETA_TAN_0_25
+
+        # Object to test
+        formula = Form8Dot125TransverseTieForceNearEdge(f_d=f_d, theta_cf=theta_cf)
+
+        # Expected result, manually calculated: 100000 * 0.25
+        manually_calculated_result = 25000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("f_d", "theta_cf"),
+        [
+            (-100000.0, THETA_TAN_0_25),  # f_d is negative
+            (100000.0, -14.0),  # theta_cf is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, f_d: float, theta_cf: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot125TransverseTieForceNearEdge(f_d=f_d, theta_cf=theta_cf)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"F_{td} = F_d \cdot \tan(\theta_{cf}) = 100000.000 \cdot \tan(14.036) = 25000.000 \ N",
+            ),
+            (
+                "complete_with_units",
+                r"F_{td} = F_d \cdot \tan(\theta_{cf}) = 100000.000 \ N \cdot \tan(14.036 ^\circ) = 25000.000 \ N",
+            ),
+            ("short", r"F_{td} = 25000.000 \ N"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        f_d = 100000.0
+        theta_cf = THETA_TAN_0_25
+
+        # Object to test
+        latex = Form8Dot125TransverseTieForceNearEdge(f_d=f_d, theta_cf=theta_cf).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/test_math_helpers.py
+++ b/tests/test_math_helpers.py
@@ -3,8 +3,24 @@
 import numpy as np
 import pytest
 
-from blueprints.utils.math_helpers import angle_to_slope, cot, csc, sec, slope_to_angle
+from blueprints.utils.math_helpers import angle_to_slope, cot, csc, sec, slope_to_angle, tan
 from blueprints.validations import GreaterThan90Error, LessOrEqualToZeroError, NegativeValueError
+
+
+class TestTan:
+    """Validation for tangent function."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        x = 45.0
+        expected_result = 1.0
+        assert tan(x) == pytest.approx(expected_result, rel=1e-4)
+
+    @pytest.mark.parametrize("x", [-45.0])
+    def test_raise_error_when_invalid_values_are_given(self, x: float) -> None:
+        """Test invalid values."""
+        with pytest.raises((NegativeValueError, GreaterThan90Error)):
+            tan(x)
 
 
 class TestCot:


### PR DESCRIPTION
Adds all three numbered formulas of clause 8.5.5 "Transfer of concentrated forces into a member" from FprEN 1992-1-1:2023: (8.123), (8.124) and (8.125), printed on pages 156 and 157. This completes clause 8.5.5.

Formula (8.123) gives the transverse tie force from the general spreading of a concentrated force into a member. Formula (8.124) is the spreading angle's tangent, either from a narrow-element expression or a fixed value for wide elements. Formula (8.125) gives the transverse tie force for a concentrated force acting close to an edge.

## Decisions a reviewer has to weigh

- **(8.123) and (8.125) take the angle theta_cf in degrees, not its tangent.** The printed formulas multiply by tan(theta_cf). An earlier draft took the tangent directly as a dimensionless input, reasoning that the standard itself chains tan(theta_cf) as a value between (8.124) and these two formulas. That was flagged in review as the same defect found and corrected in (8.55) to (8.57): a trigonometric ratio as a parameter hides the angle's physical domain and lets two formulas silently receive inconsistent values. Both classes now take theta_cf: DEG and compute the tangent internally.
- **A `tan()` helper was added to `blueprints/utils/math_helpers.py`**, alongside the existing `cot()`, `sec()` and `csc()`, since this is the first formula in the package that needs a plain tangent of a design angle.
- **(8.124) as a casus with two branches.** The standard presents the narrow-element expression (1 - a/b) / 2 as the primary rule and the fixed value 0,5 for wide elements (Figures 8.30 c and d) as a replacement under the condition b > a + H/2. Both are implemented as one class; H only enters the branch condition, never the narrow-element expression itself, matching what is printed.
- **The recommendation "tan(theta_cf) >= 1/4 may be assumed" in (8.125) is not enforced.** It is worded as a permitted simplification for theta_cf, not a hard bound on the formula, so a caller may supply any valid angle.

## Formulas as implemented

**Formula (8.123)**, `Form8Dot123TransverseTieForceSpreadingForces`

`equation`

$$
F_{td} = \frac{F_d}{2} \cdot \tan(\theta_{cf})
$$

`complete`

$$
F_{td} = \frac{F_d}{2} \cdot \tan(\theta_{cf}) = \frac{100000.000}{2} \cdot \tan(26.565) = 25000.000 \ N
$$

`complete_with_units`

$$
F_{td} = \frac{F_d}{2} \cdot \tan(\theta_{cf}) = \frac{100000.000 \ N}{2} \cdot \tan(26.565 ^\circ) = 25000.000 \ N
$$

**Formula (8.124)**, `Form8Dot124SpreadingAngleTangent`

`equation`

$$
\tan\theta_{cf} = \begin{cases} \dfrac{1 - a/b}{2} & \text{if } b \leq a + H/2 \\ 0.5 & \text{if } b > a + H/2 \end{cases}
$$

`complete`

$$
\tan\theta_{cf} = \begin{cases} \dfrac{1 - a/b}{2} & \text{if } b \leq a + H/2 \\ 0.5 & \text{if } b > a + H/2 \end{cases} = \begin{cases} \dfrac{1 - 200.000/500.000}{2} & \text{if } 500.000 \leq 200.000 + 1000.000/2 \\ 0.5 & \text{if } 500.000 > 200.000 + 1000.000/2 \end{cases} = 0.300 \ -
$$

`complete_with_units`

$$
\tan\theta_{cf} = \begin{cases} \dfrac{1 - a/b}{2} & \text{if } b \leq a + H/2 \\ 0.5 & \text{if } b > a + H/2 \end{cases} = \begin{cases} \dfrac{1 - 200.000/500.000}{2} & \text{if } 500.000 \leq 200.000 + 1000.000/2 \\ 0.5 & \text{if } 500.000 > 200.000 + 1000.000/2 \end{cases} = 0.300 \ -
$$

**Formula (8.125)**, `Form8Dot125TransverseTieForceNearEdge`

`equation`

$$
F_d \cdot \tan(\theta_{cf})
$$

`complete`

$$
F_{td} = F_d \cdot \tan(\theta_{cf}) = 100000.000 \cdot \tan(14.036) = 25000.000 \ N
$$

`complete_with_units`

$$
F_{td} = F_d \cdot \tan(\theta_{cf}) = 100000.000 \ N \cdot \tan(14.036 ^\circ) = 25000.000 \ N
$$

Contributes to #1083.
