### PR TITLE
feat: add formulas 8.1 to 8.3 from FprEN 1992-1-1:2023 clause 8.1.1

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_1.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_1.py
@@ -1,0 +1,80 @@
+"""Formula 8.1 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, NMM, N
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form8Dot1MinimumDesignMoment(Formula):
+    r"""Class representing formula 8.1 for the calculation of the minimum design moment to be considered
+    together with an axial compression force.
+    """
+
+    label = "8.1"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        n_ed: N,
+        h: MM,
+    ) -> None:
+        r"""[$M_{Ed,min}$] Minimum design moment [$Nmm$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.1(5) - Formula (8.1)
+
+        The standard prints this moment as [$\pm N_{Ed} \cdot e_{d,min}$]: the cross-section shall be designed
+        for this minimum moment in both directions. This class returns the magnitude, and it is left to the
+        caller to apply it with either sign.
+
+        Parameters
+        ----------
+        n_ed : N
+            [$N_{Ed}$] Design axial compression force [$N$].
+        h : MM
+            [$h$] Overall depth of the cross-section [$mm$].
+        """
+        super().__init__()
+        self.n_ed = n_ed
+        self.h = h
+
+    @staticmethod
+    def _evaluate(
+        n_ed: N,
+        h: MM,
+    ) -> NMM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(h=h)
+
+        e_d_min = max(h / 30, 20)
+        return abs(n_ed) * e_d_min
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.1."""
+        _equation: str = r"\left|N_{Ed}\right| \cdot \max\left(\frac{h}{30}, 20\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"N_{Ed}": f"{self.n_ed:.{n}f}",
+                r"{h}": "{" + f"{self.h:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"N_{Ed}": rf"{self.n_ed:.{n}f} \ N",
+                r"{h}": "{" + rf"{self.h:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"M_{Ed,min}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="Nmm",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_2.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_2.py
@@ -1,0 +1,108 @@
+"""Formula 8.2 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+import operator
+from collections.abc import Callable
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import ComparisonFormula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, NMM
+from blueprints.validations import raise_if_less_or_equal_to_zero
+
+
+class Form8Dot2CheckBiaxialBending(ComparisonFormula):
+    r"""Class representing formula 8.2 for the simplified verification of biaxial bending."""
+
+    label = "8.2"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        m_edz: NMM,
+        m_rdz_n: NMM,
+        m_edy: NMM,
+        m_rdy_n: NMM,
+        a_n: DIMENSIONLESS,
+    ) -> None:
+        r"""Verify a cross-section for biaxial bending with a simplified criterion.
+
+        FprEN 1992-1-1:2023 (E) art 8.1.1(8) - Formula (8.2)
+
+        Parameters
+        ----------
+        m_edz : NMM
+            [$M_{Edz}$] Design moment about the z axis, including a 2nd order moment. Only its magnitude is
+            used, so it may be passed signed [$Nmm$].
+        m_rdz_n : NMM
+            [$M_{Rdz,N}$] Moment resistance about the z axis for the given axial compression force [$Nmm$].
+        m_edy : NMM
+            [$M_{Edy}$] Design moment about the y axis, including a 2nd order moment. Only its magnitude is
+            used, so it may be passed signed [$Nmm$].
+        m_rdy_n : NMM
+            [$M_{Rdy,N}$] Moment resistance about the y axis for the given axial compression force [$Nmm$].
+        a_n : DIMENSIONLESS
+            [$a_N$] Exponent, taken as 2 for circular and elliptical cross-sections. For rectangular
+            cross-sections it follows from [$\left|N_{Ed}\right|/N_{Rd,0}$] according to Formula (8.3), see
+            Form8Dot3AxialResistanceWithoutMoment: 1,0 at a ratio of 0,1, 1,5 at 0,7 and 2,0 at 1,0, with
+            linear interpolation for intermediate values [$-$].
+        """
+        super().__init__()
+        self.m_edz = m_edz
+        self.m_rdz_n = m_rdz_n
+        self.m_edy = m_edy
+        self.m_rdy_n = m_rdy_n
+        self.a_n = a_n
+
+    @classmethod
+    def _comparison_operator(cls) -> Callable[[float, float], bool]:
+        return operator.le
+
+    @staticmethod
+    def _evaluate_lhs(m_edz: NMM, m_rdz_n: NMM, m_edy: NMM, m_rdy_n: NMM, a_n: DIMENSIONLESS, *_args, **_kwargs) -> float:
+        """Evaluates the biaxial bending ratio, for more information see the __init__ method."""
+        raise_if_less_or_equal_to_zero(m_rdz_n=m_rdz_n, m_rdy_n=m_rdy_n)
+
+        return float((abs(m_edz) / m_rdz_n) ** a_n + (abs(m_edy) / m_rdy_n) ** a_n)
+
+    @staticmethod
+    def _evaluate_rhs(*_args, **_kwargs) -> float:
+        """Evaluates the limit of the biaxial bending ratio, for more information see the __init__ method."""
+        return 1.0
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.2."""
+        _equation: str = (
+            r"\left(\frac{\left|M_{Edz}\right|}{M_{Rdz,N}}\right)^{a_N} + "
+            r"\left(\frac{\left|M_{Edy}\right|}{M_{Rdy,N}}\right)^{a_N} \leq 1.0"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"M_{Edz}": f"{self.m_edz:.{n}f}",
+                r"M_{Rdz,N}": f"{self.m_rdz_n:.{n}f}",
+                r"M_{Edy}": f"{self.m_edy:.{n}f}",
+                r"M_{Rdy,N}": f"{self.m_rdy_n:.{n}f}",
+                r"a_N": f"{self.a_n:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"M_{Edz}": rf"{self.m_edz:.{n}f} \ Nmm",
+                r"M_{Rdz,N}": rf"{self.m_rdz_n:.{n}f} \ Nmm",
+                r"M_{Edy}": rf"{self.m_edy:.{n}f} \ Nmm",
+                r"M_{Rdy,N}": rf"{self.m_rdy_n:.{n}f} \ Nmm",
+                r"a_N": f"{self.a_n:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"CHECK",
+            result="OK" if self.__bool__() else r"\text{Not OK}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label=r"\to",
+            unit="",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_3.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_3.py
@@ -1,0 +1,92 @@
+"""Formula 8.3 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM2, MPA, N
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot3AxialResistanceWithoutMoment(Formula):
+    r"""Class representing formula 8.3 for the calculation of the design value of axial resistance under
+    compression without accompanying moments.
+    """
+
+    label = "8.3"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a_c: MM2,
+        f_cd: MPA,
+        a_s: MM2,
+        f_yd: MPA,
+    ) -> None:
+        r"""[$N_{Rd,0}$] Design value of axial resistance under compression without accompanying moments [$N$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.1(8) - Formula (8.3)
+
+        In case of members with confinement reinforcement, [$f_{cd}$] should be replaced by [$f_{cd,c}$]
+        according to Formula (8.15).
+
+        Parameters
+        ----------
+        a_c : MM2
+            [$A_c$] Cross-sectional area of the concrete [$mm^2$].
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        a_s : MM2
+            [$A_s$] Cross-sectional area of the reinforcement [$mm^2$].
+        f_yd : MPA
+            [$f_{yd}$] Design value of the yield strength of the reinforcement [$MPa$].
+        """
+        super().__init__()
+        self.a_c = a_c
+        self.f_cd = f_cd
+        self.a_s = a_s
+        self.f_yd = f_yd
+
+    @staticmethod
+    def _evaluate(
+        a_c: MM2,
+        f_cd: MPA,
+        a_s: MM2,
+        f_yd: MPA,
+    ) -> N:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_c=a_c, f_cd=f_cd, a_s=a_s, f_yd=f_yd)
+
+        return a_c * f_cd + a_s * f_yd
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.3."""
+        _equation: str = r"A_c \cdot f_{cd} + A_s \cdot f_{yd}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_c": f"{self.a_c:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+                r"A_s": f"{self.a_s:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_c": rf"{self.a_c:.{n}f} \ mm^2",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+                r"A_s": rf"{self.a_s:.{n}f} \ mm^2",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"N_{Rd,0}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="N",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -62,9 +62,9 @@ Total of 602 formulas present.
 |      7.33      |        :x:         |         |                                                                    |
 |      7.34      |        :x:         |         |                                                                    |
 |      7.35      |        :x:         |         |                                                                    |
-|      8.1       |        :x:         |         |                                                                    |
-|      8.2       |        :x:         |         |                                                                    |
-|      8.3       |        :x:         |         |                                                                    |
+|      8.1       | :heavy_check_mark: |         | Form8Dot1MinimumDesignMoment                                       |
+|      8.2       | :heavy_check_mark: |         | Form8Dot2CheckBiaxialBending                                       |
+|      8.3       | :heavy_check_mark: |         | Form8Dot3AxialResistanceWithoutMoment                              |
 |      8.4       |        :x:         |         |                                                                    |
 |      8.5       |        :x:         |         |                                                                    |
 |      8.6       |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_1.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_1.py
@@ -1,0 +1,103 @@
+"""Testing formula 8.1 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_1 import (
+    Form8Dot1MinimumDesignMoment,
+)
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm8Dot1MinimumDesignMoment:
+    """Validation for formula 8.1 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation_expression_governs(self) -> None:
+        """Tests the evaluation of the result where h / 30 governs."""
+        # Example values
+        n_ed = 500000.0
+        h = 900.0
+
+        # Object to test
+        formula = Form8Dot1MinimumDesignMoment(n_ed=n_ed, h=h)
+
+        # Expected result, manually calculated: 500000 * max(900 / 30, 20) = 500000 * 30
+        manually_calculated_result = 15000000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_bound_governs(self) -> None:
+        """Tests the evaluation of the result where the bound of 20 mm governs."""
+        # Example values
+        n_ed = 500000.0
+        h = 300.0
+
+        # Object to test
+        formula = Form8Dot1MinimumDesignMoment(n_ed=n_ed, h=h)
+
+        # Expected result, manually calculated: 500000 * max(300 / 30, 20) = 500000 * 20
+        manually_calculated_result = 10000000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_negative_axial_force(self) -> None:
+        """Tests the evaluation of the result when the axial force is given as a negative value."""
+        # Example values
+        n_ed = -500000.0
+        h = 900.0
+
+        # Object to test
+        formula = Form8Dot1MinimumDesignMoment(n_ed=n_ed, h=h)
+
+        # Expected result, manually calculated: |-500000| * max(900 / 30, 20) = 500000 * 30
+        manually_calculated_result = 15000000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        "h",
+        [
+            -900.0,  # h is negative
+            0.0,  # h is zero
+        ],
+    )
+    def test_raise_error_when_h_is_less_or_equal_to_zero(self, h: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot1MinimumDesignMoment(n_ed=500000.0, h=h)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"M_{Ed,min} = \left|N_{Ed}\right| \cdot \max\left(\frac{h}{30}, 20\right) = "
+                    r"\left|500000.000\right| \cdot \max\left(\frac{900.000}{30}, 20\right) = 15000000.000 \ Nmm"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"M_{Ed,min} = \left|N_{Ed}\right| \cdot \max\left(\frac{h}{30}, 20\right) = "
+                    r"\left|500000.000 \ N\right| \cdot \max\left(\frac{900.000 \ mm}{30}, 20\right) = 15000000.000 \ Nmm"
+                ),
+            ),
+            ("short", r"M_{Ed,min} = 15000000.000 \ Nmm"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        n_ed = 500000.0
+        h = 900.0
+
+        # Object to test
+        latex = Form8Dot1MinimumDesignMoment(n_ed=n_ed, h=h).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_2.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_2.py
@@ -1,0 +1,83 @@
+"""Testing formula 8.2 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_2 import (
+    Form8Dot2CheckBiaxialBending,
+)
+from blueprints.validations import LessOrEqualToZeroError
+
+
+class TestForm8Dot2CheckBiaxialBending:
+    """Validation for formula 8.2 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("m_edz", "expected"),
+        [
+            (100e6, True),  # the biaxial bending criterion is satisfied
+            (190e6, False),  # the biaxial bending criterion is not satisfied
+        ],
+    )
+    def test_evaluation(self, m_edz: float, expected: bool) -> None:
+        """Tests the evaluation of the result."""
+        formula = Form8Dot2CheckBiaxialBending(m_edz=m_edz, m_rdz_n=200e6, m_edy=50e6, m_rdy_n=150e6, a_n=1.5)
+        assert bool(formula) is expected
+
+    def test_evaluation_negative_moments(self) -> None:
+        """Tests that only the magnitude of the moments is used."""
+        formula = Form8Dot2CheckBiaxialBending(m_edz=-100e6, m_rdz_n=200e6, m_edy=-50e6, m_rdy_n=150e6, a_n=1.5)
+        assert bool(formula) is True
+
+    @pytest.mark.parametrize(
+        ("m_rdz_n", "m_rdy_n"),
+        [
+            (-200e6, 150e6),  # m_rdz_n is negative
+            (0.0, 150e6),  # m_rdz_n is zero
+            (200e6, -150e6),  # m_rdy_n is negative
+            (200e6, 0.0),  # m_rdy_n is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, m_rdz_n: float, m_rdy_n: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot2CheckBiaxialBending(m_edz=100e6, m_rdz_n=m_rdz_n, m_edy=50e6, m_rdy_n=m_rdy_n, a_n=1.5)
+
+    @pytest.mark.parametrize(
+        ("m_edz", "representation", "expected"),
+        [
+            (
+                100e6,
+                "complete",
+                (
+                    r"CHECK \to \left(\frac{\left|M_{Edz}\right|}{M_{Rdz,N}}\right)^{a_N} + "
+                    r"\left(\frac{\left|M_{Edy}\right|}{M_{Rdy,N}}\right)^{a_N} \leq 1.0 \to "
+                    r"\left(\frac{\left|100000000.000\right|}{200000000.000}\right)^{1.500} + "
+                    r"\left(\frac{\left|50000000.000\right|}{150000000.000}\right)^{1.500} \leq 1.0 \to OK"
+                ),
+            ),
+            (
+                100e6,
+                "complete_with_units",
+                (
+                    r"CHECK \to \left(\frac{\left|M_{Edz}\right|}{M_{Rdz,N}}\right)^{a_N} + "
+                    r"\left(\frac{\left|M_{Edy}\right|}{M_{Rdy,N}}\right)^{a_N} \leq 1.0 \to "
+                    r"\left(\frac{\left|100000000.000 \ Nmm\right|}{200000000.000 \ Nmm}\right)^{1.500} + "
+                    r"\left(\frac{\left|50000000.000 \ Nmm\right|}{150000000.000 \ Nmm}\right)^{1.500} \leq 1.0 \to OK"
+                ),
+            ),
+            (100e6, "short", r"CHECK \to OK"),
+            (190e6, "short", r"CHECK \to \text{Not OK}"),
+        ],
+    )
+    def test_latex(self, m_edz: float, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Object to test
+        latex = Form8Dot2CheckBiaxialBending(m_edz=m_edz, m_rdz_n=200e6, m_edy=50e6, m_rdy_n=150e6, a_n=1.5).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_3.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_3.py
@@ -1,0 +1,78 @@
+"""Testing formula 8.3 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_3 import (
+    Form8Dot3AxialResistanceWithoutMoment,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot3AxialResistanceWithoutMoment:
+    """Validation for formula 8.3 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_c = 200000.0
+        f_cd = 20.0
+        a_s = 5000.0
+        f_yd = 435.0
+
+        # Object to test
+        formula = Form8Dot3AxialResistanceWithoutMoment(a_c=a_c, f_cd=f_cd, a_s=a_s, f_yd=f_yd)
+
+        # Expected result, manually calculated: 200000 * 20 + 5000 * 435
+        manually_calculated_result = 6175000.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_c", "f_cd", "a_s", "f_yd"),
+        [
+            (-200000.0, 20.0, 5000.0, 435.0),  # a_c is negative
+            (200000.0, -20.0, 5000.0, 435.0),  # f_cd is negative
+            (200000.0, 20.0, -5000.0, 435.0),  # a_s is negative
+            (200000.0, 20.0, 5000.0, -435.0),  # f_yd is negative
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, a_c: float, f_cd: float, a_s: float, f_yd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot3AxialResistanceWithoutMoment(a_c=a_c, f_cd=f_cd, a_s=a_s, f_yd=f_yd)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"N_{Rd,0} = A_c \cdot f_{cd} + A_s \cdot f_{yd} = 200000.000 \cdot 20.000 + 5000.000 \cdot 435.000 = 6175000.000 \ N",
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"N_{Rd,0} = A_c \cdot f_{cd} + A_s \cdot f_{yd} = "
+                    r"200000.000 \ mm^2 \cdot 20.000 \ MPa + 5000.000 \ mm^2 \cdot 435.000 \ MPa = 6175000.000 \ N"
+                ),
+            ),
+            ("short", r"N_{Rd,0} = 6175000.000 \ N"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_c = 200000.0
+        f_cd = 20.0
+        a_s = 5000.0
+        f_yd = 435.0
+
+        # Object to test
+        latex = Form8Dot3AxialResistanceWithoutMoment(a_c=a_c, f_cd=f_cd, a_s=a_s, f_yd=f_yd).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
Adds formulas (8.1) to (8.3) from clause 8.1.1 "General" of FprEN 1992-1-1:2023, printed on pages 109 and 110. This is the first clause of chapter 8.1 (Bending with or without axial force).

Formula (8.1) gives the minimum design moment to consider alongside an axial compression force, to cover unaccounted second-order and imperfection effects. Formula (8.2) is a simplified biaxial bending criterion. Formula (8.3) is the axial resistance the criterion of (8.2) needs, without an accompanying moment.

## Decisions a reviewer has to weigh

- **(8.1) returns a magnitude, not a signed moment.** The standard prints M_Ed,min = ± N_Ed * e_d,min: the cross-section must be designed for this minimum moment in either direction, given whatever sign convention N_Ed carries. Fixing one sign in the return value would bake in an interpretation the text does not support, so the class returns abs(N_Ed) * e_d,min and leaves applying the sign to the caller.
- **(8.2) as `ComparisonFormula`.** Paragraph (8) introduces it as "the following simplified criterion may be used", printed directly as an inequality with no separate assignment, so it is a genuine verification.
- **a_N in (8.2) is a caller-supplied input.** The standard gives it as 2 for circular and elliptical cross-sections, or for rectangular ones from a table (0.1 to 1.0, 1.5 at 0.7, 2.0 at 1.0) with linear interpolation, based on formula (8.3)'s N_Rd,0. That table lookup is not itself a numbered formula, so it is left to the caller, with the guidance documented in the parameter docstring.
- **(8.3)'s confinement note is documented, not enforced.** The standard notes that f_cd should be replaced by f_cd,c per Formula (8.15) for members with confinement reinforcement. Formula (8.15) is not yet implemented, so this class covers the unconfined case, with the substitution left to the caller once it exists.

## Formulas as implemented

**Formula (8.1)**, `Form8Dot1MinimumDesignMoment`

`equation`

$$
\left|N_{Ed}\right| \cdot \max\left(\frac{h}{30}, 20\right)
$$

`complete`

$$
M_{Ed,min} = \left|N_{Ed}\right| \cdot \max\left(\frac{h}{30}, 20\right) = \left|500000.000\right| \cdot \max\left(\frac{900.000}{30}, 20\right) = 15000000.000 \ Nmm
$$

`complete_with_units`

$$
M_{Ed,min} = \left|N_{Ed}\right| \cdot \max\left(\frac{h}{30}, 20\right) = \left|500000.000 \ N\right| \cdot \max\left(\frac{900.000 \ mm}{30}, 20\right) = 15000000.000 \ Nmm
$$

**Formula (8.2)**, `Form8Dot2CheckBiaxialBending`

`equation`

$$
\left(\frac{\left|M_{Edz}\right|}{M_{Rdz,N}}\right)^{a_N} + \left(\frac{\left|M_{Edy}\right|}{M_{Rdy,N}}\right)^{a_N} \leq 1.0
$$

`complete`

$$
CHECK \to \left(\frac{\left|M_{Edz}\right|}{M_{Rdz,N}}\right)^{a_N} + \left(\frac{\left|M_{Edy}\right|}{M_{Rdy,N}}\right)^{a_N} \leq 1.0 \to \left(\frac{\left|100000000.000\right|}{200000000.000}\right)^{1.500} + \left(\frac{\left|50000000.000\right|}{150000000.000}\right)^{1.500} \leq 1.0 \to OK
$$

`complete_with_units`

$$
CHECK \to \left(\frac{\left|M_{Edz}\right|}{M_{Rdz,N}}\right)^{a_N} + \left(\frac{\left|M_{Edy}\right|}{M_{Rdy,N}}\right)^{a_N} \leq 1.0 \to \left(\frac{\left|100000000.000 \ Nmm\right|}{200000000.000 \ Nmm}\right)^{1.500} + \left(\frac{\left|50000000.000 \ Nmm\right|}{150000000.000 \ Nmm}\right)^{1.500} \leq 1.0 \to OK
$$

**Formula (8.3)**, `Form8Dot3AxialResistanceWithoutMoment`

`equation`

$$
A_c \cdot f_{cd} + A_s \cdot f_{yd}
$$

`complete`

$$
N_{Rd,0} = A_c \cdot f_{cd} + A_s \cdot f_{yd} = 200000.000 \cdot 20.000 + 5000.000 \cdot 435.000 = 6175000.000 \ N
$$

`complete_with_units`

$$
N_{Rd,0} = A_c \cdot f_{cd} + A_s \cdot f_{yd} = 200000.000 \ mm^2 \cdot 20.000 \ MPa + 5000.000 \ mm^2 \cdot 435.000 \ MPa = 6175000.000 \ N
$$

Contributes to #1083.
