### PR TITLE
feat: add formulas 8.15 to 8.17 from FprEN 1992-1-1:2023 clause 8.1.4

### DIFF
--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_15.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_15.py
@@ -1,0 +1,95 @@
+"""Formula 8.15 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_negative
+
+
+class Form8Dot15AverageConfinedConcreteStrength(Formula):
+    r"""Class representing formula 8.15 for the calculation of the average design compressive strength of
+    confined concrete.
+    """
+
+    label = "8.15"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        f_cd: MPA,
+        k_conf_b: DIMENSIONLESS,
+        k_conf_s: DIMENSIONLESS,
+        delta_f_cd: MPA,
+    ) -> None:
+        r"""[$f_{cd,c}$] Average design compressive strength of confined concrete, smeared over the compression
+        zone [$MPa$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.4(4) - Formula (8.15)
+
+        Parameters
+        ----------
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        k_conf_b : DIMENSIONLESS
+            [$k_{conf,b}$] Effectiveness factor accounting for the shape of the compression zone and of the
+            confinement reinforcement, according to Table 8.1 [$-$].
+        k_conf_s : DIMENSIONLESS
+            [$k_{conf,s}$] Effectiveness factor accounting for the spacing of the confinement reinforcement,
+            according to Table 8.1 [$-$].
+        delta_f_cd : MPA
+            [$\Delta f_{cd}$] Compressive strength increase of the confined concrete according to Formula
+            (8.9) or (8.10), see Form8Dot9To10ConcreteStrengthIncreaseConfinement [$MPa$].
+        """
+        super().__init__()
+        self.f_cd = f_cd
+        self.k_conf_b = k_conf_b
+        self.k_conf_s = k_conf_s
+        self.delta_f_cd = delta_f_cd
+
+    @staticmethod
+    def _evaluate(
+        f_cd: MPA,
+        k_conf_b: DIMENSIONLESS,
+        k_conf_s: DIMENSIONLESS,
+        delta_f_cd: MPA,
+    ) -> MPA:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(f_cd=f_cd, k_conf_b=k_conf_b, k_conf_s=k_conf_s, delta_f_cd=delta_f_cd)
+
+        return f_cd + k_conf_b * k_conf_s * delta_f_cd
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.15."""
+        _equation: str = r"f_{cd} + k_{conf,b} \cdot k_{conf,s} \cdot \Delta f_{cd}"
+        # \Delta f_{cd} is substituted before the bare f_{cd}, since f_{cd} is a literal substring of
+        # \Delta f_{cd} and would otherwise also match there.
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Delta f_{cd}": f"{self.delta_f_cd:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+                r"k_{conf,b}": f"{self.k_conf_b:.{n}f}",
+                r"k_{conf,s}": f"{self.k_conf_s:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\Delta f_{cd}": rf"{self.delta_f_cd:.{n}f} \ MPa",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+                r"k_{conf,b}": f"{self.k_conf_b:.{n}f}",
+                r"k_{conf,s}": f"{self.k_conf_s:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"f_{cd,c}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="MPa",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_16.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_16.py
@@ -1,0 +1,83 @@
+"""Formula 8.16 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot16ConfinedStrainAtPeakStress(Formula):
+    r"""Class representing formula 8.16 for the calculation of the confined compressive strain at peak
+    stress, enhanced by confinement.
+    """
+
+    label = "8.16"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        delta_f_cd: MPA,
+        f_cd: MPA,
+    ) -> None:
+        r"""[$\varepsilon_{c2,c}$] Confined compressive strain at peak stress [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.4(5) - Formula (8.16)
+
+        [$\varepsilon_{c2} = 0{,}002$], the unconfined value used in Formula (8.4), is fixed by the standard
+        and is not an input of this class.
+
+        Parameters
+        ----------
+        delta_f_cd : MPA
+            [$\Delta f_{cd}$] Compressive strength increase of the confined concrete according to Formula
+            (8.9) or (8.10), see Form8Dot9To10ConcreteStrengthIncreaseConfinement [$MPa$].
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        """
+        super().__init__()
+        self.delta_f_cd = delta_f_cd
+        self.f_cd = f_cd
+
+    @staticmethod
+    def _evaluate(
+        delta_f_cd: MPA,
+        f_cd: MPA,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(delta_f_cd=delta_f_cd)
+        raise_if_less_or_equal_to_zero(f_cd=f_cd)
+
+        epsilon_c2 = 0.002
+        return epsilon_c2 * (1 + 5 * delta_f_cd / f_cd)
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.16."""
+        _equation: str = r"\varepsilon_{c2} \cdot \left(1 + 5 \cdot \frac{\Delta f_{cd}}{f_{cd}}\right)"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\varepsilon_{c2}": "0.002",
+                r"\Delta f_{cd}": f"{self.delta_f_cd:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\varepsilon_{c2}": "0.002",
+                r"\Delta f_{cd}": rf"{self.delta_f_cd:.{n}f} \ MPa",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\varepsilon_{c2,c}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_17.py
+++ b/blueprints/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/formula_8_17.py
@@ -1,0 +1,82 @@
+"""Formula 8.17 from FprEN 1992-1-1:2023: Chapter 8: Ultimate limit states (ULS)."""
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023 import FPR_EN_1992_1_1_2023
+from blueprints.codes.formula import Formula
+from blueprints.codes.latex_formula import LatexFormula, latex_replace_symbols
+from blueprints.type_alias import DIMENSIONLESS, MPA
+from blueprints.validations import raise_if_less_or_equal_to_zero, raise_if_negative
+
+
+class Form8Dot17ConfinedUltimateStrain(Formula):
+    r"""Class representing formula 8.17 for the calculation of the confined ultimate compressive strain,
+    enhanced by confinement.
+    """
+
+    label = "8.17"
+    source_document = FPR_EN_1992_1_1_2023
+
+    def __init__(
+        self,
+        sigma_c2d: MPA,
+        f_cd: MPA,
+    ) -> None:
+        r"""[$\varepsilon_{cu,c}$] Confined ultimate compressive strain [$-$].
+
+        FprEN 1992-1-1:2023 (E) art. 8.1.4(5) - Formula (8.17)
+
+        [$\varepsilon_{cu} = 0{,}0035$], the unconfined value used in Formula (8.4), is fixed by the standard
+        and is not an input of this class.
+
+        Parameters
+        ----------
+        sigma_c2d : MPA
+            [$\sigma_{c2d}$] Absolute value of the minimum principal transverse compressive stress [$MPa$].
+        f_cd : MPA
+            [$f_{cd}$] Design value of the compressive strength of concrete [$MPa$].
+        """
+        super().__init__()
+        self.sigma_c2d = sigma_c2d
+        self.f_cd = f_cd
+
+    @staticmethod
+    def _evaluate(
+        sigma_c2d: MPA,
+        f_cd: MPA,
+    ) -> DIMENSIONLESS:
+        """Evaluates the formula, for more information see the __init__ method."""
+        raise_if_negative(sigma_c2d=sigma_c2d)
+        raise_if_less_or_equal_to_zero(f_cd=f_cd)
+
+        epsilon_cu = 0.0035
+        return epsilon_cu + 0.2 * sigma_c2d / f_cd
+
+    def latex(self, n: int = 3) -> LatexFormula:
+        """Returns LatexFormula object for formula 8.17."""
+        _equation: str = r"\varepsilon_{cu} + 0.2 \cdot \frac{\sigma_{c2d}}{f_{cd}}"
+        _numeric_equation: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\varepsilon_{cu}": "0.0035",
+                r"\sigma_{c2d}": f"{self.sigma_c2d:.{n}f}",
+                r"f_{cd}": f"{self.f_cd:.{n}f}",
+            },
+            unique_symbol_check=False,
+        )
+        _numeric_equation_with_units: str = latex_replace_symbols(
+            template=_equation,
+            replacements={
+                r"\varepsilon_{cu}": "0.0035",
+                r"\sigma_{c2d}": rf"{self.sigma_c2d:.{n}f} \ MPa",
+                r"f_{cd}": rf"{self.f_cd:.{n}f} \ MPa",
+            },
+            unique_symbol_check=False,
+        )
+        return LatexFormula(
+            return_symbol=r"\varepsilon_{cu,c}",
+            result=f"{self:.{n}f}",
+            equation=_equation,
+            numeric_equation=_numeric_equation,
+            numeric_equation_with_units=_numeric_equation_with_units,
+            comparison_operator_label="=",
+            unit="-",
+        )

--- a/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
+++ b/docs/guides/concepts/codes/eurocode/fpr_en_1992_1_1_2023/formulas.md
@@ -76,9 +76,9 @@ Total of 602 formulas present.
 |      8.12      |        :x:         |         |                                                                    |
 |      8.13      |        :x:         |         |                                                                    |
 |      8.14      |        :x:         |         |                                                                    |
-|      8.15      |        :x:         |         |                                                                    |
-|      8.16      |        :x:         |         |                                                                    |
-|      8.17      |        :x:         |         |                                                                    |
+|      8.15      | :heavy_check_mark: |         | Form8Dot15AverageConfinedConcreteStrength                         |
+|      8.16      | :heavy_check_mark: |         | Form8Dot16ConfinedStrainAtPeakStress                              |
+|      8.17      | :heavy_check_mark: |         | Form8Dot17ConfinedUltimateStrain                                  |
 |      8.18      | :heavy_check_mark: |         | Form8Dot18AverageShearStress                                       |
 |      8.19      | :heavy_check_mark: |         | Form8Dot19AverageShearStressPlanarMembers                          |
 |      8.20      | :heavy_check_mark: |         | Form8Dot20MinimumShearStressResistance                             |

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_15.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_15.py
@@ -1,0 +1,78 @@
+"""Testing formula 8.15 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_15 import (
+    Form8Dot15AverageConfinedConcreteStrength,
+)
+from blueprints.validations import NegativeValueError
+
+
+class TestForm8Dot15AverageConfinedConcreteStrength:
+    """Validation for formula 8.15 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        f_cd = 20.0
+        k_conf_b = 0.5
+        k_conf_s = 0.8
+        delta_f_cd = 10.0
+
+        # Object to test
+        formula = Form8Dot15AverageConfinedConcreteStrength(f_cd=f_cd, k_conf_b=k_conf_b, k_conf_s=k_conf_s, delta_f_cd=delta_f_cd)
+
+        # Expected result, manually calculated: 20 + 0.5 * 0.8 * 10
+        manually_calculated_result = 24.0
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    @pytest.mark.parametrize(
+        ("f_cd", "k_conf_b", "k_conf_s", "delta_f_cd"),
+        [
+            (-20.0, 0.5, 0.8, 10.0),  # f_cd is negative
+            (20.0, -0.5, 0.8, 10.0),  # k_conf_b is negative
+            (20.0, 0.5, -0.8, 10.0),  # k_conf_s is negative
+            (20.0, 0.5, 0.8, -10.0),  # delta_f_cd is negative
+        ],
+    )
+    def test_raise_error_when_negative_values_are_given(self, f_cd: float, k_conf_b: float, k_conf_s: float, delta_f_cd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot15AverageConfinedConcreteStrength(f_cd=f_cd, k_conf_b=k_conf_b, k_conf_s=k_conf_s, delta_f_cd=delta_f_cd)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                r"f_{cd,c} = f_{cd} + k_{conf,b} \cdot k_{conf,s} \cdot \Delta f_{cd} = 20.000 + 0.500 \cdot 0.800 \cdot 10.000 = 24.000 \ MPa",
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"f_{cd,c} = f_{cd} + k_{conf,b} \cdot k_{conf,s} \cdot \Delta f_{cd} = "
+                    r"20.000 \ MPa + 0.500 \cdot 0.800 \cdot 10.000 \ MPa = 24.000 \ MPa"
+                ),
+            ),
+            ("short", r"f_{cd,c} = 24.000 \ MPa"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        f_cd = 20.0
+        k_conf_b = 0.5
+        k_conf_s = 0.8
+        delta_f_cd = 10.0
+
+        # Object to test
+        latex = Form8Dot15AverageConfinedConcreteStrength(f_cd=f_cd, k_conf_b=k_conf_b, k_conf_s=k_conf_s, delta_f_cd=delta_f_cd).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_16.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_16.py
@@ -1,0 +1,80 @@
+"""Testing formula 8.16 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_16 import (
+    Form8Dot16ConfinedStrainAtPeakStress,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot16ConfinedStrainAtPeakStress:
+    """Validation for formula 8.16 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        delta_f_cd = 10.0
+        f_cd = 20.0
+
+        # Object to test
+        formula = Form8Dot16ConfinedStrainAtPeakStress(delta_f_cd=delta_f_cd, f_cd=f_cd)
+
+        # Expected result, manually calculated: 0.002 * (1 + 5 * 10 / 20)
+        manually_calculated_result = 0.007
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_raise_error_when_delta_f_cd_is_negative(self) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot16ConfinedStrainAtPeakStress(delta_f_cd=-10.0, f_cd=20.0)
+
+    @pytest.mark.parametrize(
+        "f_cd",
+        [
+            -20.0,  # f_cd is negative
+            0.0,  # f_cd is zero
+        ],
+    )
+    def test_raise_error_when_f_cd_is_less_or_equal_to_zero(self, f_cd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot16ConfinedStrainAtPeakStress(delta_f_cd=10.0, f_cd=f_cd)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\varepsilon_{c2,c} = \varepsilon_{c2} \cdot \left(1 + 5 \cdot \frac{\Delta f_{cd}}{f_{cd}}\right) = "
+                    r"0.002 \cdot \left(1 + 5 \cdot \frac{10.000}{20.000}\right) = 0.007 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\varepsilon_{c2,c} = \varepsilon_{c2} \cdot \left(1 + 5 \cdot \frac{\Delta f_{cd}}{f_{cd}}\right) = "
+                    r"0.002 \cdot \left(1 + 5 \cdot \frac{10.000 \ MPa}{20.000 \ MPa}\right) = 0.007 \ -"
+                ),
+            ),
+            ("short", r"\varepsilon_{c2,c} = 0.007 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        delta_f_cd = 10.0
+        f_cd = 20.0
+
+        # Object to test
+        latex = Form8Dot16ConfinedStrainAtPeakStress(delta_f_cd=delta_f_cd, f_cd=f_cd).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."

--- a/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_17.py
+++ b/tests/codes/eurocode/fpr_en_1992_1_1_2023/chapter_8_ultimate_limit_states/test_formula_8_17.py
@@ -1,0 +1,80 @@
+"""Testing formula 8.17 of FprEN 1992-1-1:2023."""
+
+import pytest
+
+from blueprints.codes.eurocode.fpr_en_1992_1_1_2023.chapter_8_ultimate_limit_states.formula_8_17 import (
+    Form8Dot17ConfinedUltimateStrain,
+)
+from blueprints.validations import LessOrEqualToZeroError, NegativeValueError
+
+
+class TestForm8Dot17ConfinedUltimateStrain:
+    """Validation for formula 8.17 from FprEN 1992-1-1:2023."""
+
+    def test_evaluation(self) -> None:
+        """Tests the evaluation of the result."""
+        # Example values
+        sigma_c2d = 5.0
+        f_cd = 20.0
+
+        # Object to test
+        formula = Form8Dot17ConfinedUltimateStrain(sigma_c2d=sigma_c2d, f_cd=f_cd)
+
+        # Expected result, manually calculated: 0.0035 + 0.2 * 5 / 20
+        manually_calculated_result = 0.0535
+
+        assert formula == pytest.approx(expected=manually_calculated_result, rel=1e-4)
+
+    def test_raise_error_when_sigma_c2d_is_negative(self) -> None:
+        """Test invalid values."""
+        with pytest.raises(NegativeValueError):
+            Form8Dot17ConfinedUltimateStrain(sigma_c2d=-5.0, f_cd=20.0)
+
+    @pytest.mark.parametrize(
+        "f_cd",
+        [
+            -20.0,  # f_cd is negative
+            0.0,  # f_cd is zero
+        ],
+    )
+    def test_raise_error_when_f_cd_is_less_or_equal_to_zero(self, f_cd: float) -> None:
+        """Test invalid values."""
+        with pytest.raises(LessOrEqualToZeroError):
+            Form8Dot17ConfinedUltimateStrain(sigma_c2d=5.0, f_cd=f_cd)
+
+    @pytest.mark.parametrize(
+        ("representation", "expected"),
+        [
+            (
+                "complete",
+                (
+                    r"\varepsilon_{cu,c} = \varepsilon_{cu} + 0.2 \cdot \frac{\sigma_{c2d}}{f_{cd}} = "
+                    r"0.0035 + 0.2 \cdot \frac{5.000}{20.000} = 0.054 \ -"
+                ),
+            ),
+            (
+                "complete_with_units",
+                (
+                    r"\varepsilon_{cu,c} = \varepsilon_{cu} + 0.2 \cdot \frac{\sigma_{c2d}}{f_{cd}} = "
+                    r"0.0035 + 0.2 \cdot \frac{5.000 \ MPa}{20.000 \ MPa} = 0.054 \ -"
+                ),
+            ),
+            ("short", r"\varepsilon_{cu,c} = 0.054 \ -"),
+        ],
+    )
+    def test_latex(self, representation: str, expected: str) -> None:
+        """Test the latex representation of the formula."""
+        # Example values
+        sigma_c2d = 5.0
+        f_cd = 20.0
+
+        # Object to test
+        latex = Form8Dot17ConfinedUltimateStrain(sigma_c2d=sigma_c2d, f_cd=f_cd).latex()
+
+        actual = {
+            "complete": latex.complete,
+            "complete_with_units": latex.complete_with_units,
+            "short": latex.short,
+        }
+
+        assert expected == actual[representation], f"{representation} representation failed."


### PR DESCRIPTION
Adds formulas (8.15) to (8.17) from clause 8.1.4 "Confined concrete" of FprEN 1992-1-1:2023, printed on pages 113 and 114. This finishes clause 8.1.4, and with it clause 8.1 and chapter 8 (Ultimate Limit States) as a whole, apart from Table 8.1 itself (see below).

Paragraph (4) gives the average design compressive strength of confined concrete (8.15). Paragraph (5) gives the enhancement of the two strain limits used in Formula (8.4) due to confinement: the strain at peak stress (8.16) and the ultimate strain (8.17).

## Decisions a reviewer has to weigh

- **(8.15) takes k_conf,b and k_conf,s as caller-supplied inputs, not computed from Table 8.1.** Table 8.1 (Figure 8.3, page 113) gives four geometric cases (a to d), each with its own algebraic formula for both factors and its own set of geometric inputs (single or multiple confinement legs, square, circular, rectangular, or general compression zones). It is a separate, substantial table, not a numbered formula, and following the precedent of Table 8.2 and Table 8.3 elsewhere in this track, it is left for a future pull request of its own. The docstrings for `k_conf_b` and `k_conf_s` reference Table 8.1 so the dependency is documented.
- **epsilon_c2 (0,002) and epsilon_cu (0,0035) are hardcoded in (8.16) and (8.17)**, reusing the same fixed constants already hardcoded in Formula (8.4) (article 8.1.2(1), Formula (8.4)'s own "where" clause). These are printed as plain numeric constants in this clause, not as a function of f_ck the way some other Eurocode 2 strain limits are defined elsewhere, so no parameter is added for them.
- **A substring collision in the LaTeX substitution for (8.15) and (8.16)**: the key `f_{cd}` is a literal substring of `\Delta f_{cd}`, so `\Delta f_{cd}` is substituted first in both classes to avoid corrupting that value. Caught before opening this pull request rather than after.

## Formulas as implemented

**Formula (8.15)**, `Form8Dot15AverageConfinedConcreteStrength`

`equation`

$$
f_{cd} + k_{conf,b} \cdot k_{conf,s} \cdot \Delta f_{cd}
$$

`complete`

$$
f_{cd,c} = f_{cd} + k_{conf,b} \cdot k_{conf,s} \cdot \Delta f_{cd} = 20.000 + 0.500 \cdot 0.800 \cdot 10.000 = 24.000 \ MPa
$$

`complete_with_units`

$$
f_{cd,c} = f_{cd} + k_{conf,b} \cdot k_{conf,s} \cdot \Delta f_{cd} = 20.000 \ MPa + 0.500 \cdot 0.800 \cdot 10.000 \ MPa = 24.000 \ MPa
$$

**Formula (8.16)**, `Form8Dot16ConfinedStrainAtPeakStress`

`equation`

$$
\varepsilon_{c2} \cdot \left(1 + 5 \cdot \frac{\Delta f_{cd}}{f_{cd}}\right)
$$

`complete`

$$
\varepsilon_{c2,c} = \varepsilon_{c2} \cdot \left(1 + 5 \cdot \frac{\Delta f_{cd}}{f_{cd}}\right) = 0.002 \cdot \left(1 + 5 \cdot \frac{10.000}{20.000}\right) = 0.007 \ -
$$

`complete_with_units`

$$
\varepsilon_{c2,c} = \varepsilon_{c2} \cdot \left(1 + 5 \cdot \frac{\Delta f_{cd}}{f_{cd}}\right) = 0.002 \cdot \left(1 + 5 \cdot \frac{10.000 \ MPa}{20.000 \ MPa}\right) = 0.007 \ -
$$

**Formula (8.17)**, `Form8Dot17ConfinedUltimateStrain`

`equation`

$$
\varepsilon_{cu} + 0.2 \cdot \frac{\sigma_{c2d}}{f_{cd}}
$$

`complete`

$$
\varepsilon_{cu,c} = \varepsilon_{cu} + 0.2 \cdot \frac{\sigma_{c2d}}{f_{cd}} = 0.0035 + 0.2 \cdot \frac{5.000}{20.000} = 0.054 \ -
$$

`complete_with_units`

$$
\varepsilon_{cu,c} = \varepsilon_{cu} + 0.2 \cdot \frac{\sigma_{c2d}}{f_{cd}} = 0.0035 + 0.2 \cdot \frac{5.000 \ MPa}{20.000 \ MPa} = 0.054 \ -
$$

Contributes to #1083.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Eurocode formulas 8.15–8.17 covering confined concrete strength and strain calculations.
  - Added input validation and formula representations with substituted values and units.

- **Documentation**
  - Updated formula tracking to mark formulas 8.15, 8.16, and 8.17 as implemented.

- **Tests**
  - Added coverage for calculations, invalid inputs, and formula representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->