### PR TITLE
1160 bug fix aggregatedcomparisonformula instance check and repr

### DIFF
--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -307,8 +307,9 @@ class AggregatedComparisonFormula(ComparisonFormula):
         aggregation, comparison_formulas = cls._define_aggregation(*args, **kwargs)
         result = cls._evaluate(aggregation=aggregation, comparison_formulas=comparison_formulas)
         instance = float.__new__(cls, result)
-        instance.aggregation = aggregation
-        instance.comparison_formulas = tuple(comparison_formulas)
+        # _evaluate above rejects an aggregation or a sequence of formulas that is None, which a type checker cannot see.
+        instance.aggregation = aggregation  # ty: ignore[invalid-assignment]
+        instance.comparison_formulas = tuple(comparison_formulas)  # ty: ignore[invalid-argument-type]
         instance._initialized = False  # noqa: SLF001
         return instance
 

--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -229,6 +229,24 @@ class ComparisonFormula(Formula, ABC):
         # operator returns a numpy.bool_, and Python requires __bool__ to return a real bool.
         return bool(self._comparison_operator()(self.lhs, self.rhs))
 
+    def __repr__(self) -> str:
+        """Return the result of the comparison as a readable string.
+
+        A ComparisonFormula is a float, so its default representation is the numeric value of the
+        comparison (1.0 or 0.0). This representation shows whether the condition is satisfied instead.
+
+        Examples
+        --------
+        formula = SomeComparisonFormula(...)
+        print(formula)  # Prints "Ok" if the condition is satisfied, "Not Ok" otherwise.
+
+        Returns
+        -------
+        str
+            "Ok" if the comparison condition is satisfied, "Not Ok" otherwise.
+        """
+        return "Ok" if self.__bool__() else "Not Ok"
+
     @classmethod
     def _evaluate(cls, *args, **kwargs) -> bool:
         """Implements the comparison using the class-level operator."""
@@ -247,26 +265,53 @@ class AggregatedComparisonFormula(ComparisonFormula):
     the same way concrete subclasses of :class:`ComparisonFormula` do.
     """
 
+    aggregation: Callable[[Iterable[bool]], bool]
+    comparison_formulas: tuple[ComparisonFormula, ...]
+
     def __new__(cls, *args, **kwargs) -> Self:
         """Method for creating a new instance of the class."""
-        result = cls._evaluate(*args, **kwargs)
+        aggregation, comparison_formulas = cls._resolve_aggregation(*args, **kwargs)
+        result = cls._evaluate(aggregation=aggregation, comparison_formulas=comparison_formulas)
         instance = float.__new__(cls, result)
+        instance.aggregation = aggregation
+        instance.comparison_formulas = tuple(comparison_formulas)
         instance._initialized = False  # noqa: SLF001
         return instance
 
-    def __init__(self, aggregation: Callable[[Iterable[bool]], bool], comparison_formulas: Sequence[ComparisonFormula]) -> None:
+    def __init__(self, *_args, **_kwargs) -> None:
         """Method for initializing a new instance of the class.
+
+        The aggregation function and the comparison formulas are resolved and stored by ``__new__``
+        through :meth:`_resolve_aggregation`, so the constructor arguments are not read again here.
+        """
+        super().__init__()
+
+    @classmethod
+    def _resolve_aggregation(
+        cls,
+        aggregation: Callable[[Iterable[bool]], bool] | None = None,
+        comparison_formulas: Sequence[ComparisonFormula] | None = None,
+    ) -> tuple[Callable[[Iterable[bool]], bool] | None, Sequence[ComparisonFormula] | None]:
+        """Resolve the constructor arguments into the aggregation function and the formulas to aggregate.
+
+        By default the two are passed to the constructor directly. A subclass whose constructor takes
+        something else (e.g. a table lookup that has to build the formulas first) overrides this method
+        instead of _evaluate, so that the formulas are built exactly once per instance.
 
         Parameters
         ----------
-        aggregation : Callable[[Iterable[bool]], bool]
+        aggregation : Callable[[Iterable[bool]], bool] | None
             Type of aggregation function to be used for the comparison formulas. Must be either all or any.
-        comparison_formulas : Sequence[ComparisonFormula]
+        comparison_formulas : Sequence[ComparisonFormula] | None
             Sequence of ComparisonFormula instances to be aggregated.
