### PR TITLE
feat: add formulas 8.4 to 8.8 from FprEN 1992-1-1:2023 clauses 8.1.2 and 8.1.3

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_4.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_4.py
@@ -1,0 +1,94 @@
+"""Formula 8.4 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot4DesignStressCompressionZone(Formula):
+    r"""Class representing formula 8.4 for the calculation of the design stress in the compression zone,
+    following the parabola-rectangle stress distribution.
+    """
+
+    label = "8.4"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        f_cd: MPA,
+        epsilon_c: DIMENSIONLESS,
+    ) -> None:
+        r"""[$\sigma_{cd}$] Design stress in the compression zone [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.2(1) - Formula (8.4)
+
+        The strain limits [$\varepsilon_{c2} = 0{,}002$] and [$\varepsilon_{cu} = 0{,}0035$] are fixed by the
+        standard for this stress distribution and are not inputs of this class.
+
+        Parameters
+        ----------
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        epsilon_c : DIMENSIONLESS
+            [$\varepsilon_c$] Compressive strain in the concrete, taken positive, within the range
+            [$0 \leq \varepsilon_c \leq \varepsilon_{cu}$] [$-$].
+        """
+        super().__init__()
+        self.f_cd = f_cd
+        self.epsilon_c = epsilon_c
+
+    @staticmethod
+    def _evaluate(
+        f_cd: MPA,
+        epsilon_c: DIMENSIONLESS,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(f_cd=f_cd, epsilon_c=epsilon_c)
+
+        epsilon_c2 = 0.002
+        epsilon_cu = 0.0035
+        if epsilon_c > epsilon_cu:
+            raise ValueError(f"epsilon_c of {epsilon_c} is outside the range covered by formula (8.4): 0 <= epsilon_c <= {epsilon_cu}.")
+
+        if epsilon_c <= epsilon_c2:
+            return f_cd * (1 - (1 - epsilon_c / epsilon_c2) ** 2)
+        return f_cd
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.4."""
+        _equation: str = (
+            r"\begin{cases} f_{cd} \left[1 - \left(1 - \frac{\varepsilon_c}{\varepsilon_{c2}}\right)^2\right] "
+            r"& \text{for } 0 \leq \varepsilon_c \leq \varepsilon_{c2} \\ "
+            r"f_{cd} & \text{for } \varepsilon_{c2} \leq \varepsilon_c \leq \varepsilon_{cu} \end{cases}"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+                r"\varepsilon_c": f"{self.epsilon_c:.{n}f}",
+                r"\varepsilon_{c2}": "0.002",
+                r"\varepsilon_{cu}": "0.0035",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+                r"\varepsilon_c": f"{self.epsilon_c:.{n}f}",
+                r"\varepsilon_{c2}": "0.002",
+                r"\varepsilon_{cu}": "0.0035",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\sigma_{cd}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_5_6_7_8.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_5_6_7_8.py
@@ -1,0 +1,104 @@
+"""Formula 8.5, 8.6, 8.7 and 8.8 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import NMM
+
+
+class Form8Dot5To8DesignMomentsForOrthogonalReinforcement(Formula):
+    r"""Class representing formulas 8.5, 8.6, 8.7 and 8.8 for the calculation of the design moments an
+    orthogonally reinforced solid slab element with bending and torsional moments shall be designed for.
+    """
+
+    label = "8.5/8.6/8.7/8.8"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        m_edx: NMM,
+        m_edy: NMM,
+        m_edxy: NMM,
+        is_x_direction: bool,
+        is_primed: bool,
+    ) -> None:
+        r"""[$m_{Rdx}$], [$m_{Rdy}$], [$m_{Rdx}'$] or [$m_{Rdy}'$] Design moment for the reinforcement in local
+        axis [$x$] or [$y$], on the unprimed or primed face [$Nmm$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.3(1) - Formula (8.5), (8.6), (8.7) and (8.8)
+
+        Applies to orthogonally reinforced solid slab elements with bending and torsional moments where
+        [$\left|m_{Edxy}\right| \leq 0{,}07 \cdot d^2 \cdot f_{cd}$]; that condition of application is not
+        enforced here. [$x$] and [$y$] are local axes parallel to the reinforcement.
+
+        Parameters
+        ----------
+        m_edx : NMM
+            [$m_{Edx}$] Design bending moment about the local [$x$] axis. Only used when [$is\_x\_direction$]
+            is True [$Nmm$].
+        m_edy : NMM
+            [$m_{Edy}$] Design bending moment about the local [$y$] axis. Only used when [$is\_x\_direction$]
+            is False [$Nmm$].
+        m_edxy : NMM
+            [$m_{Edxy}$] Design torsional moment. Only its magnitude is used, so it may be passed
+            signed [$Nmm$].
+        is_x_direction : bool
+            True to compute the design moment for the local [$x$] direction ([$m_{Rdx}$] or [$m_{Rdx}'$]),
+            False for the local [$y$] direction ([$m_{Rdy}$] or [$m_{Rdy}'$]).
+        is_primed : bool
+            True to compute the design moment on the primed face ([$m_{Rdx}'$] or [$m_{Rdy}'$]), False for
+            the unprimed face ([$m_{Rdx}$] or [$m_{Rdy}$]).
+        """
+        super().__init__()
+        self.m_edx = m_edx
+        self.m_edy = m_edy
+        self.m_edxy = m_edxy
+        self.is_x_direction = is_x_direction
+        self.is_primed = is_primed
+
+    @staticmethod
+    def _evaluate(
+        m_edx: NMM,
+        m_edy: NMM,
+        m_edxy: NMM,
+        is_x_direction: bool,
+        is_primed: bool,
+    ) -> NMM:
+        """Evaluates the formula, for more information see the __init__ method."""
+        m_ed = m_edx if is_x_direction else m_edy
+        sign = -1 if is_primed else 1
+        return sign * m_ed + abs(m_edxy)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formulas 8.5, 8.6, 8.7 and 8.8."""
+        m_ed_symbol = r"m_{Edx}" if self.is_x_direction else r"m_{Edy}"
+        return_symbol = ("m_{Rdx}" if self.is_x_direction else "m_{Rdy}") + ("'" if self.is_primed else "")
+        sign_symbol = "-" if self.is_primed else ""
+        m_ed = self.m_edx if self.is_x_direction else self.m_edy
+
+        _equation: str = rf"{sign_symbol}{m_ed_symbol} + \left|m_{{Edxy}}\right|"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                m_ed_symbol: f"{m_ed:.{n}f}",
+                r"m_{Edxy}": f"{self.m_edxy:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                m_ed_symbol: rf"{m_ed:.{n}f} \ Nmm",
+                r"m_{Edxy}": rf"{self.m_edxy:.{n}f} \ Nmm",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=return_symbol,
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="Nmm",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -65,11 +65,11 @@ Total of 602 formulas present.
 |      8.1       |        :x:         |         |                                                                    |
 |      8.2       |        :x:         |         |                                                                    |
 |      8.3       |        :x:         |         |                                                                    |
-|      8.4       |        :x:         |         |                                                                    |
-|      8.5       |        :x:         |         |                                                                    |
-|      8.6       |        :x:         |         |                                                                    |
-|      8.7       |        :x:         |         |                                                                    |
-|      8.8       |        :x:         |         |                                                                    |
+|      8.4       | :heavy_check_mark: |         | Form8Dot4DesignStressCompressionZone                               |
+|      8.5       | :heavy_check_mark: |         | Form8Dot5To8DesignMomentsForOrthogonalReinforcement                |
+|      8.6       | :heavy_check_mark: |         | Form8Dot5To8DesignMomentsForOrthogonalReinforcement                |
+|      8.7       | :heavy_check_mark: |         | Form8Dot5To8DesignMomentsForOrthogonalReinforcement                |
+|      8.8       | :heavy_check_mark: |         | Form8Dot5To8DesignMomentsForOrthogonalReinforcement                |
 |      8.9       |        :x:         |         |                                                                    |
 |      8.10      |        :x:         |         |                                                                    |
 |      8.11      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_4.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_4.py
@@ -1,0 +1,116 @@
+"""Testing formula 8.4 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_4 import (
+    Form8Dot4DesignStressCompressionZone,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot4DesignStressCompressionZone:
+    """Validation for formula 8.4 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation_parabolic_branch(self) -> None:
+        """Tests the evaluation of the result on the parabolic branch."""
+        # Example values
+        f_cd = 20.0
+        epsilon_c = 0.001
+
+        # Object to test
+        formula = Form8Dot4DesignStressCompressionZone(f_cd=f_cd, epsilon_c=epsilon_c)
+
+        # Expected result, manually calculated: 20 * (1 - (1 - 0.001 / 0.002)**2) = 20 * 0.75
+        manually_calculated_result = 15.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_plateau_branch(self) -> None:
+        """Tests the evaluation of the result on the plateau branch."""
+        # Example values
+        f_cd = 20.0
+        epsilon_c = 0.003
+
+        # Object to test
+        formula = Form8Dot4DesignStressCompressionZone(f_cd=f_cd, epsilon_c=epsilon_c)
+
+        # Expected result, as printed in the standard: f_cd on the plateau
+        manually_calculated_result = 20.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_at_epsilon_c2_boundary(self) -> None:
+        """Tests the evaluation of the result exactly at the boundary between the two branches."""
+        # Example values
+        f_cd = 20.0
+        epsilon_c = 0.002
+
+        # Object to test
+        formula = Form8Dot4DesignStressCompressionZone(f_cd=f_cd, epsilon_c=epsilon_c)
+
+        # Expected result: both branches agree at epsilon_c = epsilon_c2
+        manually_calculated_result = 20.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("f_cd", "epsilon_c"),
+        [
+            (-20.0, 0.001),  # f_cd is negative
+            (20.0, -0.001),  # epsilon_c is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, f_cd: float, epsilon_c: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot4DesignStressCompressionZone(f_cd=f_cd, epsilon_c=epsilon_c)
+
+    def test_raise_error_when_epsilon_c_exceeds_epsilon_cu(self) -> None:
+        """Test invalid value beyond the range covered by formula (8.4)."""
+        with pytest.raises(ValueError, match="outside the range covered by formula"):
+            Form8Dot4DesignStressCompressionZone(f_cd=20.0, epsilon_c=0.004)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\sigma_{cd} = \begin{cases} f_{cd} \left[1 - \left(1 - \frac{\varepsilon_c}{\varepsilon_{c2}}\right)^2\right] "
+                    r"& \text{for } 0 \leq \varepsilon_c \leq \varepsilon_{c2} \\ "
+                    r"f_{cd} & \text{for } \varepsilon_{c2} \leq \varepsilon_c \leq \varepsilon_{cu} \end{cases} = "
+                    r"\begin{cases} 20.000 \left[1 - \left(1 - \frac{0.001}{0.002}\right)^2\right] "
+                    r"& \text{for } 0 \leq 0.001 \leq 0.002 \\ "
+                    r"20.000 & \text{for } 0.002 \leq 0.001 \leq 0.0035 \end{cases} = 15.000 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\sigma_{cd} = \begin{cases} f_{cd} \left[1 - \left(1 - \frac{\varepsilon_c}{\varepsilon_{c2}}\right)^2\right] "
+                    r"& \text{for } 0 \leq \varepsilon_c \leq \varepsilon_{c2} \\ "
+                    r"f_{cd} & \text{for } \varepsilon_{c2} \leq \varepsilon_c \leq \varepsilon_{cu} \end{cases} = "
+                    r"\begin{cases} 20.000 \ MPa \left[1 - \left(1 - \frac{0.001}{0.002}\right)^2\right] "
+                    r"& \text{for } 0 \leq 0.001 \leq 0.002 \\ "
+                    r"20.000 \ MPa & \text{for } 0.002 \leq 0.001 \leq 0.0035 \end{cases} = 15.000 \ MPa"
+                ),
+            ),
+            ("short", r"\sigma_{cd} = 15.000 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        f_cd = 20.0
+        epsilon_c = 0.001
+
+        # Object to test
+        latex = Form8Dot4DesignStressCompressionZone(f_cd=f_cd, epsilon_c=epsilon_c).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_5_6_7_8.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_5_6_7_8.py
@@ -1,0 +1,92 @@
+"""Testing formulas 8.5, 8.6, 8.7 and 8.8 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_5_6_7_8 import (
+    Form8Dot5To8DesignMomentsForOrthogonalReinforcement,
+)
+
+
+class TestForm8Dot5To8DesignMomentsForOrthogonalReinforcement:
+    """Validation for formulas 8.5, 8.6, 8.7 and 8.8 from FprEN 1992-1-1:2023."""
+
+    @pytest.mark.parametrize(
+        ("is_x_direction", "is_primed", "expected"),
+        [
+            (True, False, 60e6),  # formula (8.5): m_edx + |m_edxy|
+            (False, False, 40e6),  # formula (8.6): m_edy + |m_edxy|
+            (True, True, -40e6),  # formula (8.7): -m_edx + |m_edxy|
+            (False, True, -20e6),  # formula (8.8): -m_edy + |m_edxy|
+        ],
+    )
+    def test_evaluation(self, is_x_direction: bool, is_primed: bool, expected: float) -> None:
+        """Tests the evaluation of the result."""
+        formula = Form8Dot5To8DesignMomentsForOrthogonalReinforcement(
+            m_edx=50e6, m_edy=30e6, m_edxy=10e6, is_x_direction=is_x_direction, is_primed=is_primed
+        )
+        assert formula == pytest.approx(expected=expected, rel=1e-4)
+
+    def test_evaluation_negative_torsional_moment(self) -> None:
+        """Tests that only the magnitude of the torsional moment is used."""
+        formula = Form8Dot5To8DesignMomentsForOrthogonalReinforcement(m_edx=50e6, m_edy=30e6, m_edxy=-10e6, is_x_direction=True, is_primed=False)
+        assert formula == pytest.approx(expected=60e6, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("is_x_direction", "is_primed", "expected"),
+        [
+            (
+                True,
+                False,
+                (
+                    r"m_{Rdx} = m_{Edx} + \left|m_{Edxy}\right| = "
+                    r"50000000.000 + \left|10000000.000\right| = 60000000.000 \ Nmm"
+                ),
+            ),
+            (
+                False,
+                False,
+                (
+                    r"m_{Rdy} = m_{Edy} + \left|m_{Edxy}\right| = "
+                    r"30000000.000 + \left|10000000.000\right| = 40000000.000 \ Nmm"
+                ),
+            ),
+            (
+                True,
+                True,
+                (
+                    r"m_{Rdx}' = -m_{Edx} + \left|m_{Edxy}\right| = "
+                    r"-50000000.000 + \left|10000000.000\right| = -40000000.000 \ Nmm"
+                ),
+            ),
+            (
+                False,
+                True,
+                (
+                    r"m_{Rdy}' = -m_{Edy} + \left|m_{Edxy}\right| = "
+                    r"-30000000.000 + \left|10000000.000\right| = -20000000.000 \ Nmm"
+                ),
+            ),
+        ],
+    )
+    def test_latex_complete(self, is_x_direction: bool, is_primed: bool, expected: str) -> None:
+        """Test the complete latex representation of the formula for all four cases."""
+        latex = Form8Dot5To8DesignMomentsForOrthogonalReinforcement(
+            m_edx=50e6, m_edy=30e6, m_edxy=10e6, is_x_direction=is_x_direction, is_primed=is_primed
+        ).latex()
+
+        assert latex.complete == expected
+
+    def test_latex_complete_with_units(self) -> None:
+        """Test the complete_with_units latex representation of the formula."""
+        latex = Form8Dot5To8DesignMomentsForOrthogonalReinforcement(m_edx=50e6, m_edy=30e6, m_edxy=10e6, is_x_direction=True, is_primed=False).latex()
+
+        assert latex.complete_with_units == (
+            r"m_{Rdx} = m_{Edx} + \left|m_{Edxy}\right| = "
+            r"50000000.000 \ Nmm + \left|10000000.000 \ Nmm\right| = 60000000.000 \ Nmm"
+        )
+
+    def test_latex_short(self) -> None:
+        """Test the short latex representation of the formula."""
+        latex = Form8Dot5To8DesignMomentsForOrthogonalReinforcement(m_edx=50e6, m_edy=30e6, m_edxy=10e6, is_x_direction=True, is_primed=False).latex()
+
+        assert latex.short == r"m_{Rdx} = 60000000.000 \ Nmm"


### PR DESCRIPTION
Adds formula (8.4) from clause 8.1.2 "Stress distribution in the compression zones", and formulas (8.5) to (8.8) from clause 8.1.3 "Bending in slabs" of FprEN 1992-1-1:2023, printed on pages 110 and 111.

Formula (8.4) is the parabola-rectangle design stress in the compression zone. Formulas (8.5) to (8.8) give the design moments an orthogonally reinforced slab element must be designed for, for bending combined with torsion.

## Decisions a reviewer has to weigh

- **epsilon_c2 and epsilon_cu in (8.4) are fixed constants, not parameters.** The standard gives them directly as 0,002 and 0,0035 in the "where" clause of this specific formula, so they are hardcoded in `_evaluate` rather than exposed on `__init__`.
- **(8.5) to (8.8) are combined into one class using two boolean flags**, `is_x_direction` and `is_primed`, rather than four separate classes. All four are the same rule (m_Rd >= +/-m_Ed + |m_Edxy|) applied to the two local axes and the two faces (unprimed/primed), so this follows the same grouping used elsewhere in this track for numbered formulas that are branches of a single rule. The trade-off: a reviewer looking specifically for "the class that implements (8.7)" finds only a flag combination, not a class name; the docstring spells out which flags produce which formula number to make that traceable.
- **The applicability condition of (8.5) to (8.8) is documented, not enforced.** Paragraph (1) restricts the method to `|m_Edxy| <= 0,07 * d^2 * f_cd`; that condition involves `d` and `f_cd`, neither of which this class needs for its own computation, so it is left to the caller and noted in the docstring.

## Formulas as implemented

**Formula (8.4)**, `Form8Dot4DesignStressCompressionZone`

`equation`

$$
\sigma_{cd} = \begin{cases} f_{cd} \left[1 - \left(1 - \frac{\varepsilon_c}{\varepsilon_{c2}}\right)^2\right] & \text{for } 0 \leq \varepsilon_c \leq \varepsilon_{c2} \\ f_{cd} & \text{for } \varepsilon_{c2} \leq \varepsilon_c \leq \varepsilon_{cu} \end{cases}
$$

`complete`

$$
\sigma_{cd} = \begin{cases} f_{cd} \left[1 - \left(1 - \frac{\varepsilon_c}{\varepsilon_{c2}}\right)^2\right] & \text{for } 0 \leq \varepsilon_c \leq \varepsilon_{c2} \\ f_{cd} & \text{for } \varepsilon_{c2} \leq \varepsilon_c \leq \varepsilon_{cu} \end{cases} = \begin{cases} 20.000 \left[1 - \left(1 - \frac{0.001}{0.002}\right)^2\right] & \text{for } 0 \leq 0.001 \leq 0.002 \\ 20.000 & \text{for } 0.002 \leq 0.001 \leq 0.0035 \end{cases} = 15.000 \ MPa
$$

`complete_with_units`

$$
\sigma_{cd} = \begin{cases} f_{cd} \left[1 - \left(1 - \frac{\varepsilon_c}{\varepsilon_{c2}}\right)^2\right] & \text{for } 0 \leq \varepsilon_c \leq \varepsilon_{c2} \\ f_{cd} & \text{for } \varepsilon_{c2} \leq \varepsilon_c \leq \varepsilon_{cu} \end{cases} = \begin{cases} 20.000 \ MPa \left[1 - \left(1 - \frac{0.001}{0.002}\right)^2\right] & \text{for } 0 \leq 0.001 \leq 0.002 \\ 20.000 \ MPa & \text{for } 0.002 \leq 0.001 \leq 0.0035 \end{cases} = 15.000 \ MPa
$$

**Formulas (8.5), (8.6), (8.7), (8.8)**, `Form8Dot5To8DesignMomentsForOrthogonalReinforcement`

`equation` (shown for `is_x_direction=True, is_primed=False`, formula 8.5; the other three flag combinations give (8.6), (8.7) and (8.8) respectively)

$$
m_{Edx} + \left|m_{Edxy}\right|
$$

`complete`, one per formula number

$$
m_{Rdx} = m_{Edx} + \left|m_{Edxy}\right| = 50000000.000 + \left|10000000.000\right| = 60000000.000 \ Nmm
$$

$$
m_{Rdy} = m_{Edy} + \left|m_{Edxy}\right| = 30000000.000 + \left|10000000.000\right| = 40000000.000 \ Nmm
$$

$$
m_{Rdx}' = -m_{Edx} + \left|m_{Edxy}\right| = -50000000.000 + \left|10000000.000\right| = -40000000.000 \ Nmm
$$

$$
m_{Rdy}' = -m_{Edy} + \left|m_{Edxy}\right| = -30000000.000 + \left|10000000.000\right| = -20000000.000 \ Nmm
$$

Contributes to #1083.
