### PR TITLE
feat: add formulas 8.126 to 8.129 from FprEN 1992-1-1:2023 clause 8.6

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_126.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_126.py
@@ -1,0 +1,101 @@
+"""Formula 8.126 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import operator
+from collections.abc import Callable
+
+import numpy as np
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import ComparisonFormula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MM2, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot126CheckPartiallyLoadedAreaResistance(ComparisonFormula):
+    r"""Class representing formula 8.126 for the verification of the design resistance of a partially loaded
+    area.
+    """
+
+    label = "8.126"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(self, f_cd: MPA, a_c1: MM2, a_c0: MM2, nu_part: DIMENSIONLESS) -> None:
+        r"""Verify the design resistance of a partially loaded area.
+
+        FprEN 1992-1-1:2023 (E) art 8.6 (2) - Formula (8.126)
+
+        Parameters
+        ----------
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        a_c1 : MM2
+            [$A_{c1}$] Contributing concrete area according to Formula (8.129), see
+            Form8Dot129ContributingConcreteArea [$mm^2$].
+        a_c0 : MM2
+            [$A_{c0}$] Loaded area according to Formula (8.127) or (8.128), see
+            Form8Dot127ConcentricallyLoadedArea or Form8Dot128EccentricallyLoadedArea [$mm^2$].
+        nu_part : DIMENSIONLESS
+            [$\nu_{part}$] Confinement factor. A value of 3,0 may be adopted unless larger resistance can be
+            justified based on refined analysis including tensile stresses due to load or restraint,
+            where relevant [$-$].
+        """
+        super().__init__()
+        self.f_cd = f_cd
+        self.a_c1 = a_c1
+        self.a_c0 = a_c0
+        self.nu_part = nu_part
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(f_cd: MPA, a_c1: MM2, a_c0: MM2, *_args, **_kwargs) -> float:
+        """Evaluates the design resistance, for more information see the __init__ method."""
+        raise_if_negative(f_cd=f_cd, a_c1=a_c1)
+        raise_if_less_or_equal_to_zero(a_c0=a_c0)
+
+        return float(f_cd * np.sqrt(a_c1 / a_c0))
+
+    @staticmethod
+    def _evaluate_rhs(f_cd: MPA, nu_part: DIMENSIONLESS, *_args, **_kwargs) -> float:
+        """Evaluates the limit on the design resistance, for more information see the __init__ method."""
+        raise_if_negative(f_cd=f_cd, nu_part=nu_part)
+
+        return float(nu_part * f_cd)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.126."""
+        _equation: str = r"\sigma_{Rdu} = f_{cd} \cdot \sqrt{\frac{A_{c1}}{A_{c0}}} \leq \nu_{part} \cdot f_{cd}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\sigma_{Rdu}": f"{self.lhs:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+                r"A_{c1}": f"{self.a_c1:.{n}f}",
+                r"A_{c0}": f"{self.a_c0:.{n}f}",
+                r"\nu_{part}": f"{self.nu_part:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\sigma_{Rdu}": rf"{self.lhs:.{n}f} \ MPa",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+                r"A_{c1}": rf"{self.a_c1:.{n}f} \ mm^2",
+                r"A_{c0}": rf"{self.a_c0:.{n}f} \ mm^2",
+                r"\nu_{part}": f"{self.nu_part:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label=r"\to",
+            unit="",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_127.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_127.py
@@ -1,0 +1,74 @@
+"""Formula 8.127 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot127ConcentricallyLoadedArea(Formula):
+    r"""Class representing formula 8.127 for the calculation of a concentrically loaded area."""
+
+    label = "8.127"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a_0: MM,
+        b_0: MM,
+    ) -> None:
+        r"""[$A_{c0}$] Concentrically loaded area [$mm^2$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.6(2) - Formula (8.127)
+
+        Parameters
+        ----------
+        a_0 : MM
+            [$a_0$] Length of the loaded area in the direction perpendicular to the closest edge of the load
+            introduction block, see Figure 8.32 [$mm$].
+        b_0 : MM
+            [$b_0$] Width of the loaded area, see Figure 8.32 [$mm$].
+        """
+        super().__init__()
+        self.a_0 = a_0
+        self.b_0 = b_0
+
+    @staticmethod
+    def _evaluate(
+        a_0: MM,
+        b_0: MM,
+    ) -> MM2:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_0=a_0, b_0=b_0)
+
+        return a_0 * b_0
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.127."""
+        _equation: str = r"a_0 \cdot b_0"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_0": f"{self.a_0:.{n}f}",
+                r"b_0": f"{self.b_0:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_0": rf"{self.a_0:.{n}f} \ mm",
+                r"b_0": rf"{self.b_0:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"A_{c0}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm^2",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_128.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_128.py
@@ -1,0 +1,93 @@
+"""Formula 8.128 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot128EccentricallyLoadedArea(Formula):
+    r"""Class representing formula 8.128 for the calculation of an eccentrically loaded area."""
+
+    label = "8.128"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a_0: MM,
+        e_a: MM,
+        b_0: MM,
+        e_b: MM,
+    ) -> None:
+        r"""[$A_{c0,red}$] Eccentrically loaded area [$mm^2$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.6(2) - Formula (8.128)
+
+        [$a_{0,red}$] and [$b_{0,red}$] follow from [$a_{0,red} = a_0 - 2 \cdot e_a$] and
+        [$b_{0,red} = b_0 - 2 \cdot e_b$], see Figure 8.33 a).
+
+        Parameters
+        ----------
+        a_0 : MM
+            [$a_0$] Length of the loaded area in the direction perpendicular to the closest edge of the load
+            introduction block, see Figure 8.32 [$mm$].
+        e_a : MM
+            [$e_a$] Eccentricity of the applied load to the center of [$A_{c0}$], parallel to [$a_0$] [$mm$].
+        b_0 : MM
+            [$b_0$] Width of the loaded area, see Figure 8.32 [$mm$].
+        e_b : MM
+            [$e_b$] Eccentricity of the applied load to the center of [$A_{c0}$], parallel to [$b_0$] [$mm$].
+        """
+        super().__init__()
+        self.a_0 = a_0
+        self.e_a = e_a
+        self.b_0 = b_0
+        self.e_b = e_b
+
+    @staticmethod
+    def _evaluate(
+        a_0: MM,
+        e_a: MM,
+        b_0: MM,
+        e_b: MM,
+    ) -> MM2:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_0=a_0, b_0=b_0)
+
+        a_0_red = a_0 - 2 * e_a
+        b_0_red = b_0 - 2 * e_b
+        return a_0_red * b_0_red
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.128."""
+        _equation: str = r"\left(a_0 - 2 \cdot e_a\right) \cdot \left(b_0 - 2 \cdot e_b\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_0": f"{self.a_0:.{n}f}",
+                r"e_a": f"{self.e_a:.{n}f}",
+                r"b_0": f"{self.b_0:.{n}f}",
+                r"e_b": f"{self.e_b:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a_0": rf"{self.a_0:.{n}f} \ mm",
+                r"e_a": rf"{self.e_a:.{n}f} \ mm",
+                r"b_0": rf"{self.b_0:.{n}f} \ mm",
+                r"e_b": rf"{self.e_b:.{n}f} \ mm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"A_{c0,red}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm^2",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_129.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_129.py
@@ -1,0 +1,94 @@
+"""Formula 8.129 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot129ContributingConcreteArea(Formula):
+    r"""Class representing formula 8.129 for the calculation of the contributing concrete area."""
+
+    label = "8.129"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a: MM,
+        a_0: MM,
+        b_0: MM,
+        b: MM,
+    ) -> None:
+        r"""[$A_{c1}$] Contributing concrete area [$mm^2$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.6(2) - Formula (8.129)
+
+        [$a_1$] is taken equal to [$a$], the length of the load introduction block parallel to [$a_0$], and
+        [$b_1 = \min\left(b_0 + \left(a_1 - a_0\right), b\right)$], see Figure 8.32. The minimum height of the
+        load introduction block should be [$h \geq a_1$].
+
+        Parameters
+        ----------
+        a : MM
+            [$a$] Length of the load introduction block parallel to [$a_0$], see Figure 8.32 [$mm$].
+        a_0 : MM
+            [$a_0$] Length of the loaded area in the direction perpendicular to the closest edge of the load
+            introduction block, see Figure 8.32 [$mm$].
+        b_0 : MM
+            [$b_0$] Width of the loaded area, see Figure 8.32 [$mm$].
+        b : MM
+            [$b$] Width of the load introduction block, see Figure 8.32 [$mm$].
+        """
+        super().__init__()
+        self.a = a
+        self.a_0 = a_0
+        self.b_0 = b_0
+        self.b = b
+
+    @staticmethod
+    def _evaluate(
+        a: MM,
+        a_0: MM,
+        b_0: MM,
+        b: MM,
+    ) -> MM2:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a=a, a_0=a_0, b_0=b_0, b=b)
+
+        a_1 = a
+        b_1 = min(b_0 + (a_1 - a_0), b)
+        return a_1 * b_1
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.129."""
+        _equation: str = r"a \cdot \min\left(b_0 + \left(a - a_0\right), b\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a - a_0": f"{self.a:.{n}f} - {self.a_0:.{n}f}",
+                r"b_0": f"{self.b_0:.{n}f}",
+                r", b\right)": f", {self.b:.{n}f}" + r"\right)",
+                r"a \cdot": f"{self.a:.{n}f} \\cdot",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"a - a_0": rf"{self.a:.{n}f} \ mm - {self.a_0:.{n}f} \ mm",
+                r"b_0": rf"{self.b_0:.{n}f} \ mm",
+                r", b\right)": f", {self.b:.{n}f} \\ mm" + r"\right)",
+                r"a \cdot": rf"{self.a:.{n}f} \ mm \cdot",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"A_{c1}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="mm^2",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -187,10 +187,10 @@ Total of 602 formulas present.
 |     8.123      |        :x:         |         |                                                                    |
 |     8.124      |        :x:         |         |                                                                    |
 |     8.125      |        :x:         |         |                                                                    |
-|     8.126      |        :x:         |         |                                                                    |
-|     8.127      |        :x:         |         |                                                                    |
-|     8.128      |        :x:         |         |                                                                    |
-|     8.129      |        :x:         |         |                                                                    |
+|     8.126      | :heavy_check_mark: |         | Form8Dot126CheckPartiallyLoadedAreaResistance                     |
+|     8.127      | :heavy_check_mark: |         | Form8Dot127ConcentricallyLoadedArea                               |
+|     8.128      | :heavy_check_mark: |         | Form8Dot128EccentricallyLoadedArea                                |
+|     8.129      | :heavy_check_mark: |         | Form8Dot129ContributingConcreteArea                               |
 |      9.1       |        :x:         |         |                                                                    |
 |      9.2       |        :x:         |         |                                                                    |
 |      9.3       |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_126.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_126.py
@@ -1,0 +1,86 @@
+"""Testing formula 8.126 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_126 import (
+    Form8Dot126CheckPartiallyLoadedAreaResistance,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot126CheckPartiallyLoadedAreaResistance:
+    """Validation for formula 8.126 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("f_cd", "a_c1", "a_c0", "nu_part", "expected"),
+        [
+            (20.0, 90000.0, 40000.0, 3.0, True),  # the design resistance suffices
+            (20.0, 360000.0, 40000.0, 3.0, True),  # exactly on the boundary, which the standard includes
+            (20.0, 490000.0, 40000.0, 3.0, False),  # the design resistance does not suffice
+        ],
+    )
+    def test_evaluation(self, f_cd: float, a_c1: float, a_c0: float, nu_part: float, expected: bool) -> None:
+        """Tests the evaluation of the result."""
+        assert bool(Form8Dot126CheckPartiallyLoadedAreaResistance(f_cd=f_cd, a_c1=a_c1, a_c0=a_c0, nu_part=nu_part)) is expected
+
+    @pytest.mark.parametrize(
+        ("f_cd", "a_c1", "a_c0", "nu_part"),
+        [
+            (-20.0, 90000.0, 40000.0, 3.0),  # f_cd is negative
+            (20.0, -90000.0, 40000.0, 3.0),  # a_c1 is negative
+            (20.0, 90000.0, 40000.0, -3.0),  # nu_part is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, f_cd: float, a_c1: float, a_c0: float, nu_part: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot126CheckPartiallyLoadedAreaResistance(f_cd=f_cd, a_c1=a_c1, a_c0=a_c0, nu_part=nu_part)
+
+    @pytest.mark.parametrize(
+        "a_c0",
+        [
+            -40000.0,  # a_c0 is negative
+            0.0,  # a_c0 is zero
+        ],
+    )
+    def test_raise_error_when_a_c0_is_less_or_equal_to_zero(self, a_c0: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot126CheckPartiallyLoadedAreaResistance(f_cd=20.0, a_c1=90000.0, a_c0=a_c0, nu_part=3.0)
+
+    @pytest.mark.parametrize(
+        ("a_c1", "representation", "expected"),
+        [
+            (
+                90000.0,
+                "complete",
+                (
+                    r"CHECK \to \sigma_{Rdu} = f_{cd} \cdot \sqrt{\frac{A_{c1}}{A_{c0}}} \leq \nu_{part} \cdot f_{cd} \to "
+                    r"30.000 = 20.000 \cdot \sqrt{\frac{90000.000}{40000.000}} \leq 3.000 \cdot 20.000 \to OK"
+                ),
+            ),
+            (
+                90000.0,
+                "complete_with_units",
+                (
+                    r"CHECK \to \sigma_{Rdu} = f_{cd} \cdot \sqrt{\frac{A_{c1}}{A_{c0}}} \leq \nu_{part} \cdot f_{cd} \to "
+                    r"30.000 \ MPa = 20.000 \ MPa \cdot \sqrt{\frac{90000.000 \ mm^2}{40000.000 \ mm^2}} \leq "
+                    r"3.000 \cdot 20.000 \ MPa \to OK"
+                ),
+            ),
+            (90000.0, "short", r"CHECK \to OK"),
+            (490000.0, "short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex(self, a_c1: float, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot126CheckPartiallyLoadedAreaResistance(f_cd=20.0, a_c1=a_c1, a_c0=40000.0, nu_part=3.0).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_127.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_127.py
@@ -1,0 +1,66 @@
+"""Testing formula 8.127 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_127 import (
+    Form8Dot127ConcentricallyLoadedArea,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot127ConcentricallyLoadedArea:
+    """Validation for formula 8.127 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_0 = 300.0
+        b_0 = 400.0
+
+        # Object to test
+        formula = Form8Dot127ConcentricallyLoadedArea(a_0=a_0, b_0=b_0)
+
+        # Expected result, manually calculated: 300 * 400
+        manually_calculated_result = 120000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_0", "b_0"),
+        [
+            (-300.0, 400.0),  # a_0 is negative
+            (300.0, -400.0),  # b_0 is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_0: float, b_0: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot127ConcentricallyLoadedArea(a_0=a_0, b_0=b_0)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            ("complete", r"A_{c0} = a_0 \cdot b_0 = 300.000 \cdot 400.000 = 120000.000 \ mm^2"),
+            (
+                "complete_with_units",
+                r"A_{c0} = a_0 \cdot b_0 = 300.000 \ mm \cdot 400.000 \ mm = 120000.000 \ mm^2",
+            ),
+            ("short", r"A_{c0} = 120000.000 \ mm^2"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_0 = 300.0
+        b_0 = 400.0
+
+        # Object to test
+        latex = Form8Dot127ConcentricallyLoadedArea(a_0=a_0, b_0=b_0).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_128.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_128.py
@@ -1,0 +1,80 @@
+"""Testing formula 8.128 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_128 import (
+    Form8Dot128EccentricallyLoadedArea,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot128EccentricallyLoadedArea:
+    """Validation for formula 8.128 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_0 = 300.0
+        e_a = 20.0
+        b_0 = 400.0
+        e_b = 25.0
+
+        # Object to test
+        formula = Form8Dot128EccentricallyLoadedArea(a_0=a_0, e_a=e_a, b_0=b_0, e_b=e_b)
+
+        # Expected result, manually calculated: (300 - 2 * 20) * (400 - 2 * 25) = 260 * 350
+        manually_calculated_result = 91000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_0", "b_0"),
+        [
+            (-300.0, 400.0),  # a_0 is negative
+            (300.0, -400.0),  # b_0 is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_0: float, b_0: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot128EccentricallyLoadedArea(a_0=a_0, e_a=20.0, b_0=b_0, e_b=25.0)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"A_{c0,red} = \left(a_0 - 2 \cdot e_a\right) \cdot \left(b_0 - 2 \cdot e_b\right) = "
+                    r"\left(300.000 - 2 \cdot 20.000\right) \cdot \left(400.000 - 2 \cdot 25.000\right) = 91000.000 \ mm^2"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"A_{c0,red} = \left(a_0 - 2 \cdot e_a\right) \cdot \left(b_0 - 2 \cdot e_b\right) = "
+                    r"\left(300.000 \ mm - 2 \cdot 20.000 \ mm\right) \cdot \left(400.000 \ mm - 2 \cdot 25.000 \ mm\right) = "
+                    r"91000.000 \ mm^2"
+                ),
+            ),
+            ("short", r"A_{c0,red} = 91000.000 \ mm^2"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_0 = 300.0
+        e_a = 20.0
+        b_0 = 400.0
+        e_b = 25.0
+
+        # Object to test
+        latex = Form8Dot128EccentricallyLoadedArea(a_0=a_0, e_a=e_a, b_0=b_0, e_b=e_b).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_129.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_129.py
@@ -1,0 +1,98 @@
+"""Testing formula 8.129 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_129 import (
+    Form8Dot129ContributingConcreteArea,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot129ContributingConcreteArea:
+    """Validation for formula 8.129 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation_expression_governs(self) -> None:
+        """Tests the evaluation of the result where the b0 + (a - a0) expression governs."""
+        # Example values
+        a = 500.0
+        a_0 = 450.0
+        b_0 = 100.0
+        b = 1000.0
+
+        # Object to test
+        formula = Form8Dot129ContributingConcreteArea(a=a, a_0=a_0, b_0=b_0, b=b)
+
+        # Expected result, manually calculated: 500 * min(100 + (500 - 450), 1000) = 500 * 150
+        manually_calculated_result = 75000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_bound_governs(self) -> None:
+        """Tests the evaluation of the result where the bound b governs."""
+        # Example values
+        a = 500.0
+        a_0 = 200.0
+        b_0 = 100.0
+        b = 350.0
+
+        # Object to test
+        formula = Form8Dot129ContributingConcreteArea(a=a, a_0=a_0, b_0=b_0, b=b)
+
+        # Expected result, manually calculated: 500 * min(100 + (500 - 200), 350) = 500 * 350
+        manually_calculated_result = 175000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a", "a_0", "b_0", "b"),
+        [
+            (-500.0, 300.0, 400.0, 600.0),  # a is negative
+            (500.0, -300.0, 400.0, 600.0),  # a_0 is negative
+            (500.0, 300.0, -400.0, 600.0),  # b_0 is negative
+            (500.0, 300.0, 400.0, -600.0),  # b is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a: float, a_0: float, b_0: float, b: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot129ContributingConcreteArea(a=a, a_0=a_0, b_0=b_0, b=b)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"A_{c1} = a \cdot \min\left(b_0 + \left(a - a_0\right), b\right) = "
+                    r"500.000 \cdot \min\left(400.000 + \left(500.000 - 300.000\right), 600.000\right) = 300000.000 \ mm^2"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"A_{c1} = a \cdot \min\left(b_0 + \left(a - a_0\right), b\right) = "
+                    r"500.000 \ mm \cdot \min\left(400.000 \ mm + \left(500.000 \ mm - 300.000 \ mm\right), 600.000 \ mm\right) = "
+                    r"300000.000 \ mm^2"
+                ),
+            ),
+            ("short", r"A_{c1} = 300000.000 \ mm^2"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a = 500.0
+        a_0 = 300.0
+        b_0 = 400.0
+        b = 600.0
+
+        # Object to test
+        latex = Form8Dot129ContributingConcreteArea(a=a, a_0=a_0, b_0=b_0, b=b).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
Adds formulas (8.126) to (8.129) from clause 8.6 "Partially loaded areas" of FprEN 1992-1-1:2023, all printed on page 158. This exceeds the usual cap of three formula classes per pull request, by explicit choice for this clause since all four are short and fit on a single page.

Formula (8.126) is the verification of the design resistance of a partially loaded area. Formulas (8.127) to (8.129) supply the three areas that (8.126) needs: the loaded area for concentric loading, the loaded area for eccentric loading, and the contributing concrete area.

## Decisions a reviewer has to weigh

- **(8.126) as `ComparisonFormula`.** Paragraph (2) introduces it with "The design resistance may be verified as follows", followed by an assignment with an upper bound in the same line (sigma_Rdu = ... <= nu_part * f_cd). This is the same shape as (8.60): a genuine verification, not a bounded value, so lhs is the computed stress and rhs is the limit.
- **nu_part is a caller-supplied input, not a hardcoded constant.** The standard gives 3,0 as the default "unless larger resistance can be justified based on refined analysis... where relevant". No further formula for the refined value is given on this page, so the choice is left to the caller, documented in the parameter docstring.
- **(8.128) and (8.129) compute their sub-terms internally.** a0,red/b0,red (under 8.128) and a1/b1 (under 8.129) are unnumbered definitions inside each formula's own "where" clause, not separately numbered formulas, so they are computed inline rather than exposed as separate classes or pre-computed inputs. a1 is taken directly as the parameter `a`, since the standard states "a1 = a" as a plain identity.

## Formulas as implemented

**Formula (8.126)**, `Form8Dot126CheckPartiallyLoadedAreaResistance`

`equation`

$$
\sigma_{Rdu} = f_{cd} \cdot \sqrt{\frac{A_{c1}}{A_{c0}}} \leq \nu_{part} \cdot f_{cd}
$$

`complete`

$$
CHECK \to \sigma_{Rdu} = f_{cd} \cdot \sqrt{\frac{A_{c1}}{A_{c0}}} \leq \nu_{part} \cdot f_{cd} \to 30.000 = 20.000 \cdot \sqrt{\frac{90000.000}{40000.000}} \leq 3.000 \cdot 20.000 \to OK
$$

`complete_with_units`

$$
CHECK \to \sigma_{Rdu} = f_{cd} \cdot \sqrt{\frac{A_{c1}}{A_{c0}}} \leq \nu_{part} \cdot f_{cd} \to 30.000 \ MPa = 20.000 \ MPa \cdot \sqrt{\frac{90000.000 \ mm^2}{40000.000 \ mm^2}} \leq 3.000 \cdot 20.000 \ MPa \to OK
$$

**Formula (8.127)**, `Form8Dot127ConcentricallyLoadedArea`

`equation`

$$
a_0 \cdot b_0
$$

`complete`

$$
A_{c0} = a_0 \cdot b_0 = 300.000 \cdot 400.000 = 120000.000 \ mm^2
$$

`complete_with_units`

$$
A_{c0} = a_0 \cdot b_0 = 300.000 \ mm \cdot 400.000 \ mm = 120000.000 \ mm^2
$$

**Formula (8.128)**, `Form8Dot128EccentricallyLoadedArea`

`equation`

$$
\left(a_0 - 2 \cdot e_a\right) \cdot \left(b_0 - 2 \cdot e_b\right)
$$

`complete`

$$
A_{c0,red} = \left(a_0 - 2 \cdot e_a\right) \cdot \left(b_0 - 2 \cdot e_b\right) = \left(300.000 - 2 \cdot 20.000\right) \cdot \left(400.000 - 2 \cdot 25.000\right) = 91000.000 \ mm^2
$$

`complete_with_units`

$$
A_{c0,red} = \left(a_0 - 2 \cdot e_a\right) \cdot \left(b_0 - 2 \cdot e_b\right) = \left(300.000 \ mm - 2 \cdot 20.000 \ mm\right) \cdot \left(400.000 \ mm - 2 \cdot 25.000 \ mm\right) = 91000.000 \ mm^2
$$

**Formula (8.129)**, `Form8Dot129ContributingConcreteArea`

`equation`

$$
a \cdot \min\left(b_0 + \left(a - a_0\right), b\right)
$$

`complete`

$$
A_{c1} = a \cdot \min\left(b_0 + \left(a - a_0\right), b\right) = 500.000 \cdot \min\left(400.000 + \left(500.000 - 300.000\right), 600.000\right) = 300000.000 \ mm^2
$$

`complete_with_units`

$$
A_{c1} = a \cdot \min\left(b_0 + \left(a - a_0\right), b\right) = 500.000 \ mm \cdot \min\left(400.000 \ mm + \left(500.000 \ mm - 300.000 \ mm\right), 600.000 \ mm\right) = 300000.000 \ mm^2
$$

Contributes to #1083.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Eurocode 2 calculations for partially loaded concrete area resistance and concentrically, eccentrically, and contributing concrete areas.
  - Added validation for invalid dimensions and material inputs.
  - Added symbolic, numeric, and unit-aware formula representations.

- **Documentation**
  - Marked formulas 8.126–8.129 as implemented in the Eurocode formula reference.

- **Tests**
  - Added coverage for calculations, validation errors, outcomes, and LaTeX representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->