+
+        Returns
+        -------
+        tuple[Callable[[Iterable[bool]], bool] | None, Sequence[ComparisonFormula] | None]
+            The aggregation function and the comparison formulas. They are validated by _evaluate,
+            so returning None for either of them is allowed and yields a readable error.
         """
-        super().__init__()
-        self.aggregation = aggregation
-        self.comparison_formulas = tuple(comparison_formulas)
+        return aggregation, comparison_formulas
 
     @classmethod
     def _comparison_operator(cls) -> Callable[[float, float], bool]:

--- a/blueprints/codes/formula.py
+++ b/blueprints/codes/formula.py
@@ -263,6 +263,40 @@ class AggregatedComparisonFormula(ComparisonFormula):
     This class is abstract: it does not implement ``label``, ``source_document`` or ``latex``.
     A concrete formula that aggregates other comparison formulas should subclass this and provide those,
     the same way concrete subclasses of :class:`ComparisonFormula` do.
+
+    Such a subclass takes the parameters of the code formula it represents, and not an aggregation function
+    with a list of formulas. It translates the one into the other by overriding :meth:`_define_aggregation`,
+    which is where the formulas to aggregate are built.
+
+    Examples
+    --------
+    class SomeAggregatedComparisonFormula(AggregatedComparisonFormula):
+        label = "1.1"
+        source_document = "Some code document"
+
+        def __init__(self, value: float, lower_bound: float, upper_bound: float) -> None:
+            # The arguments are read by _define_aggregation, so nothing is passed on to the base class here.
+            super().__init__()
+            self.value = value
+            self.lower_bound = lower_bound
+            self.upper_bound = upper_bound
+
+        @classmethod
+        def _define_aggregation(cls, value, lower_bound, upper_bound):
+            return all, (
+                SomeLowerBoundFormula(value=value, lower_bound=lower_bound),
+                SomeUpperBoundFormula(value=value, upper_bound=upper_bound),
+            )
+
+    formula = SomeAggregatedComparisonFormula(value=5, lower_bound=1, upper_bound=10)
+    bool(formula)  # True, both bounds are satisfied
+    formula.comparison_formulas  # the two bounds, built once by _define_aggregation
+    formula.unity_check  # the largest of the two unity checks, because the aggregation is 'all'
+
+    The default implementation returns what it is given, so formulas that are already instantiated can be
+    aggregated without such a subclass:
+
+    aggregated_formula = AggregatedComparisonFormula(all, [formula1, formula2])
     """
 
     aggregation: Callable[[Iterable[bool]], bool]
@@ -270,7 +304,7 @@ class AggregatedComparisonFormula(ComparisonFormula):
 
     def __new__(cls, *args, **kwargs) -> Self:
         """Method for creating a new instance of the class."""
-        aggregation, comparison_formulas = cls._resolve_aggregation(*args, **kwargs)
+        aggregation, comparison_formulas = cls._define_aggregation(*args, **kwargs)
         result = cls._evaluate(aggregation=aggregation, comparison_formulas=comparison_formulas)
         instance = float.__new__(cls, result)
         instance.aggregation = aggregation
@@ -281,22 +315,25 @@ class AggregatedComparisonFormula(ComparisonFormula):
     def __init__(self, *_args, **_kwargs) -> None:
         """Method for initializing a new instance of the class.
 
-        The aggregation function and the comparison formulas are resolved and stored by ``__new__``
-        through :meth:`_resolve_aggregation`, so the constructor arguments are not read again here.
+        The aggregation function and the comparison formulas are defined and stored by ``__new__``
+        through :meth:`_define_aggregation`, so the constructor arguments are not read again here.
         """
         super().__init__()
 
     @classmethod
-    def _resolve_aggregation(
+    def _define_aggregation(
         cls,
         aggregation: Callable[[Iterable[bool]], bool] | None = None,
         comparison_formulas: Sequence[ComparisonFormula] | None = None,
     ) -> tuple[Callable[[Iterable[bool]], bool] | None, Sequence[ComparisonFormula] | None]:
-        """Resolve the constructor arguments into the aggregation function and the formulas to aggregate.
+        """Define the aggregation function and the comparison formulas that this formula aggregates.
 
-        By default the two are passed to the constructor directly. A subclass whose constructor takes
-        something else (e.g. a table lookup that has to build the formulas first) overrides this method
-        instead of _evaluate, so that the formulas are built exactly once per instance.
+        This is the method a concrete subclass overrides, see the examples in the class docstring. Its
+        parameters are then the parameters of the code formula itself, which it translates into the
+        aggregation to be evaluated. By default the two are passed to the constructor directly.
+
+        It is called exactly once per instance, from ``__new__``, and it is the place to build the formulas
+        to aggregate: building them in ``__init__`` or in ``_evaluate`` instead would build them twice.
 
         Parameters
         ----------

--- a/tests/codes/test_formula.py
+++ b/tests/codes/test_formula.py
@@ -792,6 +792,11 @@ class AggregatedComparisonFormulaTestOwnParameters(AggregatedComparisonFormula):
         )
 
 
