### PR TITLE
feat: add formulas 8.11 to 8.14 from FprEN 1992-1-1:2023 clause 8.1.4

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_11.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_11.py
@@ -1,0 +1,92 @@
+"""Formula 8.11 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot11ConfinementStressCircularSquareSingleConfinement(Formula):
+    r"""Class representing formula 8.11 for the calculation of the confinement stress for circular and square
+    members in compression with single confinement reinforcement.
+    """
+
+    label = "8.11"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a_s_conf: MM2,
+        f_yd: MPA,
+        b_cs: MM,
+        s: MM,
+    ) -> None:
+        r"""[$\sigma_{c2d}$] Confinement stress for circular and square members in compression with single
+        confinement reinforcement, see Figure 8.3 a) and b) [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.4(3) - Formula (8.11)
+
+        Parameters
+        ----------
+        a_s_conf : MM2
+            [$A_{s,conf}$] Cross-sectional area of one leg of confinement reinforcement [$mm^2$].
+        f_yd : MPA
+            [$f_{yd}$] Design value of the yield strength of the reinforcement [$MPa$].
+        b_cs : MM
+            [$b_{cs}$] Width of the confinement core, to the centrelines of the confinement reinforcement,
+            see Figure 8.3 [$mm$].
+        s : MM
+            [$s$] Spacing of confinement reinforcement [$mm$].
+        """
+        super().__init__()
+        self.a_s_conf = a_s_conf
+        self.f_yd = f_yd
+        self.b_cs = b_cs
+        self.s = s
+
+    @staticmethod
+    def _evaluate(
+        a_s_conf: MM2,
+        f_yd: MPA,
+        b_cs: MM,
+        s: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_s_conf=a_s_conf, f_yd=f_yd)
+        raise_if_less_or_equal_to_zero(b_cs=b_cs, s=s)
+
+        return 2 * a_s_conf * f_yd / (b_cs * s)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.11."""
+        _equation: str = r"\frac{2 \cdot A_{s,conf} \cdot f_{yd}}{b_{cs} \cdot s}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_{s,conf}": f"{self.a_s_conf:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+                r"b_{cs}": f"{self.b_cs:.{n}f}",
+                r"\cdot s}": rf"\cdot {self.s:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_{s,conf}": rf"{self.a_s_conf:.{n}f} \ mm^2",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+                r"b_{cs}": rf"{self.b_cs:.{n}f} \ mm",
+                r"\cdot s}": rf"\cdot {self.s:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\sigma_{c2d}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_12.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_12.py
@@ -1,0 +1,100 @@
+"""Formula 8.12 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot12ConfinementStressRectangularSingleConfinement(Formula):
+    r"""Class representing formula 8.12 for the calculation of the confinement stress for rectangular members
+    in compression with single confinement reinforcement.
+    """
+
+    label = "8.12"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        a_s_conf: MM2,
+        f_yd: MPA,
+        b_csx: MM,
+        b_csy: MM,
+        s: MM,
+    ) -> None:
+        r"""[$\sigma_{c2d}$] Confinement stress for rectangular members in compression with single confinement
+        reinforcement, with [$b_{csx}$] and [$b_{csy}$] according to Figure 8.3 c) [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.4(3) - Formula (8.12)
+
+        Parameters
+        ----------
+        a_s_conf : MM2
+            [$A_{s,conf}$] Cross-sectional area of one leg of confinement reinforcement [$mm^2$].
+        f_yd : MPA
+            [$f_{yd}$] Design value of the yield strength of the reinforcement [$MPa$].
+        b_csx : MM
+            [$b_{csx}$] Width of the confinement core in the [$x$] direction, to the centrelines of the
+            confinement reinforcement, see Figure 8.3 [$mm$].
+        b_csy : MM
+            [$b_{csy}$] Width of the confinement core in the [$y$] direction, to the centrelines of the
+            confinement reinforcement, see Figure 8.3 [$mm$].
+        s : MM
+            [$s$] Spacing of confinement reinforcement [$mm$].
+        """
+        super().__init__()
+        self.a_s_conf = a_s_conf
+        self.f_yd = f_yd
+        self.b_csx = b_csx
+        self.b_csy = b_csy
+        self.s = s
+
+    @staticmethod
+    def _evaluate(
+        a_s_conf: MM2,
+        f_yd: MPA,
+        b_csx: MM,
+        b_csy: MM,
+        s: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(a_s_conf=a_s_conf, f_yd=f_yd)
+        raise_if_less_or_equal_to_zero(b_csx=b_csx, b_csy=b_csy, s=s)
+
+        return 2 * a_s_conf * f_yd / (max(b_csx, b_csy) * s)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.12."""
+        _equation: str = r"\frac{2 \cdot A_{s,conf} \cdot f_{yd}}{\max\left(b_{csx}, b_{csy}\right) \cdot s}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_{s,conf}": f"{self.a_s_conf:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+                r"b_{csx}": f"{self.b_csx:.{n}f}",
+                r"b_{csy}": f"{self.b_csy:.{n}f}",
+                r"\cdot s}": rf"\cdot {self.s:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"A_{s,conf}": rf"{self.a_s_conf:.{n}f} \ mm^2",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+                r"b_{csx}": rf"{self.b_csx:.{n}f} \ mm",
+                r"b_{csy}": rf"{self.b_csy:.{n}f} \ mm",
+                r"\cdot s}": rf"\cdot {self.s:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\sigma_{c2d}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_13.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_13.py
@@ -1,0 +1,111 @@
+"""Formula 8.13 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot13ConfinementStressMultipleConfinement(Formula):
+    r"""Class representing formula 8.13 for the calculation of the confinement stress for members in
+    compression with multiple confinement reinforcement.
+    """
+
+    label = "8.13"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        sum_a_s_confx: MM2,
+        b_csy: MM,
+        sum_a_s_confy: MM2,
+        b_csx: MM,
+        f_yd: MPA,
+        s: MM,
+    ) -> None:
+        r"""[$\sigma_{c2d}$] Confinement stress for members in compression with multiple confinement
+        reinforcement, see Figure 8.3 c) and d) [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.4(3) - Formula (8.13)
+
+        Parameters
+        ----------
+        sum_a_s_confx : MM2
+            [$\Sigma A_{s,confx}$] Sum of the cross-sectional areas of the legs of confinement reinforcement in
+            the [$x$] direction [$mm^2$].
+        b_csy : MM
+            [$b_{csy}$] Width of the confinement core in the [$y$] direction, to the centrelines of the
+            confinement reinforcement, see Figure 8.3 [$mm$].
+        sum_a_s_confy : MM2
+            [$\Sigma A_{s,confy}$] Sum of the cross-sectional areas of the legs of confinement reinforcement in
+            the [$y$] direction [$mm^2$].
+        b_csx : MM
+            [$b_{csx}$] Width of the confinement core in the [$x$] direction, to the centrelines of the
+            confinement reinforcement, see Figure 8.3 [$mm$].
+        f_yd : MPA
+            [$f_{yd}$] Design value of the yield strength of the reinforcement [$MPa$].
+        s : MM
+            [$s$] Spacing of confinement reinforcement [$mm$].
+        """
+        super().__init__()
+        self.sum_a_s_confx = sum_a_s_confx
+        self.b_csy = b_csy
+        self.sum_a_s_confy = sum_a_s_confy
+        self.b_csx = b_csx
+        self.f_yd = f_yd
+        self.s = s
+
+    @staticmethod
+    def _evaluate(
+        sum_a_s_confx: MM2,
+        b_csy: MM,
+        sum_a_s_confy: MM2,
+        b_csx: MM,
+        f_yd: MPA,
+        s: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(sum_a_s_confx=sum_a_s_confx, sum_a_s_confy=sum_a_s_confy, f_yd=f_yd)
+        raise_if_less_or_equal_to_zero(b_csy=b_csy, b_csx=b_csx, s=s)
+
+        return min(sum_a_s_confx / b_csy, sum_a_s_confy / b_csx) * f_yd / s
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.13."""
+        _equation: str = r"\min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{\Sigma A_{s,confy}}{b_{csx}}\right) \cdot \frac{f_{yd}}{s}"
+        # The lone symbol s is anchored as "{s}" (its own fraction denominator) to avoid matching the "s" that
+        # is part of b_csx and b_csy.
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Sigma A_{s,confx}": f"{self.sum_a_s_confx:.{n}f}",
+                r"b_{csy}": f"{self.b_csy:.{n}f}",
+                r"\Sigma A_{s,confy}": f"{self.sum_a_s_confy:.{n}f}",
+                r"b_{csx}": f"{self.b_csx:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+                r"{s}": "{" + f"{self.s:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Sigma A_{s,confx}": rf"{self.sum_a_s_confx:.{n}f} \ mm^2",
+                r"b_{csy}": rf"{self.b_csy:.{n}f} \ mm",
+                r"\Sigma A_{s,confy}": rf"{self.sum_a_s_confy:.{n}f} \ mm^2",
+                r"b_{csx}": rf"{self.b_csx:.{n}f} \ mm",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+                r"{s}": "{" + rf"{self.s:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\sigma_{c2d}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_14.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_14.py
@@ -1,0 +1,108 @@
+"""Formula 8.14 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MM2, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot14ConfinementStressCompressionZone(Formula):
+    r"""Class representing formula 8.14 for the calculation of the confinement stress for compression zones."""
+
+    label = "8.14"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        sum_a_s_confx: MM2,
+        b_csy: MM,
+        a_s_confy: MM2,
+        x_cs: MM,
+        f_yd: MPA,
+        s: MM,
+    ) -> None:
+        r"""[$\sigma_{c2d}$] Confinement stress for compression zones, see Figure 8.3 e) [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.4(3) - Formula (8.14)
+
+        Parameters
+        ----------
+        sum_a_s_confx : MM2
+            [$\Sigma A_{s,confx}$] Sum of the cross-sectional areas of the legs of confinement reinforcement in
+            the [$x$] direction [$mm^2$].
+        b_csy : MM
+            [$b_{csy}$] Width of the confinement core in the [$y$] direction, to the centrelines of the
+            confinement reinforcement, see Figure 8.3 [$mm$].
+        a_s_confy : MM2
+            [$A_{s,confy}$] Cross-sectional area of the leg of confinement reinforcement in the [$y$]
+            direction [$mm^2$].
+        x_cs : MM
+            [$x_{cs}$] Distance to the confinement reinforcement in the [$y$] direction, see Figure 8.3 e)
+            [$mm$].
+        f_yd : MPA
+            [$f_{yd}$] Design value of the yield strength of the reinforcement [$MPa$].
+        s : MM
+            [$s$] Spacing of confinement reinforcement [$mm$].
+        """
+        super().__init__()
+        self.sum_a_s_confx = sum_a_s_confx
+        self.b_csy = b_csy
+        self.a_s_confy = a_s_confy
+        self.x_cs = x_cs
+        self.f_yd = f_yd
+        self.s = s
+
+    @staticmethod
+    def _evaluate(
+        sum_a_s_confx: MM2,
+        b_csy: MM,
+        a_s_confy: MM2,
+        x_cs: MM,
+        f_yd: MPA,
+        s: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(sum_a_s_confx=sum_a_s_confx, a_s_confy=a_s_confy, f_yd=f_yd)
+        raise_if_less_or_equal_to_zero(b_csy=b_csy, x_cs=x_cs, s=s)
+
+        return min(sum_a_s_confx / b_csy, a_s_confy / x_cs) * f_yd / s
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.14."""
+        _equation: str = r"\min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{A_{s,confy}}{x_{cs}}\right) \cdot \frac{f_{yd}}{s}"
+        # The lone symbol s is anchored as "{s}" (its own fraction denominator) to avoid matching the "s" that
+        # is part of b_csy and x_cs.
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Sigma A_{s,confx}": f"{self.sum_a_s_confx:.{n}f}",
+                r"b_{csy}": f"{self.b_csy:.{n}f}",
+                r"A_{s,confy}": f"{self.a_s_confy:.{n}f}",
+                r"x_{cs}": f"{self.x_cs:.{n}f}",
+                r"f_{yd}": f"{self.f_yd:.{n}f}",
+                r"{s}": "{" + f"{self.s:.{n}f}" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Sigma A_{s,confx}": rf"{self.sum_a_s_confx:.{n}f} \ mm^2",
+                r"b_{csy}": rf"{self.b_csy:.{n}f} \ mm",
+                r"A_{s,confy}": rf"{self.a_s_confy:.{n}f} \ mm^2",
+                r"x_{cs}": rf"{self.x_cs:.{n}f} \ mm",
+                r"f_{yd}": rf"{self.f_yd:.{n}f} \ MPa",
+                r"{s}": "{" + rf"{self.s:.{n}f} \ mm" + "}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\sigma_{c2d}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -72,10 +72,10 @@ Total of 602 formulas present.
 |      8.8       |        :x:         |         |                                                                    |
 |      8.9       |        :x:         |         |                                                                    |
 |      8.10      |        :x:         |         |                                                                    |
-|      8.11      |        :x:         |         |                                                                    |
-|      8.12      |        :x:         |         |                                                                    |
-|      8.13      |        :x:         |         |                                                                    |
-|      8.14      |        :x:         |         |                                                                    |
+|      8.11      | :heavy_check_mark: |         | Form8Dot11ConfinementStressCircularSquareSingleConfinement        |
+|      8.12      | :heavy_check_mark: |         | Form8Dot12ConfinementStressRectangularSingleConfinement           |
+|      8.13      | :heavy_check_mark: |         | Form8Dot13ConfinementStressMultipleConfinement                    |
+|      8.14      | :heavy_check_mark: |         | Form8Dot14ConfinementStressCompressionZone                        |
 |      8.15      |        :x:         |         |                                                                    |
 |      8.16      |        :x:         |         |                                                                    |
 |      8.17      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_11.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_11.py
@@ -1,0 +1,93 @@
+"""Testing formula 8.11 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_11 import (
+    Form8Dot11ConfinementStressCircularSquareSingleConfinement,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot11ConfinementStressCircularSquareSingleConfinement:
+    """Validation for formula 8.11 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        a_s_conf = 100.0
+        f_yd = 500.0
+        b_cs = 300.0
+        s = 150.0
+
+        # Object to test
+        formula = Form8Dot11ConfinementStressCircularSquareSingleConfinement(a_s_conf=a_s_conf, f_yd=f_yd, b_cs=b_cs, s=s)
+
+        # Expected result, manually calculated: 2 * 100 * 500 / (300 * 150)
+        manually_calculated_result = 2.2222222222222223
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_s_conf", "f_yd"),
+        [
+            (-100.0, 500.0),  # a_s_conf is negative
+            (100.0, -500.0),  # f_yd is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, a_s_conf: float, f_yd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot11ConfinementStressCircularSquareSingleConfinement(a_s_conf=a_s_conf, f_yd=f_yd, b_cs=300.0, s=150.0)
+
+    @pytest.mark.parametrize(
+        ("b_cs", "s"),
+        [
+            (-300.0, 150.0),  # b_cs is negative
+            (0.0, 150.0),  # b_cs is zero
+            (300.0, -150.0),  # s is negative
+            (300.0, 0.0),  # s is zero
+        ],
+    )
+    def test_raise_error_when_b_cs_or_s_is_less_or_equal_to_zero(self, b_cs: float, s: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot11ConfinementStressCircularSquareSingleConfinement(a_s_conf=100.0, f_yd=500.0, b_cs=b_cs, s=s)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\sigma_{c2d} = \frac{2 \cdot A_{s,conf} \cdot f_{yd}}{b_{cs} \cdot s} = "
+                    r"\frac{2 \cdot 100.000 \cdot 500.000}{300.000 \cdot 150.000} = 2.222 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\sigma_{c2d} = \frac{2 \cdot A_{s,conf} \cdot f_{yd}}{b_{cs} \cdot s} = "
+                    r"\frac{2 \cdot 100.000 \ mm^2 \cdot 500.000 \ MPa}{300.000 \ mm \cdot 150.000 \ mm} = 2.222 \ MPa"
+                ),
+            ),
+            ("short", r"\sigma_{c2d} = 2.222 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_s_conf = 100.0
+        f_yd = 500.0
+        b_cs = 300.0
+        s = 150.0
+
+        # Object to test
+        latex = Form8Dot11ConfinementStressCircularSquareSingleConfinement(a_s_conf=a_s_conf, f_yd=f_yd, b_cs=b_cs, s=s).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_12.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_12.py
@@ -1,0 +1,113 @@
+"""Testing formula 8.12 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_12 import (
+    Form8Dot12ConfinementStressRectangularSingleConfinement,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot12ConfinementStressRectangularSingleConfinement:
+    """Validation for formula 8.12 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation_bcsy_governs(self) -> None:
+        """Tests the evaluation of the result where b_csy governs the max."""
+        # Example values
+        a_s_conf = 100.0
+        f_yd = 500.0
+        b_csx = 300.0
+        b_csy = 400.0
+        s = 150.0
+
+        # Object to test
+        formula = Form8Dot12ConfinementStressRectangularSingleConfinement(a_s_conf=a_s_conf, f_yd=f_yd, b_csx=b_csx, b_csy=b_csy, s=s)
+
+        # Expected result, manually calculated: 2 * 100 * 500 / (max(300, 400) * 150)
+        manually_calculated_result = 1.6666666666666667
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_bcsx_governs(self) -> None:
+        """Tests the evaluation of the result where b_csx governs the max."""
+        # Example values
+        a_s_conf = 100.0
+        f_yd = 500.0
+        b_csx = 400.0
+        b_csy = 300.0
+        s = 150.0
+
+        # Object to test
+        formula = Form8Dot12ConfinementStressRectangularSingleConfinement(a_s_conf=a_s_conf, f_yd=f_yd, b_csx=b_csx, b_csy=b_csy, s=s)
+
+        # Expected result, manually calculated: 2 * 100 * 500 / (max(400, 300) * 150)
+        manually_calculated_result = 1.6666666666666667
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("a_s_conf", "f_yd"),
+        [
+            (-100.0, 500.0),  # a_s_conf is negative
+            (100.0, -500.0),  # f_yd is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, a_s_conf: float, f_yd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot12ConfinementStressRectangularSingleConfinement(a_s_conf=a_s_conf, f_yd=f_yd, b_csx=300.0, b_csy=400.0, s=150.0)
+
+    @pytest.mark.parametrize(
+        ("b_csx", "b_csy", "s"),
+        [
+            (-300.0, 400.0, 150.0),  # b_csx is negative
+            (300.0, -400.0, 150.0),  # b_csy is negative
+            (300.0, 400.0, -150.0),  # s is negative
+            (300.0, 400.0, 0.0),  # s is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, b_csx: float, b_csy: float, s: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot12ConfinementStressRectangularSingleConfinement(a_s_conf=100.0, f_yd=500.0, b_csx=b_csx, b_csy=b_csy, s=s)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\sigma_{c2d} = \frac{2 \cdot A_{s,conf} \cdot f_{yd}}{\max\left(b_{csx}, b_{csy}\right) \cdot s} = "
+                    r"\frac{2 \cdot 100.000 \cdot 500.000}{\max\left(300.000, 400.000\right) \cdot 150.000} = 1.667 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\sigma_{c2d} = \frac{2 \cdot A_{s,conf} \cdot f_{yd}}{\max\left(b_{csx}, b_{csy}\right) \cdot s} = "
+                    r"\frac{2 \cdot 100.000 \ mm^2 \cdot 500.000 \ MPa}"
+                    r"{\max\left(300.000 \ mm, 400.000 \ mm\right) \cdot 150.000 \ mm} = 1.667 \ MPa"
+                ),
+            ),
+            ("short", r"\sigma_{c2d} = 1.667 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        a_s_conf = 100.0
+        f_yd = 500.0
+        b_csx = 300.0
+        b_csy = 400.0
+        s = 150.0
+
+        # Object to test
+        latex = Form8Dot12ConfinementStressRectangularSingleConfinement(a_s_conf=a_s_conf, f_yd=f_yd, b_csx=b_csx, b_csy=b_csy, s=s).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_13.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_13.py
@@ -1,0 +1,126 @@
+"""Testing formula 8.13 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_13 import (
+    Form8Dot13ConfinementStressMultipleConfinement,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot13ConfinementStressMultipleConfinement:
+    """Validation for formula 8.13 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation_x_term_governs(self) -> None:
+        """Tests the evaluation of the result where the x term governs the minimum."""
+        # Example values
+        sum_a_s_confx = 200.0
+        b_csy = 500.0
+        sum_a_s_confy = 300.0
+        b_csx = 300.0
+        f_yd = 500.0
+        s = 100.0
+
+        # Object to test
+        formula = Form8Dot13ConfinementStressMultipleConfinement(
+            sum_a_s_confx=sum_a_s_confx, b_csy=b_csy, sum_a_s_confy=sum_a_s_confy, b_csx=b_csx, f_yd=f_yd, s=s
+        )
+
+        # Expected result, manually calculated: min(200 / 500, 300 / 300) * 500 / 100
+        manually_calculated_result = 2.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_y_term_governs(self) -> None:
+        """Tests the evaluation of the result where the y term governs the minimum."""
+        # Example values
+        sum_a_s_confx = 400.0
+        b_csy = 500.0
+        sum_a_s_confy = 150.0
+        b_csx = 300.0
+        f_yd = 500.0
+        s = 100.0
+
+        # Object to test
+        formula = Form8Dot13ConfinementStressMultipleConfinement(
+            sum_a_s_confx=sum_a_s_confx, b_csy=b_csy, sum_a_s_confy=sum_a_s_confy, b_csx=b_csx, f_yd=f_yd, s=s
+        )
+
+        # Expected result, manually calculated: min(400 / 500, 150 / 300) * 500 / 100
+        manually_calculated_result = 2.5
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("sum_a_s_confx", "sum_a_s_confy", "f_yd"),
+        [
+            (-200.0, 300.0, 500.0),  # sum_a_s_confx is negative
+            (200.0, -300.0, 500.0),  # sum_a_s_confy is negative
+            (200.0, 300.0, -500.0),  # f_yd is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, sum_a_s_confx: float, sum_a_s_confy: float, f_yd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot13ConfinementStressMultipleConfinement(
+                sum_a_s_confx=sum_a_s_confx, b_csy=500.0, sum_a_s_confy=sum_a_s_confy, b_csx=300.0, f_yd=f_yd, s=100.0
+            )
+
+    @pytest.mark.parametrize(
+        ("b_csy", "b_csx", "s"),
+        [
+            (-500.0, 300.0, 100.0),  # b_csy is negative
+            (500.0, -300.0, 100.0),  # b_csx is negative
+            (500.0, 300.0, -100.0),  # s is negative
+            (500.0, 300.0, 0.0),  # s is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, b_csy: float, b_csx: float, s: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot13ConfinementStressMultipleConfinement(sum_a_s_confx=200.0, b_csy=b_csy, sum_a_s_confy=300.0, b_csx=b_csx, f_yd=500.0, s=s)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\sigma_{c2d} = \min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{\Sigma A_{s,confy}}{b_{csx}}\right) "
+                    r"\cdot \frac{f_{yd}}{s} = \min\left(\frac{200.000}{500.000}, \frac{300.000}{300.000}\right) "
+                    r"\cdot \frac{500.000}{100.000} = 2.000 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\sigma_{c2d} = \min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{\Sigma A_{s,confy}}{b_{csx}}\right) "
+                    r"\cdot \frac{f_{yd}}{s} = \min\left(\frac{200.000 \ mm^2}{500.000 \ mm}, \frac{300.000 \ mm^2}{300.000 \ mm}\right) "
+                    r"\cdot \frac{500.000 \ MPa}{100.000 \ mm} = 2.000 \ MPa"
+                ),
+            ),
+            ("short", r"\sigma_{c2d} = 2.000 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        sum_a_s_confx = 200.0
+        b_csy = 500.0
+        sum_a_s_confy = 300.0
+        b_csx = 300.0
+        f_yd = 500.0
+        s = 100.0
+
+        # Object to test
+        latex = Form8Dot13ConfinementStressMultipleConfinement(
+            sum_a_s_confx=sum_a_s_confx, b_csy=b_csy, sum_a_s_confy=sum_a_s_confy, b_csx=b_csx, f_yd=f_yd, s=s
+        ).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_14.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_14.py
@@ -1,0 +1,120 @@
+"""Testing formula 8.14 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_14 import (
+    Form8Dot14ConfinementStressCompressionZone,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot14ConfinementStressCompressionZone:
+    """Validation for formula 8.14 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation_x_term_governs(self) -> None:
+        """Tests the evaluation of the result where the x term governs the minimum."""
+        # Example values
+        sum_a_s_confx = 200.0
+        b_csy = 500.0
+        a_s_confy = 300.0
+        x_cs = 300.0
+        f_yd = 500.0
+        s = 100.0
+
+        # Object to test
+        formula = Form8Dot14ConfinementStressCompressionZone(sum_a_s_confx=sum_a_s_confx, b_csy=b_csy, a_s_confy=a_s_confy, x_cs=x_cs, f_yd=f_yd, s=s)
+
+        # Expected result, manually calculated: min(200 / 500, 300 / 300) * 500 / 100
+        manually_calculated_result = 2.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_y_term_governs(self) -> None:
+        """Tests the evaluation of the result where the y term governs the minimum."""
+        # Example values
+        sum_a_s_confx = 400.0
+        b_csy = 500.0
+        a_s_confy = 150.0
+        x_cs = 300.0
+        f_yd = 500.0
+        s = 100.0
+
+        # Object to test
+        formula = Form8Dot14ConfinementStressCompressionZone(sum_a_s_confx=sum_a_s_confx, b_csy=b_csy, a_s_confy=a_s_confy, x_cs=x_cs, f_yd=f_yd, s=s)
+
+        # Expected result, manually calculated: min(400 / 500, 150 / 300) * 500 / 100
+        manually_calculated_result = 2.5
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("sum_a_s_confx", "a_s_confy", "f_yd"),
+        [
+            (-200.0, 300.0, 500.0),  # sum_a_s_confx is negative
+            (200.0, -300.0, 500.0),  # a_s_confy is negative
+            (200.0, 300.0, -500.0),  # f_yd is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, sum_a_s_confx: float, a_s_confy: float, f_yd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot14ConfinementStressCompressionZone(sum_a_s_confx=sum_a_s_confx, b_csy=500.0, a_s_confy=a_s_confy, x_cs=300.0, f_yd=f_yd, s=100.0)
+
+    @pytest.mark.parametrize(
+        ("b_csy", "x_cs", "s"),
+        [
+            (-500.0, 300.0, 100.0),  # b_csy is negative
+            (500.0, -300.0, 100.0),  # x_cs is negative
+            (500.0, 300.0, -100.0),  # s is negative
+            (500.0, 300.0, 0.0),  # s is zero
+        ],
+    )
+    def test_raise_error_when_invalid_values_are_given(self, b_csy: float, x_cs: float, s: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot14ConfinementStressCompressionZone(sum_a_s_confx=200.0, b_csy=b_csy, a_s_confy=300.0, x_cs=x_cs, f_yd=500.0, s=s)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\sigma_{c2d} = \min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{A_{s,confy}}{x_{cs}}\right) "
+                    r"\cdot \frac{f_{yd}}{s} = \min\left(\frac{200.000}{500.000}, \frac{300.000}{300.000}\right) "
+                    r"\cdot \frac{500.000}{100.000} = 2.000 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\sigma_{c2d} = \min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{A_{s,confy}}{x_{cs}}\right) "
+                    r"\cdot \frac{f_{yd}}{s} = \min\left(\frac{200.000 \ mm^2}{500.000 \ mm}, \frac{300.000 \ mm^2}{300.000 \ mm}\right) "
+                    r"\cdot \frac{500.000 \ MPa}{100.000 \ mm} = 2.000 \ MPa"
+                ),
+            ),
+            ("short", r"\sigma_{c2d} = 2.000 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        sum_a_s_confx = 200.0
+        b_csy = 500.0
+        a_s_confy = 300.0
+        x_cs = 300.0
+        f_yd = 500.0
+        s = 100.0
+
+        # Object to test
+        latex = Form8Dot14ConfinementStressCompressionZone(
+            sum_a_s_confx=sum_a_s_confx, b_csy=b_csy, a_s_confy=a_s_confy, x_cs=x_cs, f_yd=f_yd, s=s
+        ).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
Adds formulas (8.11) to (8.14) from clause 8.1.4(3) "Confined concrete" of FprEN 1992-1-1:2023, all printed on page 112. This exceeds the usual cap of three formula classes per pull request, by explicit choice for this clause since all four are short and fit on a single page.

Paragraph (3) gives the confinement stress sigma_c2d resulting from confinement reinforcement, as four alternative formulas depending on the geometric confinement configuration: circular/square members with single confinement (8.11), rectangular members with single confinement (8.12), members with multiple confinement (8.13), and compression zones (8.14).

## Decisions a reviewer has to weigh

- **Four separate classes, not one combined casus.** All four formulas compute the same physical quantity, sigma_c2d, and are presented as a group of alternatives selected by geometric configuration, similar in shape to the stepped/branching formulas combined elsewhere in this track (e.g. (8.115) to (8.118)). Here they are kept as separate classes instead, because each takes a genuinely different set of inputs: (8.11) and (8.12) take a single `a_s_conf`, while (8.13) and (8.14) take summed areas (`sum_a_s_confx`/`sum_a_s_confy`) that do not apply to the first two, and (8.14) mixes a summed and a single-leg area where (8.13) uses two summed areas. A single flag-based class would carry several parameters that are irrelevant depending on the selected case, which this track's precedent (the duplicated expression of (8.27) and (8.33), left as two classes rather than one) treats as a reason to keep formulas separate when their expressions genuinely differ.
- **(8.13)'s cross-pairing is implemented as printed**: the x-direction sum is divided by the y-direction width (`sum_a_s_confx / b_csy`), and the y-direction sum by the x-direction width (`sum_a_s_confy / b_csx`), confirmed against the page rather than assumed.
- **(8.14) differs from (8.13) only in its second term**: a single `a_s_confy` over `x_cs`, not a summed area over `b_csx`, matching how the two are printed.
- **The optional sqrt(2) factor for confining reinforcement not aligned with the x or y axes is not modelled.** The standard describes it as an adjustment to the input area for that specific reinforcement layout (Figure 8.3 d)), which is left to the caller to apply before passing the area in.

## Formulas as implemented

**Formula (8.11)**, `Form8Dot11ConfinementStressCircularSquareSingleConfinement`

`equation`

$$
\frac{2 \cdot A_{s,conf} \cdot f_{yd}}{b_{cs} \cdot s}
$$

`complete`

$$
\sigma_{c2d} = \frac{2 \cdot A_{s,conf} \cdot f_{yd}}{b_{cs} \cdot s} = \frac{2 \cdot 100.000 \cdot 500.000}{300.000 \cdot 150.000} = 2.222 \ MPa
$$

`complete_with_units`

$$
\sigma_{c2d} = \frac{2 \cdot A_{s,conf} \cdot f_{yd}}{b_{cs} \cdot s} = \frac{2 \cdot 100.000 \ mm^2 \cdot 500.000 \ MPa}{300.000 \ mm \cdot 150.000 \ mm} = 2.222 \ MPa
$$

**Formula (8.12)**, `Form8Dot12ConfinementStressRectangularSingleConfinement`

`equation`

$$
\frac{2 \cdot A_{s,conf} \cdot f_{yd}}{\max\left(b_{csx}, b_{csy}\right) \cdot s}
$$

`complete`

$$
\sigma_{c2d} = \frac{2 \cdot A_{s,conf} \cdot f_{yd}}{\max\left(b_{csx}, b_{csy}\right) \cdot s} = \frac{2 \cdot 100.000 \cdot 500.000}{\max\left(300.000, 400.000\right) \cdot 150.000} = 1.667 \ MPa
$$

`complete_with_units`

$$
\sigma_{c2d} = \frac{2 \cdot A_{s,conf} \cdot f_{yd}}{\max\left(b_{csx}, b_{csy}\right) \cdot s} = \frac{2 \cdot 100.000 \ mm^2 \cdot 500.000 \ MPa}{\max\left(300.000 \ mm, 400.000 \ mm\right) \cdot 150.000 \ mm} = 1.667 \ MPa
$$

**Formula (8.13)**, `Form8Dot13ConfinementStressMultipleConfinement`

`equation`

$$
\min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{\Sigma A_{s,confy}}{b_{csx}}\right) \cdot \frac{f_{yd}}{s}
$$

`complete`

$$
\sigma_{c2d} = \min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{\Sigma A_{s,confy}}{b_{csx}}\right) \cdot \frac{f_{yd}}{s} = \min\left(\frac{200.000}{500.000}, \frac{300.000}{300.000}\right) \cdot \frac{500.000}{100.000} = 2.000 \ MPa
$$

`complete_with_units`

$$
\sigma_{c2d} = \min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{\Sigma A_{s,confy}}{b_{csx}}\right) \cdot \frac{f_{yd}}{s} = \min\left(\frac{200.000 \ mm^2}{500.000 \ mm}, \frac{300.000 \ mm^2}{300.000 \ mm}\right) \cdot \frac{500.000 \ MPa}{100.000 \ mm} = 2.000 \ MPa
$$

**Formula (8.14)**, `Form8Dot14ConfinementStressCompressionZone`

`equation`

$$
\min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{A_{s,confy}}{x_{cs}}\right) \cdot \frac{f_{yd}}{s}
$$

`complete`

$$
\sigma_{c2d} = \min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{A_{s,confy}}{x_{cs}}\right) \cdot \frac{f_{yd}}{s} = \min\left(\frac{200.000}{500.000}, \frac{300.000}{300.000}\right) \cdot \frac{500.000}{100.000} = 2.000 \ MPa
$$

`complete_with_units`

$$
\sigma_{c2d} = \min\left(\frac{\Sigma A_{s,confx}}{b_{csy}}, \frac{A_{s,confy}}{x_{cs}}\right) \cdot \frac{f_{yd}}{s} = \min\left(\frac{200.000 \ mm^2}{500.000 \ mm}, \frac{300.000 \ mm^2}{300.000 \ mm}\right) \cdot \frac{500.000 \ MPa}{100.000 \ mm} = 2.000 \ MPa
$$

Contributes to #1083.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eurocode 2 confinement stress calculations for circular, square, rectangular, multiple-reinforcement, and compression-zone cases (Formulas 8.11–8.14).
  * Added validation for invalid input values and formatted calculation representations with units.

* **Documentation**
  * Updated the Eurocode 2 formula tracking table to mark Formulas 8.11–8.14 as implemented.

* **Tests**
  * Added coverage for calculation results, validation errors, and formatted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->