### PR TITLE
feat: add formulas 8.9 and 8.10 from FprEN 1992-1-1:2023 clause 8.1.4

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_9_10.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_9_10.py
@@ -1,0 +1,95 @@
+"""Formula 8.9 and 8.10 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import MM, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot9To10ConcreteStrengthIncreaseConfinement(Formula):
+    r"""Class representing formulas 8.9 and 8.10 for the calculation of the compressive strength increase of a
+    concrete due to a transverse compressive stress from confinement reinforcement or triaxial compression.
+    """
+
+    label = "8.9/8.10"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        sigma_c2d: MPA,
+        f_cd: MPA,
+        d_dg: MM,
+    ) -> None:
+        r"""[$\Delta f_{cd}$] Compressive strength increase of a concrete due to a transverse compressive
+        stress [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.4(2) - Formula (8.9) and (8.10)
+
+        In case of concrete with [$d_{dg} < 32$] mm, the strength increase is reduced by the factor
+        [$d_{dg}/32$ mm]; that reduction is applied inside this class rather than as a separate step.
+
+        Parameters
+        ----------
+        sigma_c2d : MPA
+            [$\sigma_{c2d}$] Absolute value of the minimum principal transverse compressive stress [$MPa$].
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        d_dg : MM
+            [$d_{dg}$] Size parameter describing the failure zone roughness, according to 8.2.1(4) [$mm$].
+        """
+        super().__init__()
+        self.sigma_c2d = sigma_c2d
+        self.f_cd = f_cd
+        self.d_dg = d_dg
+
+    @staticmethod
+    def _evaluate(
+        sigma_c2d: MPA,
+        f_cd: MPA,
+        d_dg: MM,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(sigma_c2d=sigma_c2d, f_cd=f_cd)
+        raise_if_less_or_equal_to_zero(d_dg=d_dg)
+
+        delta_f_cd = 4 * sigma_c2d if sigma_c2d <= 0.6 * f_cd else 3.5 * sigma_c2d ** (3 / 4) * f_cd ** (1 / 4)
+
+        reduction_factor = min(d_dg / 32, 1.0)
+        return delta_f_cd * reduction_factor
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formulas 8.9 and 8.10."""
+        _equation: str = (
+            r"\min\left(\frac{d_{dg}}{32}, 1.0\right) \cdot "
+            r"\begin{cases} 4 \cdot \sigma_{c2d} & \text{for } \sigma_{c2d} \leq 0.6 \cdot f_{cd} \\ "
+            r"3.5 \cdot \left(\sigma_{c2d}\right)^{3/4} \cdot \left(f_{cd}\right)^{1/4} & \text{for } \sigma_{c2d} > 0.6 \cdot f_{cd} "
+            r"\end{cases}"
+        )
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"d_{dg}": f"{self.d_dg:.{n}f}",
+                r"\sigma_{c2d}": f"{self.sigma_c2d:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"d_{dg}": rf"{self.d_dg:.{n}f} \ mm",
+                r"\sigma_{c2d}": rf"{self.sigma_c2d:.{n}f} \ MPa",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\Delta f_{cd}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -70,8 +70,8 @@ Total of 602 formulas present.
 |      8.6       |        :x:         |         |                                                                    |
 |      8.7       |        :x:         |         |                                                                    |
 |      8.8       |        :x:         |         |                                                                    |
-|      8.9       |        :x:         |         |                                                                    |
-|      8.10      |        :x:         |         |                                                                    |
+|      8.9       | :heavy_check_mark: |         | Form8Dot9To10ConcreteStrengthIncreaseConfinement                  |
+|      8.10      | :heavy_check_mark: |         | Form8Dot9To10ConcreteStrengthIncreaseConfinement                  |
 |      8.11      |        :x:         |         |                                                                    |
 |      8.12      |        :x:         |         |                                                                    |
 |      8.13      |        :x:         |         |                                                                    |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_9_10.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_9_10.py
@@ -1,0 +1,146 @@
+"""Testing formulas 8.9 and 8.10 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_9_10 import (
+    Form8Dot9To10ConcreteStrengthIncreaseConfinement,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot9To10ConcreteStrengthIncreaseConfinement:
+    """Validation for formulas 8.9 and 8.10 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation_low_stress_branch(self) -> None:
+        """Tests the evaluation of the result on the low-stress branch, formula (8.9), without reduction."""
+        # Example values
+        sigma_c2d = 5.0
+        f_cd = 20.0
+        d_dg = 32.0
+
+        # Object to test
+        formula = Form8Dot9To10ConcreteStrengthIncreaseConfinement(sigma_c2d=sigma_c2d, f_cd=f_cd, d_dg=d_dg)
+
+        # Expected result, manually calculated: 4 * 5 * min(32 / 32, 1.0)
+        manually_calculated_result = 20.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_high_stress_branch(self) -> None:
+        """Tests the evaluation of the result on the high-stress branch, formula (8.10), without reduction."""
+        # Example values
+        sigma_c2d = 15.0
+        f_cd = 20.0
+        d_dg = 32.0
+
+        # Object to test
+        formula = Form8Dot9To10ConcreteStrengthIncreaseConfinement(sigma_c2d=sigma_c2d, f_cd=f_cd, d_dg=d_dg)
+
+        # Expected result, manually calculated: 3.5 * 15**(3/4) * 20**(1/4) * min(32 / 32, 1.0)
+        manually_calculated_result = 56.41492142073595
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_at_boundary(self) -> None:
+        """Tests the evaluation of the result exactly at the boundary, where the low-stress branch governs."""
+        # Example values
+        sigma_c2d = 12.0
+        f_cd = 20.0
+        d_dg = 32.0
+
+        # Object to test
+        formula = Form8Dot9To10ConcreteStrengthIncreaseConfinement(sigma_c2d=sigma_c2d, f_cd=f_cd, d_dg=d_dg)
+
+        # Expected result, manually calculated: 4 * 12 (the low-stress branch, since sigma_c2d = 0.6 * f_cd)
+        manually_calculated_result = 48.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_evaluation_with_reduction_factor(self) -> None:
+        """Tests the evaluation of the result where d_dg < 32 mm and the reduction factor applies."""
+        # Example values
+        sigma_c2d = 5.0
+        f_cd = 20.0
+        d_dg = 16.0
+
+        # Object to test
+        formula = Form8Dot9To10ConcreteStrengthIncreaseConfinement(sigma_c2d=sigma_c2d, f_cd=f_cd, d_dg=d_dg)
+
+        # Expected result, manually calculated: 4 * 5 * (16 / 32)
+        manually_calculated_result = 10.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("sigma_c2d", "f_cd"),
+        [
+            (-5.0, 20.0),  # sigma_c2d is negative
+            (5.0, -20.0),  # f_cd is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, sigma_c2d: float, f_cd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot9To10ConcreteStrengthIncreaseConfinement(sigma_c2d=sigma_c2d, f_cd=f_cd, d_dg=32.0)
+
+    @pytest.mark.parametrize(
+        "d_dg",
+        [
+            -32.0,  # d_dg is negative
+            0.0,  # d_dg is zero
+        ],
+    )
+    def test_raise_error_when_d_dg_is_less_or_equal_to_zero(self, d_dg: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot9To10ConcreteStrengthIncreaseConfinement(sigma_c2d=5.0, f_cd=20.0, d_dg=d_dg)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\Delta f_{cd} = \min\left(\frac{d_{dg}}{32}, 1.0\right) \cdot "
+                    r"\begin{cases} 4 \cdot \sigma_{c2d} & \text{for } \sigma_{c2d} \leq 0.6 \cdot f_{cd} \\ "
+                    r"3.5 \cdot \left(\sigma_{c2d}\right)^{3/4} \cdot \left(f_{cd}\right)^{1/4} & "
+                    r"\text{for } \sigma_{c2d} > 0.6 \cdot f_{cd} \end{cases} = "
+                    r"\min\left(\frac{32.000}{32}, 1.0\right) \cdot "
+                    r"\begin{cases} 4 \cdot 5.000 & \text{for } 5.000 \leq 0.6 \cdot 20.000 \\ "
+                    r"3.5 \cdot \left(5.000\right)^{3/4} \cdot \left(20.000\right)^{1/4} & "
+                    r"\text{for } 5.000 > 0.6 \cdot 20.000 \end{cases} = 20.000 \ MPa"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\Delta f_{cd} = \min\left(\frac{d_{dg}}{32}, 1.0\right) \cdot "
+                    r"\begin{cases} 4 \cdot \sigma_{c2d} & \text{for } \sigma_{c2d} \leq 0.6 \cdot f_{cd} \\ "
+                    r"3.5 \cdot \left(\sigma_{c2d}\right)^{3/4} \cdot \left(f_{cd}\right)^{1/4} & "
+                    r"\text{for } \sigma_{c2d} > 0.6 \cdot f_{cd} \end{cases} = "
+                    r"\min\left(\frac{32.000 \ mm}{32}, 1.0\right) \cdot "
+                    r"\begin{cases} 4 \cdot 5.000 \ MPa & \text{for } 5.000 \ MPa \leq 0.6 \cdot 20.000 \ MPa \\ "
+                    r"3.5 \cdot \left(5.000 \ MPa\right)^{3/4} \cdot \left(20.000 \ MPa\right)^{1/4} & "
+                    r"\text{for } 5.000 \ MPa > 0.6 \cdot 20.000 \ MPa \end{cases} = 20.000 \ MPa"
+                ),
+            ),
+            ("short", r"\Delta f_{cd} = 20.000 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        sigma_c2d = 5.0
+        f_cd = 20.0
+        d_dg = 32.0
+
+        # Object to test
+        latex = Form8Dot9To10ConcreteStrengthIncreaseConfinement(sigma_c2d=sigma_c2d, f_cd=f_cd, d_dg=d_dg).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
Adds formulas (8.9) and (8.10) from clause 8.1.4(2) "Confined concrete" of FprEN 1992-1-1:2023, printed on pages 111 and 112.

Paragraph (2) gives the compressive strength increase of a concrete due to a transverse compressive stress, as two branches depending on that stress relative to 0,6 times the design compressive strength.

## Decisions a reviewer has to weigh

- **(8.9) and (8.10) are combined into one class**, as a stepped rule on sigma_c2d versus 0,6*f_cd, following the same grouping used elsewhere in this track for numbered formulas that are branches of a single rule.
- **The d_dg reduction factor is folded into the same class**, rather than modelled as a separate step. The standard states it as running text directly below (8.9) and (8.10), not as its own numbered formula: "In case of concrete with d_dg < 32 mm, the strength increase shall be reduced by factor d_dg/32 mm." The class computes `min(d_dg / 32, 1.0)` so that d_dg >= 32 mm applies no reduction at all, matching the paragraph's own opening condition.

## Formula as implemented

**Formulas (8.9), (8.10)**, `Form8Dot9To10ConcreteStrengthIncreaseConfinement`

`equation`

$$
\min\left(\frac{d_{dg}}{32}, 1.0\right) \cdot \begin{cases} 4 \cdot \sigma_{c2d} & \text{for } \sigma_{c2d} \leq 0.6 \cdot f_{cd} \\ 3.5 \cdot \left(\sigma_{c2d}\right)^{3/4} \cdot \left(f_{cd}\right)^{1/4} & \text{for } \sigma_{c2d} > 0.6 \cdot f_{cd} \end{cases}
$$

`complete`

$$
\Delta f_{cd} = \min\left(\frac{d_{dg}}{32}, 1.0\right) \cdot \begin{cases} 4 \cdot \sigma_{c2d} & \text{for } \sigma_{c2d} \leq 0.6 \cdot f_{cd} \\ 3.5 \cdot \left(\sigma_{c2d}\right)^{3/4} \cdot \left(f_{cd}\right)^{1/4} & \text{for } \sigma_{c2d} > 0.6 \cdot f_{cd} \end{cases} = \min\left(\frac{32.000}{32}, 1.0\right) \cdot \begin{cases} 4 \cdot 5.000 & \text{for } 5.000 \leq 0.6 \cdot 20.000 \\ 3.5 \cdot \left(5.000\right)^{3/4} \cdot \left(20.000\right)^{1/4} & \text{for } 5.000 > 0.6 \cdot 20.000 \end{cases} = 20.000 \ MPa
$$

`complete_with_units`

$$
\Delta f_{cd} = \min\left(\frac{d_{dg}}{32}, 1.0\right) \cdot \begin{cases} 4 \cdot \sigma_{c2d} & \text{for } \sigma_{c2d} \leq 0.6 \cdot f_{cd} \\ 3.5 \cdot \left(\sigma_{c2d}\right)^{3/4} \cdot \left(f_{cd}\right)^{1/4} & \text{for } \sigma_{c2d} > 0.6 \cdot f_{cd} \end{cases} = \min\left(\frac{32.000 \ mm}{32}, 1.0\right) \cdot \begin{cases} 4 \cdot 5.000 \ MPa & \text{for } 5.000 \ MPa \leq 0.6 \cdot 20.000 \ MPa \\ 3.5 \cdot \left(5.000 \ MPa\right)^{3/4} \cdot \left(20.000 \ MPa\right)^{1/4} & \text{for } 5.000 \ MPa > 0.6 \cdot 20.000 \ MPa \end{cases} = 20.000 \ MPa
$$

Contributes to #1083.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Eurocode formulas 8.9 and 8.10, calculating concrete strength increases under transverse compressive stress.
  - Added validation for stress, strength, and aggregate-size inputs.
  - Added formula representations with symbolic expressions, numeric substitutions, and units.

- **Documentation**
  - Marked formulas 8.9 and 8.10 as implemented in the Eurocode formula documentation.

- **Tests**
  - Added coverage for stress conditions, boundary behavior, reduction factors, invalid inputs, and formula representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->