+def neither_all_nor_any(values: Iterable[bool]) -> bool:
+    """Dummy aggregation function that has the signature of an aggregation, but is neither all nor any."""
+    return all(values)
+
+
 class AggregatedComparisonFormulaTestInvalidDefinition(AggregatedComparisonFormula):
     """Dummy aggregated comparison formula whose _define_aggregation returns an unusable aggregation."""
 
@@ -801,7 +806,7 @@ class AggregatedComparisonFormulaTestInvalidDefinition(AggregatedComparisonFormu
     @classmethod
     def _define_aggregation(cls, *_args, **_kwargs) -> tuple[Callable[[Iterable[bool]], bool], Sequence[ComparisonFormula] | None]:
         """Returns an aggregation function that is neither all nor any."""
-        return sum, None
+        return neither_all_nor_any, None
 
 
 class TestAggregatedComparisonFormula:

--- a/tests/codes/test_formula.py
+++ b/tests/codes/test_formula.py
@@ -1,7 +1,7 @@
 """Module for testing the Formula classes."""
 
 import operator
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 import numpy as np
@@ -758,6 +758,52 @@ class ComparisonFormulaTestLatexGreaterOrEqual(ComparisonFormula):
         )
 
 
+class AggregatedComparisonFormulaTestOwnParameters(AggregatedComparisonFormula):
+    """Dummy aggregated comparison formula whose constructor takes the parameters of the formula itself.
+
+    Mirrors a concrete code formula: it translates its own parameters into the aggregation by overriding
+    _define_aggregation, and counts the calls to it so that they can be asserted.
+    """
+
+    label = "Dummy testing aggregated comparison formula (own parameters)"
+    source_document = "Dummy testing document"
+
+    definitions = 0
+
+    def __init__(self, value: float, lower_bound: float, upper_bound: float) -> None:
+        """Dummy aggregated comparison formula for testing purposes."""
+        super().__init__()
+        self.value = value
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+
+    @classmethod
+    def _define_aggregation(
+        cls,
+        value: float,
+        lower_bound: float,
+        upper_bound: float,
+    ) -> tuple[Callable[[Iterable[bool]], bool], Sequence[ComparisonFormula]]:
+        """Translates the parameters of this formula into the two bounds it aggregates."""
+        AggregatedComparisonFormulaTestOwnParameters.definitions += 1
+        return all, (
+            ComparisonFormulaTestLatexGreaterOrEqual(x=value, y=lower_bound),
+            ComparisonFormulaTestLatexLessOrEqual(x=value, y=upper_bound),
+        )
+
+
+class AggregatedComparisonFormulaTestInvalidDefinition(AggregatedComparisonFormula):
+    """Dummy aggregated comparison formula whose _define_aggregation returns an unusable aggregation."""
+
+    label = "Dummy testing aggregated comparison formula (invalid definition)"
+    source_document = "Dummy testing document"
+
+    @classmethod
+    def _define_aggregation(cls, *_args, **_kwargs) -> tuple[Callable[[Iterable[bool]], bool], Sequence[ComparisonFormula] | None]:
+        """Returns an aggregation function that is neither all nor any."""
+        return sum, None
+
+
 class TestAggregatedComparisonFormula:
     """Test class for AggregatedComparisonFormula."""
 
@@ -916,6 +962,49 @@ class TestAggregatedComparisonFormula:
         assert repr(AggregatedComparisonFormulaTest(aggregation=all, comparison_formulas=[passing_formula, failing_formula])) == "Not Ok"
         assert repr(AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[passing_formula, failing_formula])) == "Ok"
         assert repr(AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[failing_formula, failing_formula])) == "Not Ok"
+
+    def test_define_aggregation_passes_the_constructor_arguments_through_by_default(self) -> None:
+        """Test that the default _define_aggregation returns the aggregation and the formulas it is given."""
+        comparison_formulas = [self._le(1, 1, 10), self._le(2, 1, 10)]
+
+        assert AggregatedComparisonFormulaTest._define_aggregation(all, comparison_formulas) == (all, comparison_formulas)  # noqa: SLF001
+
+    def test_define_aggregation_translates_the_parameters_of_the_formula_itself(self) -> None:
+        """Test that a subclass can translate its own constructor parameters into the aggregation."""
+        formula = AggregatedComparisonFormulaTestOwnParameters(value=5, lower_bound=1, upper_bound=10)
+
+        lower_bound, upper_bound = formula.comparison_formulas
+        assert isinstance(lower_bound, ComparisonFormulaTestLatexGreaterOrEqual)
+        assert (lower_bound.x, lower_bound.y) == (5, 1)
+        assert isinstance(upper_bound, ComparisonFormulaTestLatexLessOrEqual)
+        assert (upper_bound.x, upper_bound.y) == (5, 10)
+        assert formula.aggregation is all
+
+        # 1 <= 5 <= 10, so both bounds are satisfied. The unity checks are 1/5 and 5/10, of which the largest is taken.
+        assert formula
+        assert formula.unity_check == pytest.approx(0.5)
+
+    def test_define_aggregation_result_is_evaluated_as_the_result_of_the_formula(self) -> None:
+        """Test that the formulas defined by a subclass determine the result of the aggregated formula."""
+        formula = AggregatedComparisonFormulaTestOwnParameters(value=20, lower_bound=1, upper_bound=10)
+
+        # 20 > 10, so the upper bound is violated and the aggregated check fails.
+        assert not formula
+        assert repr(formula) == "Not Ok"
+        assert formula.unity_check == pytest.approx(2.0)
+
+    def test_define_aggregation_is_called_exactly_once_per_instance(self) -> None:
+        """Test that the formulas to aggregate are built once, which is why they are built in _define_aggregation."""
+        AggregatedComparisonFormulaTestOwnParameters.definitions = 0
+
+        AggregatedComparisonFormulaTestOwnParameters(value=5, lower_bound=1, upper_bound=10)
+
+        assert AggregatedComparisonFormulaTestOwnParameters.definitions == 1
+
+    def test_define_aggregation_result_is_validated(self) -> None:
+        """Test that what a subclass returns from _define_aggregation is validated by _evaluate."""
+        with pytest.raises(ValueError, match="Aggregation function must be either 'all' or 'any'"):
+            AggregatedComparisonFormulaTestInvalidDefinition()
 
     def test_aggregated_comparison_formula_bool_with_negative_values_all_passes(self) -> None:
         """Test 'all' aggregation bool with negative lhs/rhs values, where each sub-formula passes."""

--- a/tests/codes/test_formula.py
+++ b/tests/codes/test_formula.py
@@ -161,6 +161,22 @@ def test_comparison_operator() -> None:
     assert ComparisonFormulaTestLessOrEqual._comparison_operator() == operator.le  # noqa: SLF001
 
 
+def test_comparison_formula_repr() -> None:
+    """Test that the representation is 'Ok'/'Not Ok' instead of the numeric value of the comparison."""
+    b = 5
+    c = 40
+
+    # check passing condition (lhs <= rhs) = True
+    formula = ComparisonFormulaTestLessOrEqual(a=10, b=b, c=c)
+    assert repr(formula) == "Ok"
+    assert str(formula) == "Ok"
+
+    # check failing condition (lhs > rhs) = False
+    formula = ComparisonFormulaTestLessOrEqual(a=30, b=b, c=c)
+    assert repr(formula) == "Not Ok"
+    assert str(formula) == "Not Ok"
+
+
 class ComparisonFormulaTestGreaterOrEqual(ComparisonFormula):
     """Dummy comparison formula with >= operator for testing purposes."""
 
@@ -890,6 +906,16 @@ class TestAggregatedComparisonFormula:
         formula = AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[f1, f2, f3])
         assert formula
         assert bool(formula) is True
+
+    def test_aggregated_comparison_formula_repr(self) -> None:
+        """Test that the inherited representation is 'Ok'/'Not Ok' for the aggregated result."""
+        passing_formula = self._le(1, 1, 10)  # lhs=2, rhs=5  →  passes
+        failing_formula = self._le(10, 1, 4)  # lhs=11, rhs=2  →  fails
+
+        assert repr(AggregatedComparisonFormulaTest(aggregation=all, comparison_formulas=[passing_formula, passing_formula])) == "Ok"
+        assert repr(AggregatedComparisonFormulaTest(aggregation=all, comparison_formulas=[passing_formula, failing_formula])) == "Not Ok"
+        assert repr(AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[passing_formula, failing_formula])) == "Ok"
+        assert repr(AggregatedComparisonFormulaTest(aggregation=any, comparison_formulas=[failing_formula, failing_formula])) == "Not Ok"
 
     def test_aggregated_comparison_formula_bool_with_negative_values_all_passes(self) -> None:
         """Test 'all' aggregation bool with negative lhs/rhs values, where each sub-formula passes."""


### PR DESCRIPTION
## Description
In this PR:
- Added dunder repr to ComparisonFormula
- Added _define_aggregation to AggregatedComparisonFormula so that it can be overriden in subclasses. Now the subclass in 8_58 overrides dunder new, which is not correct.
- Added tests for _define_aggregation 
- Added examples in the doc-string for _define_aggregation so that subclassing becomes more clear.

Fixes #1160 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Comparison results now display clear “Ok” or “Not Ok” text instead of numeric representations.
  - Aggregated comparisons support reusable, customizable aggregation definitions.

- **Documentation**
  - Added usage examples and clarified configuration options for aggregated comparisons.

- **Tests**
  - Expanded coverage for result formatting, custom aggregation behavior, validation, and evaluation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->